### PR TITLE
feat: add version flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,9 @@ import (
 // Global for Debug logging flag.
 var debug bool
 
+// Global for version string.
+var version string
+
 func newRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "copa",
@@ -32,6 +35,7 @@ func newRootCmd() *cobra.Command {
 			return cmd.Usage()
 		},
 		SilenceUsage: true,
+		Version:      version,
 	}
 
 	flags := rootCmd.PersistentFlags()

--- a/main.go
+++ b/main.go
@@ -15,11 +15,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Global for Debug logging flag.
-var debug bool
-
-// Global for version string.
-var version string
+// Globals for Debug logging flag and version reporting.
+var (
+	debug   bool
+	version string
+)
 
 func newRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{


### PR DESCRIPTION
The makefile specifies main.version in the ldflags.  This PR just pulls that value into the Version property of the command, lighting up `--version`.


Closes #158
