### PR TITLE
feat: add push flag to support pushing to registry directly

### DIFF
--- a/pkg/patch/cmd.go
+++ b/pkg/patch/cmd.go
@@ -26,6 +26,7 @@ type patchArgs struct {
 	format        string
 	output        string
 	bkOpts        buildkit.Opts
+	push          bool
 }
 
 func NewPatchCmd() *cobra.Command {
@@ -51,7 +52,9 @@ func NewPatchCmd() *cobra.Command {
 				ua.format,
 				ua.output,
 				ua.ignoreError,
-				bkopts)
+				ua.push,
+				bkopts,
+			)
 		},
 	}
 	flags := patchCmd.Flags()
@@ -68,7 +71,7 @@ func NewPatchCmd() *cobra.Command {
 	flags.BoolVar(&ua.ignoreError, "ignore-errors", false, "Ignore errors and continue patching")
 	flags.StringVarP(&ua.format, "format", "f", "openvex", "Output format, defaults to 'openvex'")
 	flags.StringVarP(&ua.output, "output", "o", "", "Output file path")
-	flags.StringVarP(&ua.pushDest, "push", "p", "", "Push patched image to destination registry. Format: <registry>/<image>:<tag>. Note: this takes precedence over tag flag if set. ")
+	flags.BoolVarP(&ua.push, "push", "p", false, "Push patched image to destination registry")
 
 	if err := patchCmd.MarkFlagRequired("image"); err != nil {
 		panic(err)

--- a/pkg/patch/cmd.go
+++ b/pkg/patch/cmd.go
@@ -68,6 +68,7 @@ func NewPatchCmd() *cobra.Command {
 	flags.BoolVar(&ua.ignoreError, "ignore-errors", false, "Ignore errors and continue patching")
 	flags.StringVarP(&ua.format, "format", "f", "openvex", "Output format, defaults to 'openvex'")
 	flags.StringVarP(&ua.output, "output", "o", "", "Output file path")
+	flags.StringVarP(&ua.pushDest, "push", "p", "", "Push patched image to destination registry. Format: <registry>/<image>:<tag>. Note: this takes precedence over tag flag if set. ")
 
 	if err := patchCmd.MarkFlagRequired("image"); err != nil {
 		panic(err)

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -133,8 +133,14 @@ func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workin
 		return err
 	}
 
-	if err = buildkit.SolveToDocker(ctx, config.Client, patchedImageState, config.ConfigData, patchedImageName); err != nil {
-		return err
+	if pushDest != "" {
+		if err = buildkit.SolveToRegistry(ctx, config.Client, patchedImageState, config.ConfigData, pushDest); err != nil {
+			return err
+		}
+	} else {
+		if err = buildkit.SolveToDocker(ctx, config.Client, patchedImageState, config.ConfigData, patchedImageName); err != nil {
+			return err
+		}
 	}
 
 	// create a new manifest with the successfully patched packages

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -114,14 +114,8 @@ func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workin
 		return err
 	}
 
-	if push {
-		if err = buildkit.SolveToRegistry(ctx, config.Client, patchedImageState, config.ConfigData, *patchedImageName); err != nil {
-			return err
-		}
-	} else {
-		if err = buildkit.SolveToDocker(ctx, config.Client, patchedImageState, config.ConfigData, *patchedImageName); err != nil {
-			return err
-		}
+	if err = buildkit.Solve(ctx, config.Client, patchedImageState, config.ConfigData, *patchedImageName, push); err != nil {
+		return err
 	}
 
 	// create a new manifest with the successfully patched packages

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -155,7 +155,7 @@ func patchedImageTarget(image, patchedTag string) (*string, error) {
 		return nil, err
 	}
 	if ref.IsNameOnly(imageName) {
-		log.Warnf("Image name has no tag or digest, using latest as tag")
+		log.Warn("Image name has no tag or digest, using latest as tag")
 		imageName = ref.TagNameOnly(imageName)
 	}
 	taggedName, ok := imageName.(ref.Tagged)
@@ -179,7 +179,6 @@ func patchedImageTarget(image, patchedTag string) (*string, error) {
 	if slashCount > 0 {
 		if slashCount < 2 {
 			err := fmt.Errorf("invalid tag %s, must be in the form <registry>/<image>:<tag>", patchedTag)
-			log.Error(err)
 			return nil, err
 		}
 		// this implies user has passed a destination image name, not just a tag

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -71,15 +71,15 @@ func TestPatchedImageTarget(t *testing.T) {
 		{
 			name:       "tag passed but without registry or repo",
 			image:      "docker.io/library/nginx:1.21.3",
-			patchedTag: "my.registry/nginx:1.21.3-patched",
+			patchedTag: "myregistry.azurecr.io/nginx:1.21.3-patched",
 			want:       "",
 			wantErr:    true,
 		},
 		{
 			name:       "tag passed contains registry, repo and image",
 			image:      "docker.io/library/nginx:1.21.3",
-			patchedTag: "my.registry.io/myrepo/nginx:1.21.3-patched",
-			want:       "my.registry.io/myrepo/nginx:1.21.3-patched",
+			patchedTag: "myregistry.azurecr.io/myrepo/nginx:1.21.3-patched",
+			want:       "myregistry.azurecr.io/myrepo/nginx:1.21.3-patched",
 			wantErr:    false,
 		},
 	}

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -44,3 +44,58 @@ func TestRemoveIfNotDebug(t *testing.T) {
 		os.RemoveAll(workingFolder)
 	})
 }
+
+func TestPatchedImageTarget(t *testing.T) {
+	tests := []struct {
+		name       string
+		image      string
+		patchedTag string
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "tag passed is empty",
+			image:      "docker.io/library/nginx:1.21.3",
+			patchedTag: "",
+			want:       "docker.io/library/nginx:1.21.3-patched",
+			wantErr:    false,
+		},
+
+		{
+			name:       "tag passed with value",
+			image:      "docker.io/library/nginx:1.21.3",
+			patchedTag: "custom",
+			want:       "docker.io/library/nginx:custom",
+			wantErr:    false,
+		},
+		{
+			name:       "tag passed but without registry or repo",
+			image:      "docker.io/library/nginx:1.21.3",
+			patchedTag: "my.registry/nginx:1.21.3-patched",
+			want:       "",
+			wantErr:    true,
+		},
+		{
+			name:       "tag passed contains registry, repo and image",
+			image:      "docker.io/library/nginx:1.21.3",
+			patchedTag: "my.registry.io/myrepo/nginx:1.21.3-patched",
+			want:       "my.registry.io/myrepo/nginx:1.21.3-patched",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := patchedImageTarget(tt.image, tt.patchedTag)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("patchedImageTarget() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != nil {
+				if *got != tt.want {
+					t.Errorf("patchedImageTarget() = %v, want %v", *got, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

This PR enables direct push to registry from buildkit:
```
copa patch -i docker.io/library/alpine:3.16.4 -r patch.json -p ttl.sh/alpinepatched:1h
```

One side-effect of this would be that copa wouldn't rely on Docker anymore if there is a remote buildkit setup as I mentioned here. https://github.com/project-copacetic/copacetic/issues/285#issuecomment-1708239927

Closes #293
