### PR TITLE
add anonymized analytics to docs site

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -41,6 +41,10 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        gtag: {
+          trackingID: 'G-3RC20QPKNS',
+          anonymizeIP: true,
+        },
       }),
     ],
   ],


### PR DESCRIPTION
Signed-off-by: Xander Grzywinski <xgrzywinski@microsoft.com>

Add anonymized analytics to the docs site. This does not track any user information, just gives us an idea of which sections of the docs are drawing the most traffic
