### PR TITLE
ci: use cached devcontainer in test jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,8 +92,8 @@ jobs:
       - name: Run functional test in dev container
         uses: devcontainers/ci@v0.2
         with:
-          imageName: ${{ env.DEVCON_NAME }}
-          imageTag: ${{ env.DEVCON_VERSION }}
+          cacheFrom: ${{ env.DEVCON_NAME }}
+          push: never
           env: |
             BUILDKIT_PORT=30321
           runCmd: |


### PR DESCRIPTION
Lockdown of `GITHUB_TOKEN` permissions revealed that the test jobs were attempting to rebuild and push the devcontainer and failing. This change corrects the `test-patch` job in build.yaml to use the cached devcontainer from the `build` step and not attempt to push it again when the job completes.

Signed-off-by: Simon Leet <simon.leet@microsoft.com>