### PR TITLE
fix: add apk add

### DIFF
--- a/.github/workflows/test-images.json
+++ b/.github/workflows/test-images.json
@@ -6,6 +6,12 @@
         "description": "Valid apk/db, apk present"
     },
     {
+        "image": "mcr.microsoft.com/oss/grafana/grafana-image-renderer",
+        "tag": "v3.6.2",
+        "distro": "Alpine",
+        "description": "Valid apk/db, apk present, tiff package with dependencies"
+    },
+    {
         "image": "mcr.microsoft.com/oss/nginx/nginx",
         "tag": "1.21.6",
         "distro": "Debian",

--- a/pkg/pkgmgr/apk.go
+++ b/pkg/pkgmgr/apk.go
@@ -155,17 +155,23 @@ func (am *apkManager) upgradePackages(ctx context.Context, updates types.UpdateP
 	// TODO: Add support for custom APK config
 	apkUpdated := am.config.ImageState.Run(llb.Shlex("apk update")).Root()
 
+	// Add all requested update packages
+	// This works around where some packages (for example, tiff) require other packages in it's dependency tree to be updated
+	const apkAddTemplate = `apk add --no-cache %s`
+	pkgStrings := []string{}
+	for _, u := range updates {
+		pkgStrings = append(pkgStrings, u.Name)
+	}
+	addCmd := fmt.Sprintf(apkAddTemplate, strings.Join(pkgStrings, " "))
+	apkAdded := apkUpdated.Run(llb.Shlex(addCmd)).Root()
+
 	// Install all requested update packages without specifying the version. This works around:
 	//  - Reports being slightly out of date, where a newer security revision has displaced the one specified leading to not found errors.
 	//  - Reports not specifying version epochs correct (e.g. bsdutils=2.36.1-8+deb11u1 instead of with epoch as 1:2.36.1-8+dev11u1)
 	// Note that this keeps the log files from the operation, which we can consider removing as a size optimization in the future.
 	const apkInstallTemplate = `apk upgrade --no-cache %s`
-	pkgStrings := []string{}
-	for _, u := range updates {
-		pkgStrings = append(pkgStrings, u.Name)
-	}
 	installCmd := fmt.Sprintf(apkInstallTemplate, strings.Join(pkgStrings, " "))
-	apkInstalled := apkUpdated.Run(llb.Shlex(installCmd)).Root()
+	apkInstalled := apkAdded.Run(llb.Shlex(installCmd)).Root()
 
 	// Write updates-manifest to host for post-patch validation
 	const outputResultsTemplate = `sh -c 'apk info --installed -v %s > %s; if [[ $? -ne 0 ]]; then echo "WARN: apk info --installed returned $?"; fi'`


### PR DESCRIPTION
Add apk packages before upgrading. This works around the issue where packages require other packages in the dependency tree to be updated.
