### PR TITLE
feat: Prefer local image

### DIFF
--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -6,7 +6,9 @@
 package buildkit
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -19,6 +21,7 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
 	"github.com/moby/buildkit/util/contentutil"
@@ -35,7 +38,7 @@ import (
 
 type Config struct {
 	ImageName  string
-	Client     *client.Client
+	Client     gwclient.Client
 	ConfigData []byte
 	Platform   ispec.Platform
 	ImageState llb.State
@@ -109,7 +112,7 @@ func resolveImageConfig(ctx context.Context, ref string, platform *ispec.Platfor
 	return dgst, config, nil
 }
 
-func InitializeBuildkitConfig(ctx context.Context, client *client.Client, image string, manifest *unversioned.UpdateManifest) (*Config, error) {
+func InitializeBuildkitConfig(ctx context.Context, c gwclient.Client, image string, manifest *unversioned.UpdateManifest) (*Config, error) {
 	// Initialize buildkit config for the target image
 	config := Config{
 		ImageName: image,
@@ -120,25 +123,80 @@ func InitializeBuildkitConfig(ctx context.Context, client *client.Client, image 
 	}
 
 	// Resolve and pull the config for the target image
-	_, configData, err := resolveImageConfig(ctx, image, &config.Platform)
+	_, _, configData, err := c.ResolveImageConfig(ctx, image, llb.ResolveImageConfigOpt{
+		ResolveMode: llb.ResolveModePreferLocal.String(),
+	})
 	if err != nil {
 		return nil, err
 	}
+
 	config.ConfigData = configData
 
 	// Load the target image state with the resolved image config in case environment variable settings
 	// are necessary for running apps in the target image for updates
 	config.ImageState, err = llb.Image(image,
 		llb.Platform(config.Platform),
-		llb.ResolveModeDefault,
+		llb.ResolveModePreferLocal,
+		llb.WithMetaResolver(c),
 	).WithImageConfig(config.ConfigData)
 	if err != nil {
 		return nil, err
 	}
 
-	config.Client = client
+	config.Client = c
 
 	return &config, nil
+}
+
+// Extracts the bytes of the file denoted by `path` from the state `st`.
+func ExtractFileFromState(ctx context.Context, c gwclient.Client, st *llb.State, path string) ([]byte, error) {
+	def, err := st.Marshal(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Solve(ctx, gwclient.SolveRequest{
+		Evaluate:   true,
+		Definition: def.ToPB(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := resp.SingleRef()
+	if err != nil {
+		return nil, err
+	}
+
+	return ref.ReadFile(ctx, gwclient.ReadRequest{
+		Filename: path,
+	})
+}
+
+func ArrayFile(input []string) []byte {
+	var b bytes.Buffer
+	for _, s := range input {
+		b.WriteString(s)
+		b.WriteRune('\n') // newline
+	}
+	return b.Bytes()
+}
+
+func WithArrayFile(s llb.State, path string, contents []string) llb.State {
+	af := ArrayFile(contents)
+	return WithFileBytes(s, path, af)
+}
+
+func WithFileString(s llb.State, path, contents string) llb.State {
+	return WithFileBytes(s, path, []byte(contents))
+}
+
+func WithFileBytes(s llb.State, path string, contents []byte) llb.State {
+	return s.File(llb.Mkfile(path, 0o600, contents))
+}
+
+func Env(k, v string) string {
+	return fmt.Sprintf("%s=%s", k, v)
 }
 
 func SolveToLocal(ctx context.Context, c *client.Client, st *llb.State, outPath string) error {

--- a/pkg/pkgmgr/dpkg.go
+++ b/pkg/pkgmgr/dpkg.go
@@ -7,10 +7,11 @@ package pkgmgr
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -26,6 +27,8 @@ const (
 	dpkgLibPath      = "/var/lib/dpkg"
 	dpkgStatusPath   = dpkgLibPath + "/status"
 	dpkgStatusFolder = dpkgLibPath + "/status.d"
+
+	statusdOutputFilename = "statusd_type"
 )
 
 type dpkgManager struct {
@@ -42,6 +45,8 @@ const (
 	DPKGStatusFile
 	DPKGStatusDirectory
 	DPKGStatusMixed
+
+	DPKGStatusInvalid // must always be the last listed
 )
 
 func (st dpkgStatusType) String() string {
@@ -83,19 +88,23 @@ func getAPTImageName(manifest *unversioned.UpdateManifest) string {
 	return fmt.Sprintf("%s:%s", manifest.Metadata.OS.Type, version)
 }
 
-func getDPKGStatusType(dir string) dpkgStatusType {
-	out := DPKGStatusNone
-	if utils.IsNonEmptyFile(dir, "status") {
-		out = DPKGStatusFile
+func getDPKGStatusType(b []byte) dpkgStatusType {
+	if len(b) == 0 {
+		return DPKGStatusNone
 	}
-	if utils.IsNonEmptyFile(dir, "status.d") {
-		if out == DPKGStatusFile {
-			out = DPKGStatusMixed
-		} else {
-			out = DPKGStatusDirectory
-		}
+
+	st, err := strconv.Atoi(string(b))
+	if err != nil {
+		st = int(DPKGStatusNone)
 	}
-	return out
+
+	// convert ascii digit to byte
+	statusType := dpkgStatusType(st)
+	if statusType >= DPKGStatusInvalid {
+		return DPKGStatusInvalid
+	}
+
+	return statusType
 }
 
 func (dm *dpkgManager) InstallUpdates(ctx context.Context, manifest *unversioned.UpdateManifest, ignoreErrors bool) (*llb.State, []string, error) {
@@ -117,21 +126,21 @@ func (dm *dpkgManager) InstallUpdates(ctx context.Context, manifest *unversioned
 	}
 
 	var updatedImageState *llb.State
+	var resultManifestBytes []byte
 	if dm.isDistroless {
-		updatedImageState, err = dm.unpackAndMergeUpdates(ctx, updates, toolImageName)
+		updatedImageState, resultManifestBytes, err = dm.unpackAndMergeUpdates(ctx, updates, toolImageName)
 		if err != nil {
 			return nil, nil, err
 		}
 	} else {
-		updatedImageState, err = dm.installUpdates(ctx, updates)
+		updatedImageState, resultManifestBytes, err = dm.installUpdates(ctx, updates)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
 
 	// Validate that the deployed packages are of the requested version or better
-	resultManifestPath := filepath.Join(dm.workingFolder, resultsPath, resultManifest)
-	errPkgs, err := validateDebianPackageVersions(updates, debComparer, resultManifestPath, ignoreErrors)
+	errPkgs, err := validateDebianPackageVersions(updates, debComparer, resultManifestBytes, ignoreErrors)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -159,26 +168,49 @@ func (dm *dpkgManager) probeDPKGStatus(ctx context.Context, toolImage string) er
 	busyBoxApplied := dm.config.ImageState.File(llb.Copy(busyBoxInstalled, "/bin/busybox", "/bin/busybox"))
 	mkFolders := busyBoxApplied.File(llb.Mkdir(resultsPath, 0o744, llb.WithParents(true)))
 
-	const probeTemplate = `/bin/busybox sh -c "if [ -f %[1]s ]; then cp %[1]s %[3]s ; fi && if [ -d %[2]s ]; then ls -1 %[2]s > %[4]s ; fi"`
-	probeCmd := fmt.Sprintf(probeTemplate, dpkgStatusPath, dpkgStatusFolder, resultsPath, filepath.Join(resultsPath, "status.d"))
-	probed := mkFolders.Run(llb.Shlex(probeCmd)).Root()
+	probed := mkFolders.
+		Run(llb.Args([]string{
+			`/bin/busybox`, `env`,
+			buildkit.Env("DPKG_STATUS_PATH", dpkgStatusPath),
+			buildkit.Env("RESULTS_PATH", resultsPath),
+			buildkit.Env("DPKG_STATUS_FOLDER", dpkgStatusFolder),
+			buildkit.Env("RESULT_STATUSD_PATH", filepath.Join(resultsPath, "status.d")),
+			buildkit.Env("DPKG_STATUS_IS_DIRECTORY", fmt.Sprintf("%d", DPKGStatusDirectory)),
+			buildkit.Env("DPKG_STATUS_IS_FILE", fmt.Sprintf("%d", DPKGStatusFile)),
+			buildkit.Env("DPKG_STATUS_IS_UNKNOWN", fmt.Sprintf("%d", DPKGStatusNone)),
+			buildkit.Env("STATUSD_OUTPUT_FILENAME", statusdOutputFilename),
+			// writebytes will write the specified number as a byte *by numeric value* to stdout
+			// for example,
+			`sh`, `-c`, `
+                status="$DPKG_STATUS_IS_UNKNOWN"
+                if [ -f "$DPKG_STATUS_PATH" ]; then
+                    status="$DPKG_STATUS_IS_FILE"
+                    cp "$DPKG_STATUS_PATH" "$RESULTS_PATH"
+                elif [ -d "$DPKG_STATUS_FOLDER" ]; then
+                    status="$DPKG_STATUS_IS_DIRECTORY"
+                    ls -1 "$DPKG_STATUS_FOLDER" > "$RESULT_STATUSD_PATH"
+                fi
+                echo -n "$status" > "${RESULTS_PATH}/${STATUSD_OUTPUT_FILENAME}"
+        `,
+		})).Root()
+
 	outState := llb.Diff(busyBoxApplied, probed)
-	if err := buildkit.SolveToLocal(ctx, dm.config.Client, &outState, dm.workingFolder); err != nil {
+	typeBytes, err := buildkit.ExtractFileFromState(ctx, dm.config.Client, &outState, filepath.Join(resultsPath, statusdOutputFilename))
+	if err != nil {
 		return err
 	}
 
-	// Check Status File
-	outStatePath := filepath.Join(dm.workingFolder, resultsPath)
-	dpkgStatus := getDPKGStatusType(outStatePath)
+	dpkgStatus := getDPKGStatusType(typeBytes)
 	switch dpkgStatus {
 	case DPKGStatusFile:
 		return nil
 	case DPKGStatusDirectory:
-		statusdNames, err := os.ReadFile(filepath.Join(outStatePath, "status.d"))
+		statusdNamesBytes, err := buildkit.ExtractFileFromState(ctx, dm.config.Client, &outState, filepath.Join(resultsPath, "status.d"))
 		if err != nil {
 			return err
 		}
-		dm.statusdNames = strings.ReplaceAll(string(statusdNames), "\n", " ")
+		dm.statusdNames = strings.ReplaceAll(string(statusdNamesBytes), "\n", " ")
+		dm.statusdNames = strings.TrimSpace(dm.statusdNames)
 		log.Infof("Processed status.d: %s", dm.statusdNames)
 		dm.isDistroless = true
 		return nil
@@ -197,7 +229,7 @@ func (dm *dpkgManager) probeDPKGStatus(ctx context.Context, toolImage string) er
 //
 // TODO: Support Debian images with valid dpkg status but missing tools. No current examples exist in test set
 // i.e. extra RunOption to mount a copy of busybox-static or full apt install into the image and invoking that.
-func (dm *dpkgManager) installUpdates(ctx context.Context, updates unversioned.UpdatePackages) (*llb.State, error) {
+func (dm *dpkgManager) installUpdates(ctx context.Context, updates unversioned.UpdatePackages) (*llb.State, []byte, error) {
 	// TODO: Add support for custom APT config and gpg key injection
 	// Since this takes place in the target container, it can interfere with install actions
 	// such as the installation of the updated debian-archive-keyring package, so it's probably best
@@ -226,17 +258,18 @@ func (dm *dpkgManager) installUpdates(ctx context.Context, updates unversioned.U
 	resultsWritten := aptInstalled.Dir(resultsPath).Run(llb.Shlex(outputResultsCmd)).Root()
 	resultsDiff := llb.Diff(aptInstalled, resultsWritten)
 
-	if err := buildkit.SolveToLocal(ctx, dm.config.Client, &resultsDiff, dm.workingFolder); err != nil {
-		return nil, err
+	resultsBytes, err := buildkit.ExtractFileFromState(ctx, dm.config.Client, &resultsDiff, filepath.Join(resultsPath, resultManifest))
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Diff the installed updates and merge that into the target image
 	patchDiff := llb.Diff(aptUpdated, aptInstalled)
 	patchMerge := llb.Merge([]llb.State{dm.config.ImageState, patchDiff})
-	return &patchMerge, nil
+	return &patchMerge, resultsBytes, nil
 }
 
-func (dm *dpkgManager) unpackAndMergeUpdates(ctx context.Context, updates unversioned.UpdatePackages, toolImage string) (*llb.State, error) {
+func (dm *dpkgManager) unpackAndMergeUpdates(ctx context.Context, updates unversioned.UpdatePackages, toolImage string) (*llb.State, []byte, error) {
 	// Spin up a build tooling container to fetch and unpack packages to create patch layer.
 	// Pull family:version -> need to create version to base image map
 	toolingBase := llb.Image(toolImage,
@@ -280,8 +313,10 @@ func (dm *dpkgManager) unpackAndMergeUpdates(ctx context.Context, updates unvers
 	outputResultsCmd := fmt.Sprintf(outputResultsTemplate, resultManifest)
 	resultsWritten := fieldsWritten.Dir(resultsPath).Run(llb.Shlex(outputResultsCmd)).Root()
 	resultsDiff := llb.Diff(fieldsWritten, resultsWritten)
-	if err := buildkit.SolveToLocal(ctx, dm.config.Client, &resultsDiff, dm.workingFolder); err != nil {
-		return nil, err
+
+	resultsBytes, err := buildkit.ExtractFileFromState(ctx, dm.config.Client, &resultsDiff, filepath.Join(resultsPath, resultManifest))
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Update the status.d folder with the package info from the applied update packages
@@ -290,7 +325,7 @@ func (dm *dpkgManager) unpackAndMergeUpdates(ctx context.Context, updates unvers
 	// - Older distroless images had a bug where the file names were base64 encoded. If the base64 versions
 	//   of the names were found in the folder previously, then we use those names.
 	copyStatusTemplate := `find . -name '*.fields' -exec sh -c
-		"awk -v statusDir=%s -v statusdNames=\"(%s)\"
+		"awk -v statusDir=%s -v statusdNames=\"%s\"
 			'BEGIN{split(statusdNames,names); for (n in names) b64names[names[n]]=\"\"} {a[\$1]=\$2}
 			 END{cmd = \"printf \" a[\"Package:\"] \" | base64\" ;
 			  cmd | getline b64name ;
@@ -315,21 +350,15 @@ func (dm *dpkgManager) unpackAndMergeUpdates(ctx context.Context, updates unvers
 	// Diff unpacked packages layers from previous and merge with target
 	statusDiff := llb.Diff(fieldsWritten, statusUpdated)
 	merged := llb.Merge([]llb.State{dm.config.ImageState, unpackedToRoot, statusDiff})
-	return &merged, nil
+	return &merged, resultsBytes, nil
 }
 
 func (dm *dpkgManager) GetPackageType() string {
 	return "deb"
 }
 
-func dpkgParseResultsManifest(path string) (map[string]string, error) {
-	// Open result file
-	f, err := os.Open(path)
-	if err != nil {
-		log.Errorf("%s could not be opened", path)
-		return nil, err
-	}
-	defer f.Close()
+func dpkgParseResultsManifest(b []byte) (map[string]string, error) {
+	buf := bytes.NewBuffer(b)
 
 	// results.manifest file is expected to be subset of DPKG status or debian info format
 	// consisting of repeating consecutive blocks of:
@@ -338,7 +367,7 @@ func dpkgParseResultsManifest(path string) (map[string]string, error) {
 	// Version: <version value>
 	// ...
 	updateMap := map[string]string{}
-	fs := bufio.NewScanner(f)
+	fs := bufio.NewScanner(buf)
 	var packageName string
 	for fs.Scan() {
 		kv := strings.Split(fs.Text(), " ")
@@ -369,9 +398,9 @@ func dpkgParseResultsManifest(path string) (map[string]string, error) {
 	return updateMap, nil
 }
 
-func validateDebianPackageVersions(updates unversioned.UpdatePackages, cmp VersionComparer, resultsPath string, ignoreErrors bool) ([]string, error) {
+func validateDebianPackageVersions(updates unversioned.UpdatePackages, cmp VersionComparer, results []byte, ignoreErrors bool) ([]string, error) {
 	// Load file into map[string]string for package:version lookup
-	updateMap, err := dpkgParseResultsManifest(resultsPath)
+	updateMap, err := dpkgParseResultsManifest(results)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use gateway client for config resolution

Implement `buildkit.ExtractFileFromState`
This code will still not compile, since the signature of `buildkit.SolveToLocal` is not satisfied by its calls.
Replace `SolveToLocal` in `probeDPKGStatus` method
In this case, we will write the status type to a file, which we thereafter read from the state as a single byte.
Fix error in awk script
Use `ExtractFileFromState` for dpkg `installUpdates`
Use `ExtractFileFromState` in `unpackAndMergeUpdates`
APK: Use `ExtractFileFromState` for `upgradePackages`
Do not use `SolveToLocal`.
Use `ExtractFileFromState` for `probeRPMStatus`
Replace `buildkit.SolveToLocal` in rpm.go
Update `patchWithContext` to pass the correct client
Fix errors and achieve parity with `main` branch
Update unit tests

Closes #177 
