### PR TITLE
fix: apk force-overwrite

### DIFF
--- a/pkg/pkgmgr/apk.go
+++ b/pkg/pkgmgr/apk.go
@@ -169,7 +169,7 @@ func (am *apkManager) upgradePackages(ctx context.Context, updates types.UpdateP
 	//  - Reports being slightly out of date, where a newer security revision has displaced the one specified leading to not found errors.
 	//  - Reports not specifying version epochs correct (e.g. bsdutils=2.36.1-8+deb11u1 instead of with epoch as 1:2.36.1-8+dev11u1)
 	// Note that this keeps the log files from the operation, which we can consider removing as a size optimization in the future.
-	const apkInstallTemplate = `apk upgrade --no-cache %s`
+	const apkInstallTemplate = `apk upgrade --no-cache --force-overwrite %s`
 	installCmd := fmt.Sprintf(apkInstallTemplate, strings.Join(pkgStrings, " "))
 	apkInstalled := apkAdded.Run(llb.Shlex(installCmd)).Root()
 


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Describe the changes in this pull request using active verbs such as _Add_, _Remove_, _Replace_ ...

Fixes ffmpeg error below:

```
#0 1.112 ERROR: ffmpeg5-libavutil-5.1.2-r10: trying to overwrite usr/lib/libavutil.so.57 owned by ffmpeg-libs-5.1.2-r1.
#0 1.112 ERROR: ffmpeg5-libavutil-5.1.2-r10: trying to overwrite usr/lib/libavutil.so.57.28.100 owned by ffmpeg-libs-5.1.2-r1.
#0 1.115 (8/34) Installing libjxl (0.8.1-r1)
#0 1.140 (9/34) Installing ffmpeg5-libswresample (5.1.2-r10)
#0 1.147 ERROR: ffmpeg5-libswresample-5.1.2-r10: trying to overwrite usr/lib/libswresample.so.4 owned by ffmpeg-libs-5.1.2-r1.
#0 1.147 ERROR: ffmpeg5-libswresample-5.1.2-r10: trying to overwrite usr/lib/libswresample.so.4.7.100 owned by ffmpeg-libs-5.1.2-r1.
#0 1.147 (10/34) Upgrading libvpx (1.12.0-r1 -> 1.13.0-r1)
#0 1.167 (11/34) Installing ffmpeg5-libavcodec (5.1.2-r10)
#0 1.175 ERROR: ffmpeg5-libavcodec-5.1.2-r10: trying to overwrite usr/lib/libavcodec.so.59 owned by ffmpeg-libs-5.1.2-r1.
#0 1.175 ERROR: ffmpeg5-libavcodec-5.1.2-r10: trying to overwrite usr/lib/libavcodec.so.59.37.100 owned by ffmpeg-libs-5.1.2-r1.
#0 1.228 (12/34) Installing ffmpeg5-libavformat (5.1.2-r10)
#0 1.235 ERROR: ffmpeg5-libavformat-5.1.2-r10: trying to overwrite usr/lib/libavformat.so.59 owned by ffmpeg-libs-5.1.2-r1.
#0 1.235 ERROR: ffmpeg5-libavformat-5.1.2-r10: trying to overwrite usr/lib/libavformat.so.59.27.100 owned by ffmpeg-libs-5.1.2-r1.
```

Closes #<_issue_ID_>
