### PR TITLE
fix: remove unneeded image push from unpackAndMergeUpdates

### DIFF
--- a/pkg/pkgmgr/dpkg.go
+++ b/pkg/pkgmgr/dpkg.go
@@ -261,9 +261,6 @@ func (dm *dpkgManager) unpackAndMergeUpdates(ctx context.Context, updates types.
 	const writeFieldsTemplate = `find . -name '*.deb' -exec sh -c "dpkg-deb -f {} > %s" \;`
 	writeFieldsCmd := fmt.Sprintf(writeFieldsTemplate, filepath.Join(resultsPath, "{}.fields"))
 	fieldsWritten := mkFolders.Dir(downloadPath).Run(llb.Shlex(writeFieldsCmd)).Root()
-	if err := buildkit.SolveToDocker(ctx, dm.config.Client, &fieldsWritten, dm.config.ConfigData, dm.config.ImageName+"-fields"); err != nil {
-		return nil, err
-	}
 
 	// Write the name and version of the packages applied to the results.manifest file for the host
 	const outputResultsTemplate = `find . -name '*.fields' -exec sh -c 'grep "^Package:\|^Version:" {} >> %s' \;`


### PR DESCRIPTION
Remove debug image creation introduced in #41.

<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Describe the changes in this pull request using active verbs such as _Add_, _Remove_, _Replace_ ...

Closes #<_issue_ID_>
