### PR TITLE
test: remove grafana image renderer test

### DIFF
--- a/.github/workflows/test-images.json
+++ b/.github/workflows/test-images.json
@@ -6,12 +6,6 @@
         "description": "Valid apk/db, apk present"
     },
     {
-        "image": "mcr.microsoft.com/oss/grafana/grafana-image-renderer",
-        "tag": "v3.6.2",
-        "distro": "Alpine",
-        "description": "Valid apk/db, apk present, tiff package with dependencies"
-    },
-    {
         "image": "mcr.microsoft.com/oss/nginx/nginx",
         "tag": "1.21.6",
         "distro": "Debian",


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Describe the changes in this pull request using active verbs such as _Add_, _Remove_, _Replace_ ...

Remove grafana image renderer test to unblock the CI

This image is using alpine `edge` repo so it is not suitable for this: https://github.com/grafana/grafana-image-renderer/blob/master/Dockerfile#L9-L11

Closes #<_issue_ID_>
