### PR TITLE
feat: add http proxy support when executing package managers

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,6 +9,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+
+	"github.com/moby/buildkit/client/llb"
 )
 
 func EnsurePath(path string, perm fs.FileMode) (bool, error) {
@@ -35,4 +37,23 @@ func IsNonEmptyFile(dir, file string) bool {
 		return false
 	}
 	return !info.IsDir() && info.Size() > 0
+}
+
+func getEnvAny(names ...string) string {
+	for _, n := range names {
+		if val := os.Getenv(n); val != "" {
+			return val
+		}
+	}
+	return ""
+}
+
+func GetProxy() llb.ProxyEnv {
+	proxy := llb.ProxyEnv{
+		HTTPProxy:  getEnvAny("HTTP_PROXY"),
+		HTTPSProxy: getEnvAny("HTTPS_PROXY"),
+		NoProxy:    getEnvAny("NO_PROXY"),
+		AllProxy:   getEnvAny("HTTP_PROXY"),
+	}
+	return proxy
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path"
 	"testing"
+
+	"github.com/moby/buildkit/client/llb"
 )
 
 const (
@@ -138,5 +140,40 @@ func TestIsNonEmptyFile(t *testing.T) {
 				t.Errorf("IsNonEmptyFile() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetProxy(t *testing.T) {
+	var got llb.ProxyEnv
+	var want llb.ProxyEnv
+
+	// Test with configured proxy
+	os.Setenv("HTTP_PROXY", "httpproxy")
+	os.Setenv("HTTPS_PROXY", "httpsproxy")
+	os.Setenv("NO_PROXY", "noproxy")
+	got = GetProxy()
+	want = llb.ProxyEnv{
+		HTTPProxy:  "httpproxy",
+		HTTPSProxy: "httpsproxy",
+		NoProxy:    "noproxy",
+		AllProxy:   "httpproxy",
+	}
+	if got != want {
+		t.Errorf("unexpected proxy config, got %#v want %#v", got, want)
+	}
+
+	// Test with unconfigured proxy
+	os.Unsetenv("HTTP_PROXY")
+	os.Unsetenv("HTTPS_PROXY")
+	os.Unsetenv("NO_PROXY")
+	got = GetProxy()
+	want = llb.ProxyEnv{
+		HTTPProxy:  "",
+		HTTPSProxy: "",
+		NoProxy:    "",
+		AllProxy:   "",
+	}
+	if got != want {
+		t.Errorf("unexpected proxy config, got %#v want %#v", got, want)
 	}
 }


### PR DESCRIPTION
Add http proxy support when executing package managers.

Closes #80

