### PR TITLE
fix: google distroless patching for libssl1.1

### DIFF
--- a/.github/workflows/test-images.json
+++ b/.github/workflows/test-images.json
@@ -21,7 +21,13 @@
         "image": "mcr.microsoft.com/oss/fluent/fluent-bit",
         "tag": "v1.8.4",
         "distro": "Google Distroless",
-        "description": "Custom dpkg/status.d, no apt"
+        "description": "Custom dpkg/status.d with base64 names, no apt"
+    },
+    {
+        "image": "mcr.microsoft.com/oss/open-policy-agent/opa",
+        "tag": "0.46.0",
+        "distro": "Google Distroless",
+        "description": "Custom dpkg/status.d with text names, no apt"
     },
     {
         "image": "mcr.microsoft.com/oss/calico/cni",

--- a/pkg/pkgmgr/pkgmgr.go
+++ b/pkg/pkgmgr/pkgmgr.go
@@ -22,6 +22,7 @@ const (
 	copaPrefix     = "copa-"
 	resultsPath    = "/" + copaPrefix + "out"
 	downloadPath   = "/" + copaPrefix + "downloads"
+	unpackPath     = "/" + copaPrefix + "unpacked"
 	resultManifest = "results.manifest"
 )
 


### PR DESCRIPTION
- Match naming of libssl1.1 status.d control file to match libssl1 as provided by the distroless base image. This implementation truncates all package file names to the first period, which does not affect other existing packages in the base images seen in the distroless images test set, but may need to be revisited if that behavior changes.
- Add test case for distroless libssl1.1 patching.
- Fix failure to copy unpacked update files to target image if the tooling image already has the latest versions of the files. dpkg.go now unpacks the update files to a separate root and copies those into a layer for merge into the target image instead of relying of a diff layer after unpacking the update files into the tooling image.
- Clarify in comments for rpm.go why the distroless patching behavior differs from dpkg.go.

Closes #37 
