### PR TITLE
fix: trigger copa-action release on new copa release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,16 +37,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout copa-action repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-        with:
-          repository: project-copacetic/copa-action
-          ref: main
-
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2.9.1
-
-      - name: Build and push copa-action image with new version
+      - name: Trigger Repo Dispatch for Copa Action Release
         run: |
-          tag="$(echo "${{ github.ref }}" | tr -d 'refs/tags/v')"
-          docker buildx build --build-arg copa_version=${tag} -t ghcr.io/project-copacetic/copa-action:v"$tag" --push .
+            tag="$(echo "${{ github.ref }}" | tr -d 'refs/tags/v')"
+            payload="{\"event_type\": \"copa_release\", \"client_payload\": { \"version\": \"$tag\" }}"
+            curl -H "Accept: application/vnd.github.everest-preview+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            --request POST \
+            --data "$payload" \
+            https://api.github.com/repos/project-copacetic/copa-action/dispatches


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Creates request to trigger copa-action release event whenever there is a new release of copa. 

Related copa action PR: https://github.com/project-copacetic/copa-action/pull/14

Describe the changes in this pull request using active verbs such as _Add_, _Remove_, _Replace_ ...

Closes #266 