### PR TITLE
docs: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,11 +7,11 @@ body:
     attributes:
       value: |
         Please search to see if an issue already exists for your bug before continuing.
-        > If you need to report a security issue please see https://github.com/project-copacetic/copacetic/SECURITY.md instead.
+        > If you need to report a security issue please see https://github.com/project-copacetic/copacetic/security/policy instead.
   - type: input
     attributes:
       label: Version of copa
-      placeholder: Release version (e.g. v0.0.1) or `git describe --dirty` output if built from source
+      placeholder: Release version (e.g. v0.1.0) or `git describe --dirty` output if built from source
   - type: textarea
     attributes:
       label: Expected Behavior

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: true
-contact_links:
-  - name: Report a security issue
-    url: https://github.com/project-copacetic/copacetic/SECURITY.md
-    about: Please report security vulnerabilities using these instructions.


### PR DESCRIPTION
* Remove security policy link in issues config.yml as the new github private vulnerability reporting feature makes it redundant.
* Fix link to security policy in bug_report.yml issue template.

Signed-off-by: Simon Leet <simon.leet@microsoft.com>