### PR TITLE
feat: publish Darwin binaries in release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,8 +3,10 @@ builds:
   - id: copacetic
     goos:
     - linux
+    - darwin
     goarch:
     - amd64
+    - arm64
     env:
       - CGO_ENABLED=0
       - GO111MODULE=on


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Publish Darwin/arm64 binaries as Copa is supported on mac os when buildkitd is running as a container. 

Closes #104
