### PR TITLE
feat: Prefer local image

### DIFF
--- a/.github/workflows/scripts/buildkitenvs/docker/custom-unix
+++ b/.github/workflows/scripts/buildkitenvs/docker/custom-unix
@@ -25,7 +25,7 @@ _check_docker_dind() {
 }
 
 while ! _check_docker_dind; do
-    check_docker_dind || sleep 1
+    _check_docker_dind || sleep 1
 done
 
 export COPA_BUILDKIT_ADDR="docker://unix://${sock_dir}/docker.sock"

--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apimachinery v0.28.1 // indirect
+	k8s.io/apimachinery v0.28.1
 	k8s.io/client-go v0.28.1 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.20
 require (
 	github.com/aquasecurity/trivy v0.45.1
 	github.com/containerd/console v1.0.3
-	github.com/containerd/containerd v1.7.8
 	github.com/cpuguy83/dockercfg v0.3.1
+	github.com/cpuguy83/go-docker v0.2.1
 	github.com/distribution/reference v0.5.0
 	github.com/docker/buildx v0.11.2
 	github.com/docker/cli v24.0.7+incompatible
@@ -26,9 +26,8 @@ require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/sync v0.4.0
 	google.golang.org/grpc v1.59.0
+	k8s.io/apimachinery v0.28.1
 )
-
-require github.com/containerd/log v0.1.0 // indirect
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect
@@ -41,10 +40,10 @@ require (
 	github.com/aquasecurity/trivy-db v0.0.0-20230831170347-f732860d4917 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/containerd/containerd v1.7.8 // indirect
 	github.com/containerd/continuity v0.4.2 // indirect
-	github.com/containerd/ttrpc v1.2.2 // indirect
+	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/typeurl/v2 v2.1.1 // indirect
-	github.com/cpuguy83/go-docker v0.2.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v24.0.7+incompatible // indirect
@@ -141,7 +140,6 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apimachinery v0.28.1
 	k8s.io/client-go v0.28.1 // indirect
 	k8s.io/klog/v2 v2.100.1 // indirect
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -99,7 +99,6 @@ github.com/containerd/nydus-snapshotter v0.8.2 h1:7SOrMU2YmLzfbsr5J7liMZJlNi5WT6
 github.com/containerd/stargz-snapshotter v0.14.3 h1:OTUVZoPSPs8mGgmQUE1dqw3WX/3nrsmsurW7UPLWl1U=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3 h1:OqlDCK3ZVUO6C3B/5FSkDwbkEETK84kQgEeFwDC+62k=
 github.com/containerd/ttrpc v1.2.2 h1:9vqZr0pxwOF5koz6N0N3kJ0zDHokrcPxIR/ZR2YFtOs=
-github.com/containerd/ttrpc v1.2.2/go.mod h1:sIT6l32Ph/H9cvnJsfXM5drIVzTr5A2flTf1G5tYZak=
 github.com/containerd/typeurl/v2 v2.1.1 h1:3Q4Pt7i8nYwy2KmQWIw2+1hTvwTE/6w9FqcttATPO/4=
 github.com/containerd/typeurl/v2 v2.1.1/go.mod h1:IDp2JFvbwZ31H8dQbEIY7sDl2L3o3HZj1hsSQlywkQ0=
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
@@ -376,7 +375,6 @@ github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
-github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -394,7 +392,6 @@ github.com/shibumi/go-pathspec v1.3.0 h1:QUyMZhFo0Md5B8zV8x2tesohbb5kfbpTi9rBnKh
 github.com/shibumi/go-pathspec v1.3.0/go.mod h1:Xutfslp817l2I1cZvgcfeMQJG5QnU2lh5tVaaMCl3jE=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
@@ -591,7 +588,6 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -623,7 +619,6 @@ golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/integration/fixtures/test-images.json
+++ b/integration/fixtures/test-images.json
@@ -8,11 +8,29 @@
         "ignoreErrors": false
     },
     {
+        "image": "docker.io/grafana/grafana",
+        "tag": "8.5.0",
+        "localName": "registry.copacetic.test/repo/image:tag",
+        "digest": "sha256:42d3e6bc186572245aded5a0be381012adba6d89355fa9486dd81b0c634695b5",
+        "distro": "Alpine",
+        "description": "Valid apk/db, apk present, locally tagged with fully-qualified name",
+        "ignoreErrors": false
+    },
+    {
         "image": "docker.io/library/nginx",
         "tag": "1.21.6",
         "digest": "sha256:2bcabc23b45489fb0885d69a06ba1d648aeda973fae7bb981bafbb884165e514",
         "distro": "Debian",
         "description": "Valid dpkg/status, apt present",
+        "ignoreErrors": false
+    },
+    {
+        "image": "docker.io/library/nginx",
+        "tag": "1.21.6",
+        "digest": "sha256:2bcabc23b45489fb0885d69a06ba1d648aeda973fae7bb981bafbb884165e514",
+        "localName": "local/image:tag",
+        "distro": "Debian",
+        "description": "Valid dpkg/status, apt present, locally tagged with repo and image name",
         "ignoreErrors": false
     },
     {
@@ -37,6 +55,15 @@
         "digest": "sha256:2d80c13c2e7e06aa6a2e54a1825c6adbb3829c8a133ff617a0a61790bd61c53d",
         "distro": "Google Distroless",
         "description": "Custom dpkg/status.d with base64 names, no apt",
+        "ignoreErrors": false
+    },
+    {
+        "image": "docker.io/fluent/fluent-bit",
+        "tag": "1.8.4",
+        "digest": "sha256:2d80c13c2e7e06aa6a2e54a1825c6adbb3829c8a133ff617a0a61790bd61c53d",
+        "localName": "localimage:tag",
+        "distro": "Google Distroless",
+        "description": "Custom dpkg/status.d with base64 names, no apt, locally tagged with image name only",
         "ignoreErrors": false
     },
     {

--- a/integration/patch_test.go
+++ b/integration/patch_test.go
@@ -116,7 +116,7 @@ func dockerCmd(t *testing.T, args ...string) {
 
 		dockerDINDAddress = new(string)
 		if addr := os.Getenv("COPA_BUILDKIT_ADDR"); addr != "" && strings.HasPrefix(addr, "docker://") {
-			*dockerDINDAddress = addr
+			*dockerDINDAddress = strings.TrimPrefix(addr, "docker://")
 		}
 
 		return *dockerDINDAddress

--- a/integration/patch_test.go
+++ b/integration/patch_test.go
@@ -118,6 +118,8 @@ type addrWrapper struct {
 	address *string
 }
 
+var dockerDINDAddress addrWrapper
+
 func (w *addrWrapper) addr() string {
 	w.m.Lock()
 	defer w.m.Unlock()
@@ -133,8 +135,6 @@ func (w *addrWrapper) addr() string {
 
 	return *w.address
 }
-
-var dockerDINDAddress addrWrapper
 
 func dockerCmd(t *testing.T, args ...string) {
 	var err error

--- a/integration/patch_test.go
+++ b/integration/patch_test.go
@@ -48,6 +48,15 @@ func TestPatch(t *testing.T) {
 
 	for _, img := range images {
 		img := img
+
+		// Only the buildkit instance running within the docker daemon can work
+		// with locally-built or locally-tagged images. As a result, skip tests
+		// for local-only images when the daemon in question is not docker itself.
+		// i.e., don't test local images in buildx or with stock buildkit.
+		if img.LocalName != "" && !strings.HasPrefix(os.Getenv(`COPA_BUILDKIT_ADDR`), "docker://") {
+			continue
+		}
+
 		t.Run(img.Description, func(t *testing.T) {
 			t.Parallel()
 

--- a/integration/patch_test.go
+++ b/integration/patch_test.go
@@ -54,7 +54,7 @@ func TestPatch(t *testing.T) {
 		// for local-only images when the daemon in question is not docker itself.
 		// i.e., don't test local images in buildx or with stock buildkit.
 		if img.LocalName != "" && !strings.HasPrefix(os.Getenv(`COPA_BUILDKIT_ADDR`), "docker://") {
-			continue
+			t.Skip()
 		}
 
 		t.Run(img.Description, func(t *testing.T) {

--- a/integration/patch_test.go
+++ b/integration/patch_test.go
@@ -48,17 +48,16 @@ func TestPatch(t *testing.T) {
 
 	for _, img := range images {
 		img := img
-
-		// Only the buildkit instance running within the docker daemon can work
-		// with locally-built or locally-tagged images. As a result, skip tests
-		// for local-only images when the daemon in question is not docker itself.
-		// i.e., don't test local images in buildx or with stock buildkit.
-		if img.LocalName != "" && !strings.HasPrefix(os.Getenv(`COPA_BUILDKIT_ADDR`), "docker://") {
-			t.Skip()
-		}
-
 		t.Run(img.Description, func(t *testing.T) {
 			t.Parallel()
+
+			// Only the buildkit instance running within the docker daemon can work
+			// with locally-built or locally-tagged images. As a result, skip tests
+			// for local-only images when the daemon in question is not docker itself.
+			// i.e., don't test local images in buildx or with stock buildkit.
+			if img.LocalName != "" && !strings.HasPrefix(os.Getenv(`COPA_BUILDKIT_ADDR`), "docker://") {
+				t.Skip()
+			}
 
 			dir := t.TempDir()
 			scanResults := filepath.Join(dir, "scan.json")

--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -3,7 +3,6 @@ package buildkit
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -142,10 +141,6 @@ func WithFileString(s *llb.State, path, contents string) llb.State {
 
 func WithFileBytes(s *llb.State, path string, contents []byte) llb.State {
 	return s.File(llb.Mkfile(path, 0o600, contents))
-}
-
-func Env(k, v string) string {
-	return fmt.Sprintf("%s=%s", k, v)
 }
 
 func SolveToLocal(ctx context.Context, c *client.Client, st *llb.State, outPath string) error {

--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -1,7 +1,9 @@
 package buildkit
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -14,6 +16,7 @@ import (
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
 	"github.com/moby/buildkit/util/contentutil"
@@ -30,7 +33,7 @@ import (
 
 type Config struct {
 	ImageName  string
-	Client     *client.Client
+	Client     gwclient.Client
 	ConfigData []byte
 	Platform   ispec.Platform
 	ImageState llb.State
@@ -104,7 +107,7 @@ func resolveImageConfig(ctx context.Context, ref string, platform *ispec.Platfor
 	return dgst, config, nil
 }
 
-func InitializeBuildkitConfig(ctx context.Context, client *client.Client, image string, manifest *unversioned.UpdateManifest) (*Config, error) {
+func InitializeBuildkitConfig(ctx context.Context, c gwclient.Client, image string, manifest *unversioned.UpdateManifest) (*Config, error) {
 	// Initialize buildkit config for the target image
 	config := Config{
 		ImageName: image,
@@ -115,25 +118,80 @@ func InitializeBuildkitConfig(ctx context.Context, client *client.Client, image 
 	}
 
 	// Resolve and pull the config for the target image
-	_, configData, err := resolveImageConfig(ctx, image, &config.Platform)
+	_, _, configData, err := c.ResolveImageConfig(ctx, image, llb.ResolveImageConfigOpt{
+		ResolveMode: llb.ResolveModePreferLocal.String(),
+	})
 	if err != nil {
 		return nil, err
 	}
+
 	config.ConfigData = configData
 
 	// Load the target image state with the resolved image config in case environment variable settings
 	// are necessary for running apps in the target image for updates
 	config.ImageState, err = llb.Image(image,
 		llb.Platform(config.Platform),
-		llb.ResolveModeDefault,
+		llb.ResolveModePreferLocal,
+		llb.WithMetaResolver(c),
 	).WithImageConfig(config.ConfigData)
 	if err != nil {
 		return nil, err
 	}
 
-	config.Client = client
+	config.Client = c
 
 	return &config, nil
+}
+
+// Extracts the bytes of the file denoted by `path` from the state `st`.
+func ExtractFileFromState(ctx context.Context, c gwclient.Client, st *llb.State, path string) ([]byte, error) {
+	def, err := st.Marshal(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Solve(ctx, gwclient.SolveRequest{
+		Evaluate:   true,
+		Definition: def.ToPB(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ref, err := resp.SingleRef()
+	if err != nil {
+		return nil, err
+	}
+
+	return ref.ReadFile(ctx, gwclient.ReadRequest{
+		Filename: path,
+	})
+}
+
+func ArrayFile(input []string) []byte {
+	var b bytes.Buffer
+	for _, s := range input {
+		b.WriteString(s)
+		b.WriteRune('\n') // newline
+	}
+	return b.Bytes()
+}
+
+func WithArrayFile(s llb.State, path string, contents []string) llb.State {
+	af := ArrayFile(contents)
+	return WithFileBytes(s, path, af)
+}
+
+func WithFileString(s llb.State, path, contents string) llb.State {
+	return WithFileBytes(s, path, []byte(contents))
+}
+
+func WithFileBytes(s llb.State, path string, contents []byte) llb.State {
+	return s.File(llb.Mkfile(path, 0o600, contents))
+}
+
+func Env(k, v string) string {
+	return fmt.Sprintf("%s=%s", k, v)
 }
 
 func SolveToLocal(ctx context.Context, c *client.Client, st *llb.State, outPath string) error {

--- a/pkg/buildkit/buildkit_test.go
+++ b/pkg/buildkit/buildkit_test.go
@@ -218,3 +218,37 @@ func TestNewClient(t *testing.T) {
 	// TODO: Test with defaults, but then we need to control those socket paths.
 	// I considered doing this in a chroot, but it is fairly complicated to do so and requires root privileges anyway (or CAP_SYS_CHROOT).
 }
+
+func TestArrayFile(t *testing.T) {
+	type spec struct {
+		desc     string
+		input    []string
+		expected string
+	}
+
+	tests := []spec{
+		{
+			desc:     "single element, must have newline at the end of the file",
+			input:    []string{"line"},
+			expected: "line\n",
+		},
+		{
+			desc:     "multiple elements, must have newline at the end of the file",
+			input:    []string{"line", "another"},
+			expected: "line\nanother\n",
+		},
+		{
+			desc:     "empty array produces empty file",
+			input:    []string{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			b := ArrayFile(tt.input)
+			assert.Equal(t, tt.expected, string(b))
+		})
+	}
+}

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -73,12 +73,7 @@ func removeIfNotDebug(workingFolder string) {
 }
 
 func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workingFolder, scanner, format, output string, ignoreError bool, bkOpts buildkit.Opts) error {
-	ref, err := normalizeRef(image)
-	if err != nil {
-		return err
-	}
-
-	imageName, err := reference.ParseNamed(ref)
+	imageName, err := reference.ParseNormalizedNamed(image)
 	if err != nil {
 		return err
 	}
@@ -164,7 +159,7 @@ func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workin
 	eg.Go(func() error {
 		_, err := bkClient.Build(ctx, solveOpt, copaProduct, func(ctx context.Context, c gwclient.Client) (*gwclient.Result, error) {
 			// Configure buildctl/client for use by package manager
-			config, err := buildkit.InitializeBuildkitConfig(ctx, c, ref, updates)
+			config, err := buildkit.InitializeBuildkitConfig(ctx, c, imageName.String(), updates)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/containerd/console"
@@ -18,7 +17,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/distribution/reference"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
@@ -241,28 +239,6 @@ func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workin
 	})
 
 	return eg.Wait()
-}
-
-func normalizeRef(image string) (string, error) {
-	// Prevents parsing library from prefixing `index.docker.io` instead of
-	// `docker.io`. `.test` is not a valid domain suffix, so the only way this
-	// could backfire is if someone is intentionally using docker.io.test to
-	// refer to a local image.
-	modifiedRegistry := fmt.Sprintf("%s.test", defaultRegistry)
-	calculatedDefault := modifiedRegistry
-
-	s := strings.Split(image, "/")
-	if len(s) < 2 {
-		calculatedDefault = fmt.Sprintf("%s/library", modifiedRegistry)
-	}
-
-	r, err := name.ParseReference(image, name.WithDefaultRegistry(calculatedDefault), name.WithDefaultTag(defaultTag))
-	if err != nil {
-		return "", err
-	}
-
-	ref := strings.Replace(r.Name(), modifiedRegistry, defaultRegistry, 1) // undo the modification
-	return ref, nil
 }
 
 func dockerLoad(ctx context.Context, pipeR io.Reader) error {

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -11,6 +11,8 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/distribution/reference"
+	"github.com/moby/buildkit/client"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
 	"github.com/project-copacetic/copacetic/pkg/pkgmgr"
 	"github.com/project-copacetic/copacetic/pkg/report"
@@ -21,6 +23,7 @@ import (
 
 const (
 	defaultPatchedTagSuffix = "patched"
+	copaProduct             = "copa"
 )
 
 // Patch command applies package updates to an OCI image given a vulnerability report.
@@ -108,56 +111,65 @@ func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workin
 	}
 	log.Debugf("updates to apply: %v", updates)
 
-	client, err := buildkit.NewClient(ctx, bkOpts)
+	bkClient, err := buildkit.NewClient(ctx, bkOpts)
 	if err != nil {
 		return err
 	}
-	defer client.Close()
+	defer bkClient.Close()
 
-	// Configure buildctl/client for use by package manager
-	config, err := buildkit.InitializeBuildkitConfig(ctx, client, image, updates)
-	if err != nil {
-		return err
-	}
-
-	// Create package manager helper
-	pkgmgr, err := pkgmgr.GetPackageManager(updates.Metadata.OS.Type, config, workingFolder)
-	if err != nil {
-		return err
-	}
-
-	// Export the patched image state to Docker
-	// TODO: Add support for other output modes as buildctl does.
-	patchedImageState, errPkgs, err := pkgmgr.InstallUpdates(ctx, updates, ignoreError)
-	if err != nil {
-		return err
-	}
-
-	if err = buildkit.SolveToDocker(ctx, config.Client, patchedImageState, config.ConfigData, patchedImageName); err != nil {
-		return err
-	}
-
-	// create a new manifest with the successfully patched packages
-	validatedManifest := &unversioned.UpdateManifest{
-		Metadata: unversioned.Metadata{
-			OS: unversioned.OS{
-				Type:    updates.Metadata.OS.Type,
-				Version: updates.Metadata.OS.Version,
-			},
-			Config: unversioned.Config{
-				Arch: updates.Metadata.Config.Arch,
-			},
-		},
-		Updates: []unversioned.UpdatePackage{},
-	}
-	for _, update := range updates.Updates {
-		if !slices.Contains(errPkgs, update.Name) {
-			validatedManifest.Updates = append(validatedManifest.Updates, update)
+	_, err = bkClient.Build(ctx, client.SolveOpt{}, copaProduct, func(ctx context.Context, c gwclient.Client) (*gwclient.Result, error) {
+		// Configure buildctl/client for use by package manager
+		config, err := buildkit.InitializeBuildkitConfig(ctx, c, image, updates)
+		if err != nil {
+			return nil, err
 		}
-	}
-	// vex document must contain at least one statement
-	if output != "" && len(validatedManifest.Updates) > 0 {
-		return vex.TryOutputVexDocument(validatedManifest, pkgmgr, patchedImageName, format, output)
-	}
-	return nil
+
+		// Create package manager helper
+		pkgmgr, err := pkgmgr.GetPackageManager(updates.Metadata.OS.Type, config, workingFolder)
+		if err != nil {
+			return nil, err
+		}
+
+		// Export the patched image state to Docker
+		// TODO: Add support for other output modes as buildctl does.
+		patchedImageState, errPkgs, err := pkgmgr.InstallUpdates(ctx, updates, ignoreError)
+		if err != nil {
+			return nil, err
+		}
+
+		if err = buildkit.SolveToDocker(ctx, bkClient, patchedImageState, config.ConfigData, patchedImageName); err != nil {
+			return nil, err
+		}
+
+		// create a new manifest with the successfully patched packages
+		validatedManifest := &unversioned.UpdateManifest{
+			Metadata: unversioned.Metadata{
+				OS: unversioned.OS{
+					Type:    updates.Metadata.OS.Type,
+					Version: updates.Metadata.OS.Version,
+				},
+				Config: unversioned.Config{
+					Arch: updates.Metadata.Config.Arch,
+				},
+			},
+			Updates: []unversioned.UpdatePackage{},
+		}
+		for _, update := range updates.Updates {
+			if !slices.Contains(errPkgs, update.Name) {
+				validatedManifest.Updates = append(validatedManifest.Updates, update)
+			}
+		}
+		// vex document must contain at least one statement
+		if output != "" && len(validatedManifest.Updates) > 0 {
+			if err := vex.TryOutputVexDocument(validatedManifest, pkgmgr, patchedImageName, format, output); err != nil {
+				return nil, err
+			}
+
+			return nil, nil
+		}
+
+		return nil, nil
+	}, nil)
+
+	return err
 }

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -4,15 +4,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"time"
 
+	"github.com/containerd/console"
+	"github.com/docker/buildx/build"
+	"github.com/docker/cli/cli/config"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/distribution/reference"
 	"github.com/moby/buildkit/client"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/moby/buildkit/session"
+	"github.com/moby/buildkit/session/auth/authprovider"
+	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
 	"github.com/project-copacetic/copacetic/pkg/pkgmgr"
 	"github.com/project-copacetic/copacetic/pkg/report"
@@ -117,59 +126,126 @@ func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workin
 	}
 	defer bkClient.Close()
 
-	_, err = bkClient.Build(ctx, client.SolveOpt{}, copaProduct, func(ctx context.Context, c gwclient.Client) (*gwclient.Result, error) {
-		// Configure buildctl/client for use by package manager
-		config, err := buildkit.InitializeBuildkitConfig(ctx, c, image, updates)
-		if err != nil {
-			return nil, err
-		}
-
-		// Create package manager helper
-		pkgmgr, err := pkgmgr.GetPackageManager(updates.Metadata.OS.Type, config, workingFolder)
-		if err != nil {
-			return nil, err
-		}
-
-		// Export the patched image state to Docker
-		// TODO: Add support for other output modes as buildctl does.
-		patchedImageState, errPkgs, err := pkgmgr.InstallUpdates(ctx, updates, ignoreError)
-		if err != nil {
-			return nil, err
-		}
-
-		if err = buildkit.SolveToDocker(ctx, bkClient, patchedImageState, config.ConfigData, patchedImageName); err != nil {
-			return nil, err
-		}
-
-		// create a new manifest with the successfully patched packages
-		validatedManifest := &unversioned.UpdateManifest{
-			Metadata: unversioned.Metadata{
-				OS: unversioned.OS{
-					Type:    updates.Metadata.OS.Type,
-					Version: updates.Metadata.OS.Version,
-				},
-				Config: unversioned.Config{
-					Arch: updates.Metadata.Config.Arch,
+	pipeR, pipeW := io.Pipe()
+	dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
+	attachable := []session.Attachable{authprovider.NewDockerAuthProvider(dockerConfig)}
+	solveOpt := client.SolveOpt{
+		Exports: []client.ExportEntry{
+			{
+				Type: client.ExporterDocker,
+				Output: func(_ map[string]string) (io.WriteCloser, error) {
+					return pipeW, nil
 				},
 			},
-			Updates: []unversioned.UpdatePackage{},
-		}
-		for _, update := range updates.Updates {
-			if !slices.Contains(errPkgs, update.Name) {
-				validatedManifest.Updates = append(validatedManifest.Updates, update)
-			}
-		}
-		// vex document must contain at least one statement
-		if output != "" && len(validatedManifest.Updates) > 0 {
-			if err := vex.TryOutputVexDocument(validatedManifest, pkgmgr, patchedImageName, format, output); err != nil {
+		},
+		Frontend: "",         // i.e. we are passing in the llb.Definition directly
+		Session:  attachable, // used for authprovider, sshagentprovider and secretprovider
+	}
+	solveOpt.SourcePolicy, err = build.ReadSourcePolicy()
+	if err != nil {
+		return err
+	}
+
+	ch := make(chan *client.SolveStatus)
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		_, err := bkClient.Build(ctx, solveOpt, copaProduct, func(ctx context.Context, c gwclient.Client) (*gwclient.Result, error) {
+			// Configure buildctl/client for use by package manager
+			config, err := buildkit.InitializeBuildkitConfig(ctx, c, image, updates)
+			if err != nil {
 				return nil, err
 			}
 
-			return nil, nil
+			// Create package manager helper
+			pkgmgr, err := pkgmgr.GetPackageManager(updates.Metadata.OS.Type, config, workingFolder)
+			if err != nil {
+				return nil, err
+			}
+
+			// Export the patched image state to Docker
+			// TODO: Add support for other output modes as buildctl does.
+			patchedImageState, errPkgs, err := pkgmgr.InstallUpdates(ctx, updates, ignoreError)
+			if err != nil {
+				return nil, err
+			}
+
+			def, err := patchedImageState.Marshal(ctx)
+			res, err := c.Solve(ctx, gwclient.SolveRequest{
+				Definition: def.ToPB(),
+				Evaluate:   true,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			// create a new manifest with the successfully patched packages
+			validatedManifest := &unversioned.UpdateManifest{
+				Metadata: unversioned.Metadata{
+					OS: unversioned.OS{
+						Type:    updates.Metadata.OS.Type,
+						Version: updates.Metadata.OS.Version,
+					},
+					Config: unversioned.Config{
+						Arch: updates.Metadata.Config.Arch,
+					},
+				},
+				Updates: []unversioned.UpdatePackage{},
+			}
+			for _, update := range updates.Updates {
+				if !slices.Contains(errPkgs, update.Name) {
+					validatedManifest.Updates = append(validatedManifest.Updates, update)
+				}
+			}
+			// vex document must contain at least one statement
+			if output != "" && len(validatedManifest.Updates) > 0 {
+				if err := vex.TryOutputVexDocument(validatedManifest, pkgmgr, patchedImageName, format, output); err != nil {
+					return nil, err
+				}
+			}
+
+			return res, nil
+		}, ch)
+
+		return err
+	})
+
+	eg.Go(func() error {
+		var c console.Console
+		if cn, err := console.ConsoleFromFile(os.Stderr); err == nil {
+			c = cn
 		}
+		// not using shared context to not disrupt display but let us finish reporting errors
+		_, err = progressui.DisplaySolveStatus(context.TODO(), c, os.Stdout, ch)
+		return err
+	})
 
-		return nil, nil
-	}, nil)
+	eg.Go(func() error {
+		if err := dockerLoad(ctx, pipeR); err != nil {
+			return err
+		}
+		return pipeR.Close()
+	})
 
-	return err
+	return eg.Wait()
+}
+
+func dockerLoad(ctx context.Context, pipeR io.Reader) error {
+	cmd := exec.CommandContext(ctx, "docker", "load")
+	cmd.Stdin = pipeR
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	// Pipe run errors to WarnLevel since execution continues asynchronously
+	// Caller should log a separate ErrorLevel on completion based on err
+	go utils.LogPipe(stderr, log.WarnLevel)
+	go utils.LogPipe(stdout, log.InfoLevel)
+
+	return cmd.Run()
 }

--- a/pkg/pkgmgr/apk.go
+++ b/pkg/pkgmgr/apk.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -179,10 +178,9 @@ func (am *apkManager) upgradePackages(ctx context.Context, updates unversioned.U
 	pkgs := strings.Trim(fmt.Sprintf("%s", pkgStrings), "[]")
 	outputResultsCmd := fmt.Sprintf(outputResultsTemplate, pkgs, resultManifest)
 	mkFolders := apkInstalled.File(llb.Mkdir(resultsPath, 0o744, llb.WithParents(true)))
-	resultsWritten := mkFolders.Dir(resultsPath).Run(llb.Shlex(outputResultsCmd)).Root()
-	resultsDiff := llb.Diff(apkInstalled, resultsWritten)
+	resultsDiff := mkFolders.Dir(resultsPath).Run(llb.Shlex(outputResultsCmd)).AddMount(resultsPath, llb.Scratch())
 
-	resultManifestBytes, err := buildkit.ExtractFileFromState(ctx, am.config.Client, &resultsDiff, filepath.Join(resultsPath, resultManifest))
+	resultManifestBytes, err := buildkit.ExtractFileFromState(ctx, am.config.Client, &resultsDiff, resultManifest)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/pkgmgr/apk.go
+++ b/pkg/pkgmgr/apk.go
@@ -2,9 +2,9 @@ package pkgmgr
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -34,16 +34,15 @@ func isLessThanAPKVersion(v1, v2 string) bool {
 	return apkV1.LessThan(apkV2)
 }
 
-func apkReadResultsManifest(path string) ([]string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		log.Errorf("%s could not be opened", path)
-		return nil, err
+func apkReadResultsManifest(b []byte) ([]string, error) {
+	if b == nil {
+		return nil, fmt.Errorf("nil buffer provided")
 	}
-	defer f.Close()
+
+	buf := bytes.NewBuffer(b)
 
 	var lines []string
-	fs := bufio.NewScanner(f)
+	fs := bufio.NewScanner(buf)
 	for fs.Scan() {
 		lines = append(lines, fs.Text())
 	}
@@ -51,8 +50,8 @@ func apkReadResultsManifest(path string) ([]string, error) {
 	return lines, nil
 }
 
-func validateAPKPackageVersions(updates unversioned.UpdatePackages, cmp VersionComparer, resultsPath string, ignoreErrors bool) ([]string, error) {
-	lines, err := apkReadResultsManifest(resultsPath)
+func validateAPKPackageVersions(updates unversioned.UpdatePackages, cmp VersionComparer, resultsBytes []byte, ignoreErrors bool) ([]string, error) {
+	lines, err := apkReadResultsManifest(resultsBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -132,14 +131,13 @@ func (am *apkManager) InstallUpdates(ctx context.Context, manifest *unversioned.
 	}
 	log.Debugf("latest unique APKs: %v", updates)
 
-	updatedImageState, err := am.upgradePackages(ctx, updates)
+	updatedImageState, resultsBytes, err := am.upgradePackages(ctx, updates)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Validate that the deployed packages are of the requested version or better
-	resultManifestPath := filepath.Join(am.workingFolder, resultsPath, resultManifest)
-	errPkgs, err := validateAPKPackageVersions(updates, apkComparer, resultManifestPath, ignoreErrors)
+	errPkgs, err := validateAPKPackageVersions(updates, apkComparer, resultsBytes, ignoreErrors)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -154,7 +152,7 @@ func (am *apkManager) InstallUpdates(ctx context.Context, manifest *unversioned.
 // TODO: support "distroless" Alpine images (e.g. APKO images)
 // Still assumes that APK exists in the target image and is pathed, which can be addressed by
 // mounting a copy of apk-tools-static into the image and invoking apk-static directly.
-func (am *apkManager) upgradePackages(ctx context.Context, updates unversioned.UpdatePackages) (*llb.State, error) {
+func (am *apkManager) upgradePackages(ctx context.Context, updates unversioned.UpdatePackages) (*llb.State, []byte, error) {
 	// TODO: Add support for custom APK config
 	apkUpdated := am.config.ImageState.Run(llb.Shlex("apk update"), llb.WithProxy(utils.GetProxy())).Root()
 
@@ -184,14 +182,15 @@ func (am *apkManager) upgradePackages(ctx context.Context, updates unversioned.U
 	resultsWritten := mkFolders.Dir(resultsPath).Run(llb.Shlex(outputResultsCmd)).Root()
 	resultsDiff := llb.Diff(apkInstalled, resultsWritten)
 
-	if err := buildkit.SolveToLocal(ctx, am.config.Client, &resultsDiff, am.workingFolder); err != nil {
-		return nil, err
+	resultManifestBytes, err := buildkit.ExtractFileFromState(ctx, am.config.Client, &resultsDiff, filepath.Join(resultsPath, resultManifest))
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Diff the installed updates and merge that into the target image
 	patchDiff := llb.Diff(apkUpdated, apkInstalled)
 	patchMerge := llb.Merge([]llb.State{am.config.ImageState, patchDiff})
-	return &patchMerge, nil
+	return &patchMerge, resultManifestBytes, nil
 }
 
 func (am *apkManager) GetPackageType() string {

--- a/pkg/pkgmgr/apk_test.go
+++ b/pkg/pkgmgr/apk_test.go
@@ -74,13 +74,12 @@ var (
 	//go:embed testdata/empty.txt
 	apkEmpty []byte
 
-	// tests the error handling of the function
-	apkNoSuchFile []byte = nil
+	// initialized to `nil`; tests the error handling of the function.
+	apkNoSuchFile []byte
 )
 
 // TestApkReadResultsManifest tests the apkReadResultsManifest function.
 func TestApkReadResultsManifest(t *testing.T) {
-
 	type args struct {
 		path []byte
 	}

--- a/pkg/pkgmgr/apk_test.go
+++ b/pkg/pkgmgr/apk_test.go
@@ -1,6 +1,7 @@
 package pkgmgr
 
 import (
+	_ "embed"
 	"reflect"
 	"strings"
 	"testing"
@@ -63,10 +64,25 @@ func TestIsLessThanAPKVersion(t *testing.T) {
 	}
 }
 
+var (
+	//go:embed testdata/apk_valid.txt
+	apkValid []byte
+
+	//go:embed testdata/apk_invalid.txt
+	apkInvalid []byte
+
+	//go:embed testdata/empty.txt
+	apkEmpty []byte
+
+	// tests the error handling of the function
+	apkNoSuchFile []byte = nil
+)
+
 // TestApkReadResultsManifest tests the apkReadResultsManifest function.
 func TestApkReadResultsManifest(t *testing.T) {
+
 	type args struct {
-		path string
+		path []byte
 	}
 	tests := []struct {
 		name    string
@@ -74,9 +90,9 @@ func TestApkReadResultsManifest(t *testing.T) {
 		want    []string
 		wantErr bool
 	}{
-		{"valid file", args{"testdata/apk_valid.txt"}, []string{"apk-tools-2.12.7-r0", "busybox-1.33.1-r8"}, false},
-		{"file does not exist", args{"testdata/no_such_file.txt"}, nil, true},
-		{"empty file", args{"testdata/empty.txt"}, nil, false},
+		{"valid file", args{apkValid}, []string{"apk-tools-2.12.7-r0", "busybox-1.33.1-r8"}, false},
+		{"file does not exist", args{apkNoSuchFile}, nil, true},
+		{"empty file", args{apkEmpty}, nil, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -101,7 +117,7 @@ func TestValidateAPKPackageVersions(t *testing.T) {
 		name            string
 		updates         unversioned.UpdatePackages
 		cmp             VersionComparer
-		resultsPath     string
+		resultsBytes    []byte
 		ignoreErrors    bool
 		expectedError   string
 		expectedErrPkgs []string
@@ -110,14 +126,14 @@ func TestValidateAPKPackageVersions(t *testing.T) {
 			name:         "valid updates",
 			updates:      []unversioned.UpdatePackage{{Name: "apk-tools", FixedVersion: "2.12.7-r0"}, {Name: "busybox", FixedVersion: "1.33.1-r8"}},
 			cmp:          apkComparer,
-			resultsPath:  "testdata/apk_valid.txt",
+			resultsBytes: apkValid,
 			ignoreErrors: false,
 		},
 		{
 			name:         "invalid version",
 			updates:      []unversioned.UpdatePackage{{Name: "apk-tools", FixedVersion: "1.0"}, {Name: "busybox", FixedVersion: "2.0"}},
 			cmp:          apkComparer,
-			resultsPath:  "testdata/apk_invalid.txt",
+			resultsBytes: apkInvalid,
 			ignoreErrors: false,
 			expectedError: `2 errors occurred:
 	* invalid version x.y found for package apk-tools
@@ -127,14 +143,14 @@ func TestValidateAPKPackageVersions(t *testing.T) {
 			name:         "invalid version with ignore errors",
 			updates:      []unversioned.UpdatePackage{{Name: "apk-tools", FixedVersion: "1.0"}, {Name: "busybox", FixedVersion: "2.0"}},
 			cmp:          apkComparer,
-			resultsPath:  "testdata/apk_valid.txt",
+			resultsBytes: apkValid,
 			ignoreErrors: true,
 		},
 		{
 			name:          "expected 1 updates, installed 2",
 			updates:       []unversioned.UpdatePackage{{Name: "apk-tools", FixedVersion: "2.12.7-r0"}},
 			cmp:           apkComparer,
-			resultsPath:   "testdata/apk_valid.txt",
+			resultsBytes:  apkValid,
 			ignoreErrors:  false,
 			expectedError: `expected 1 updates, installed 2`,
 		},
@@ -144,7 +160,7 @@ func TestValidateAPKPackageVersions(t *testing.T) {
 		// Use t.Run to run each test case as a subtest
 		t.Run(tc.name, func(t *testing.T) {
 			// Run the function to be tested
-			errorPkgs, err := validateAPKPackageVersions(tc.updates, tc.cmp, tc.resultsPath, tc.ignoreErrors)
+			errorPkgs, err := validateAPKPackageVersions(tc.updates, tc.cmp, tc.resultsBytes, tc.ignoreErrors)
 			if tc.expectedError != "" {
 				if !strings.Contains(err.Error(), tc.expectedError) {
 					t.Errorf("expected error %v, got %v", tc.expectedError, err.Error())

--- a/pkg/pkgmgr/dpkg.go
+++ b/pkg/pkgmgr/dpkg.go
@@ -2,10 +2,11 @@ package pkgmgr
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -21,6 +22,8 @@ const (
 	dpkgLibPath      = "/var/lib/dpkg"
 	dpkgStatusPath   = dpkgLibPath + "/status"
 	dpkgStatusFolder = dpkgLibPath + "/status.d"
+
+	statusdOutputFilename = "statusd_type"
 )
 
 type dpkgManager struct {
@@ -37,6 +40,8 @@ const (
 	DPKGStatusFile
 	DPKGStatusDirectory
 	DPKGStatusMixed
+
+	DPKGStatusInvalid // must always be the last listed
 )
 
 func (st dpkgStatusType) String() string {
@@ -78,19 +83,23 @@ func getAPTImageName(manifest *unversioned.UpdateManifest) string {
 	return fmt.Sprintf("%s:%s", manifest.Metadata.OS.Type, version)
 }
 
-func getDPKGStatusType(dir string) dpkgStatusType {
-	out := DPKGStatusNone
-	if utils.IsNonEmptyFile(dir, "status") {
-		out = DPKGStatusFile
+func getDPKGStatusType(b []byte) dpkgStatusType {
+	if len(b) == 0 {
+		return DPKGStatusNone
 	}
-	if utils.IsNonEmptyFile(dir, "status.d") {
-		if out == DPKGStatusFile {
-			out = DPKGStatusMixed
-		} else {
-			out = DPKGStatusDirectory
-		}
+
+	st, err := strconv.Atoi(string(b))
+	if err != nil {
+		st = int(DPKGStatusNone)
 	}
-	return out
+
+	// convert ascii digit to byte
+	statusType := dpkgStatusType(st)
+	if statusType >= DPKGStatusInvalid {
+		return DPKGStatusInvalid
+	}
+
+	return statusType
 }
 
 func (dm *dpkgManager) InstallUpdates(ctx context.Context, manifest *unversioned.UpdateManifest, ignoreErrors bool) (*llb.State, []string, error) {
@@ -112,21 +121,21 @@ func (dm *dpkgManager) InstallUpdates(ctx context.Context, manifest *unversioned
 	}
 
 	var updatedImageState *llb.State
+	var resultManifestBytes []byte
 	if dm.isDistroless {
-		updatedImageState, err = dm.unpackAndMergeUpdates(ctx, updates, toolImageName)
+		updatedImageState, resultManifestBytes, err = dm.unpackAndMergeUpdates(ctx, updates, toolImageName)
 		if err != nil {
 			return nil, nil, err
 		}
 	} else {
-		updatedImageState, err = dm.installUpdates(ctx, updates)
+		updatedImageState, resultManifestBytes, err = dm.installUpdates(ctx, updates)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
 
 	// Validate that the deployed packages are of the requested version or better
-	resultManifestPath := filepath.Join(dm.workingFolder, resultsPath, resultManifest)
-	errPkgs, err := validateDebianPackageVersions(updates, debComparer, resultManifestPath, ignoreErrors)
+	errPkgs, err := validateDebianPackageVersions(updates, debComparer, resultManifestBytes, ignoreErrors)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -154,26 +163,47 @@ func (dm *dpkgManager) probeDPKGStatus(ctx context.Context, toolImage string) er
 	busyBoxApplied := dm.config.ImageState.File(llb.Copy(busyBoxInstalled, "/bin/busybox", "/bin/busybox"))
 	mkFolders := busyBoxApplied.File(llb.Mkdir(resultsPath, 0o744, llb.WithParents(true)))
 
-	const probeTemplate = `/bin/busybox sh -c "if [ -f %[1]s ]; then cp %[1]s %[3]s ; fi && if [ -d %[2]s ]; then ls -1 %[2]s > %[4]s ; fi"`
-	probeCmd := fmt.Sprintf(probeTemplate, dpkgStatusPath, dpkgStatusFolder, resultsPath, filepath.Join(resultsPath, "status.d"))
-	probed := mkFolders.Run(llb.Shlex(probeCmd)).Root()
+	probed := mkFolders.
+		Run(llb.Args([]string{
+			`/bin/busybox`, `env`,
+			buildkit.Env("DPKG_STATUS_PATH", dpkgStatusPath),
+			buildkit.Env("RESULTS_PATH", resultsPath),
+			buildkit.Env("DPKG_STATUS_FOLDER", dpkgStatusFolder),
+			buildkit.Env("RESULT_STATUSD_PATH", filepath.Join(resultsPath, "status.d")),
+			buildkit.Env("DPKG_STATUS_IS_DIRECTORY", fmt.Sprintf("%d", DPKGStatusDirectory)),
+			buildkit.Env("DPKG_STATUS_IS_FILE", fmt.Sprintf("%d", DPKGStatusFile)),
+			buildkit.Env("DPKG_STATUS_IS_UNKNOWN", fmt.Sprintf("%d", DPKGStatusNone)),
+			buildkit.Env("STATUSD_OUTPUT_FILENAME", statusdOutputFilename),
+			`sh`, `-c`, `
+                status="$DPKG_STATUS_IS_UNKNOWN"
+                if [ -f "$DPKG_STATUS_PATH" ]; then
+                    status="$DPKG_STATUS_IS_FILE"
+                    cp "$DPKG_STATUS_PATH" "$RESULTS_PATH"
+                elif [ -d "$DPKG_STATUS_FOLDER" ]; then
+                    status="$DPKG_STATUS_IS_DIRECTORY"
+                    ls -1 "$DPKG_STATUS_FOLDER" > "$RESULT_STATUSD_PATH"
+                fi
+                echo -n "$status" > "${RESULTS_PATH}/${STATUSD_OUTPUT_FILENAME}"
+        `,
+		})).Root()
+
 	outState := llb.Diff(busyBoxApplied, probed)
-	if err := buildkit.SolveToLocal(ctx, dm.config.Client, &outState, dm.workingFolder); err != nil {
+	typeBytes, err := buildkit.ExtractFileFromState(ctx, dm.config.Client, &outState, filepath.Join(resultsPath, statusdOutputFilename))
+	if err != nil {
 		return err
 	}
 
-	// Check Status File
-	outStatePath := filepath.Join(dm.workingFolder, resultsPath)
-	dpkgStatus := getDPKGStatusType(outStatePath)
+	dpkgStatus := getDPKGStatusType(typeBytes)
 	switch dpkgStatus {
 	case DPKGStatusFile:
 		return nil
 	case DPKGStatusDirectory:
-		statusdNames, err := os.ReadFile(filepath.Join(outStatePath, "status.d"))
+		statusdNamesBytes, err := buildkit.ExtractFileFromState(ctx, dm.config.Client, &outState, filepath.Join(resultsPath, "status.d"))
 		if err != nil {
 			return err
 		}
-		dm.statusdNames = strings.ReplaceAll(string(statusdNames), "\n", " ")
+		dm.statusdNames = strings.ReplaceAll(string(statusdNamesBytes), "\n", " ")
+		dm.statusdNames = strings.TrimSpace(dm.statusdNames)
 		log.Infof("Processed status.d: %s", dm.statusdNames)
 		dm.isDistroless = true
 		return nil
@@ -192,7 +222,7 @@ func (dm *dpkgManager) probeDPKGStatus(ctx context.Context, toolImage string) er
 //
 // TODO: Support Debian images with valid dpkg status but missing tools. No current examples exist in test set
 // i.e. extra RunOption to mount a copy of busybox-static or full apt install into the image and invoking that.
-func (dm *dpkgManager) installUpdates(ctx context.Context, updates unversioned.UpdatePackages) (*llb.State, error) {
+func (dm *dpkgManager) installUpdates(ctx context.Context, updates unversioned.UpdatePackages) (*llb.State, []byte, error) {
 	// TODO: Add support for custom APT config and gpg key injection
 	// Since this takes place in the target container, it can interfere with install actions
 	// such as the installation of the updated debian-archive-keyring package, so it's probably best
@@ -221,17 +251,18 @@ func (dm *dpkgManager) installUpdates(ctx context.Context, updates unversioned.U
 	resultsWritten := aptInstalled.Dir(resultsPath).Run(llb.Shlex(outputResultsCmd)).Root()
 	resultsDiff := llb.Diff(aptInstalled, resultsWritten)
 
-	if err := buildkit.SolveToLocal(ctx, dm.config.Client, &resultsDiff, dm.workingFolder); err != nil {
-		return nil, err
+	resultsBytes, err := buildkit.ExtractFileFromState(ctx, dm.config.Client, &resultsDiff, filepath.Join(resultsPath, resultManifest))
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Diff the installed updates and merge that into the target image
 	patchDiff := llb.Diff(aptUpdated, aptInstalled)
 	patchMerge := llb.Merge([]llb.State{dm.config.ImageState, patchDiff})
-	return &patchMerge, nil
+	return &patchMerge, resultsBytes, nil
 }
 
-func (dm *dpkgManager) unpackAndMergeUpdates(ctx context.Context, updates unversioned.UpdatePackages, toolImage string) (*llb.State, error) {
+func (dm *dpkgManager) unpackAndMergeUpdates(ctx context.Context, updates unversioned.UpdatePackages, toolImage string) (*llb.State, []byte, error) {
 	// Spin up a build tooling container to fetch and unpack packages to create patch layer.
 	// Pull family:version -> need to create version to base image map
 	toolingBase := llb.Image(toolImage,
@@ -275,8 +306,10 @@ func (dm *dpkgManager) unpackAndMergeUpdates(ctx context.Context, updates unvers
 	outputResultsCmd := fmt.Sprintf(outputResultsTemplate, resultManifest)
 	resultsWritten := fieldsWritten.Dir(resultsPath).Run(llb.Shlex(outputResultsCmd)).Root()
 	resultsDiff := llb.Diff(fieldsWritten, resultsWritten)
-	if err := buildkit.SolveToLocal(ctx, dm.config.Client, &resultsDiff, dm.workingFolder); err != nil {
-		return nil, err
+
+	resultsBytes, err := buildkit.ExtractFileFromState(ctx, dm.config.Client, &resultsDiff, filepath.Join(resultsPath, resultManifest))
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Update the status.d folder with the package info from the applied update packages
@@ -285,7 +318,7 @@ func (dm *dpkgManager) unpackAndMergeUpdates(ctx context.Context, updates unvers
 	// - Older distroless images had a bug where the file names were base64 encoded. If the base64 versions
 	//   of the names were found in the folder previously, then we use those names.
 	copyStatusTemplate := `find . -name '*.fields' -exec sh -c
-		"awk -v statusDir=%s -v statusdNames=\"(%s)\"
+		"awk -v statusDir=%s -v statusdNames=\"%s\"
 			'BEGIN{split(statusdNames,names); for (n in names) b64names[names[n]]=\"\"} {a[\$1]=\$2}
 			 END{cmd = \"printf \" a[\"Package:\"] \" | base64\" ;
 			  cmd | getline b64name ;
@@ -310,21 +343,15 @@ func (dm *dpkgManager) unpackAndMergeUpdates(ctx context.Context, updates unvers
 	// Diff unpacked packages layers from previous and merge with target
 	statusDiff := llb.Diff(fieldsWritten, statusUpdated)
 	merged := llb.Merge([]llb.State{dm.config.ImageState, unpackedToRoot, statusDiff})
-	return &merged, nil
+	return &merged, resultsBytes, nil
 }
 
 func (dm *dpkgManager) GetPackageType() string {
 	return "deb"
 }
 
-func dpkgParseResultsManifest(path string) (map[string]string, error) {
-	// Open result file
-	f, err := os.Open(path)
-	if err != nil {
-		log.Errorf("%s could not be opened", path)
-		return nil, err
-	}
-	defer f.Close()
+func dpkgParseResultsManifest(b []byte) (map[string]string, error) {
+	buf := bytes.NewBuffer(b)
 
 	// results.manifest file is expected to be subset of DPKG status or debian info format
 	// consisting of repeating consecutive blocks of:
@@ -333,7 +360,7 @@ func dpkgParseResultsManifest(path string) (map[string]string, error) {
 	// Version: <version value>
 	// ...
 	updateMap := map[string]string{}
-	fs := bufio.NewScanner(f)
+	fs := bufio.NewScanner(buf)
 	var packageName string
 	for fs.Scan() {
 		kv := strings.Split(fs.Text(), " ")
@@ -364,9 +391,9 @@ func dpkgParseResultsManifest(path string) (map[string]string, error) {
 	return updateMap, nil
 }
 
-func validateDebianPackageVersions(updates unversioned.UpdatePackages, cmp VersionComparer, resultsPath string, ignoreErrors bool) ([]string, error) {
+func validateDebianPackageVersions(updates unversioned.UpdatePackages, cmp VersionComparer, results []byte, ignoreErrors bool) ([]string, error) {
 	// Load file into map[string]string for package:version lookup
-	updateMap, err := dpkgParseResultsManifest(resultsPath)
+	updateMap, err := dpkgParseResultsManifest(results)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pkgmgr/dpkg.go
+++ b/pkg/pkgmgr/dpkg.go
@@ -163,18 +163,17 @@ func (dm *dpkgManager) probeDPKGStatus(ctx context.Context, toolImage string) er
 	busyBoxApplied := dm.config.ImageState.File(llb.Copy(busyBoxInstalled, "/bin/busybox", "/bin/busybox"))
 	mkFolders := busyBoxApplied.File(llb.Mkdir(resultsPath, 0o744, llb.WithParents(true)))
 
-	probed := mkFolders.
-		Run(llb.Args([]string{
-			`/bin/busybox`, `env`,
-			buildkit.Env("DPKG_STATUS_PATH", dpkgStatusPath),
-			buildkit.Env("RESULTS_PATH", resultsPath),
-			buildkit.Env("DPKG_STATUS_FOLDER", dpkgStatusFolder),
-			buildkit.Env("RESULT_STATUSD_PATH", filepath.Join(resultsPath, "status.d")),
-			buildkit.Env("DPKG_STATUS_IS_DIRECTORY", fmt.Sprintf("%d", DPKGStatusDirectory)),
-			buildkit.Env("DPKG_STATUS_IS_FILE", fmt.Sprintf("%d", DPKGStatusFile)),
-			buildkit.Env("DPKG_STATUS_IS_UNKNOWN", fmt.Sprintf("%d", DPKGStatusNone)),
-			buildkit.Env("STATUSD_OUTPUT_FILENAME", statusdOutputFilename),
-			`sh`, `-c`, `
+	probed := mkFolders.Run(
+		llb.AddEnv("DPKG_STATUS_PATH", dpkgStatusPath),
+		llb.AddEnv("RESULTS_PATH", resultsPath),
+		llb.AddEnv("DPKG_STATUS_FOLDER", dpkgStatusFolder),
+		llb.AddEnv("RESULT_STATUSD_PATH", filepath.Join(resultsPath, "status.d")),
+		llb.AddEnv("DPKG_STATUS_IS_DIRECTORY", fmt.Sprintf("%d", DPKGStatusDirectory)),
+		llb.AddEnv("DPKG_STATUS_IS_FILE", fmt.Sprintf("%d", DPKGStatusFile)),
+		llb.AddEnv("DPKG_STATUS_IS_UNKNOWN", fmt.Sprintf("%d", DPKGStatusNone)),
+		llb.AddEnv("STATUSD_OUTPUT_FILENAME", statusdOutputFilename),
+		llb.Args([]string{
+			`/bin/busybox`, `sh`, `-c`, `
                 status="$DPKG_STATUS_IS_UNKNOWN"
                 if [ -f "$DPKG_STATUS_PATH" ]; then
                     status="$DPKG_STATUS_IS_FILE"

--- a/pkg/pkgmgr/dpkg.go
+++ b/pkg/pkgmgr/dpkg.go
@@ -196,7 +196,7 @@ func (dm *dpkgManager) probeDPKGStatus(ctx context.Context, toolImage string) er
 	case DPKGStatusFile:
 		return nil
 	case DPKGStatusDirectory:
-		statusdNamesBytes, err := buildkit.ExtractFileFromState(ctx, dm.config.Client, &resultsState, filepath.Join(resultsPath, "status.d"))
+		statusdNamesBytes, err := buildkit.ExtractFileFromState(ctx, dm.config.Client, &resultsState, "status.d")
 		if err != nil {
 			return err
 		}

--- a/pkg/pkgmgr/dpkg_test.go
+++ b/pkg/pkgmgr/dpkg_test.go
@@ -1,15 +1,14 @@
 package pkgmgr
 
 import (
+	_ "embed"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
-	testutils "github.com/project-copacetic/copacetic/pkg/test_utils"
 	"github.com/project-copacetic/copacetic/pkg/types/unversioned"
 )
 
@@ -136,51 +135,36 @@ func TestGetAPTImageName(t *testing.T) {
 
 func TestGetDPKGStatusType(t *testing.T) {
 	// Create some temporary directories with different files
-	dir1 := t.TempDir() // empty directory
-
-	dir2 := t.TempDir() // directory with status files
-	testutils.CreateTempFileWithContent(dir2, "status")
-	defer os.Remove(dir2)
-
-	dir3 := t.TempDir() // directory with status.d directory
-	testutils.CreateTempFileWithContent(dir3, "status.d")
-	defer os.Remove(dir2)
-
-	dir4 := t.TempDir() // directory with status file and status.d directory
-	testutils.CreateTempFileWithContent(dir4, "status")
-	testutils.CreateTempFileWithContent(dir4, "status.d")
-	defer os.Remove(dir4)
-
 	tests := []struct {
 		name        string
-		dir         string
+		input       []byte
 		expectedOut dpkgStatusType
 	}{
 		{
 			name:        "Empty directory",
-			dir:         dir1,
+			input:       []byte(fmt.Sprintf("%d", DPKGStatusNone)),
 			expectedOut: DPKGStatusNone,
 		},
 		{
 			name:        "Directory with status file",
-			dir:         dir2,
+			input:       []byte(fmt.Sprintf("%d", DPKGStatusFile)),
 			expectedOut: DPKGStatusFile,
 		},
 		{
 			name:        "Directory with status directory",
-			dir:         dir3,
+			input:       []byte(fmt.Sprintf("%d", DPKGStatusDirectory)),
 			expectedOut: DPKGStatusDirectory,
 		},
 		{
 			name:        "Directory with both status file and directory",
-			dir:         dir4,
+			input:       []byte(fmt.Sprintf("%d", DPKGStatusMixed)),
 			expectedOut: DPKGStatusMixed,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			out := getDPKGStatusType(test.dir)
+			out := getDPKGStatusType(test.input)
 			if out != test.expectedOut {
 				t.Errorf("Expected %v but got %v", test.expectedOut, out)
 			}
@@ -188,18 +172,26 @@ func TestGetDPKGStatusType(t *testing.T) {
 	}
 }
 
-func TestDpkgParseResultsManifest(t *testing.T) {
-	manifestPath := "testdata/dpkg_valid.txt"
-	nonExistingManifestPath := "testdata/non_existing_manifest"
-	emptyManifestPath := "testdata/empty.txt"
-	invalidManifestPath := "testdata/invalid.txt"
+var (
+	//go:embed testdata/dpkg_valid.txt
+	validDPKGManifest []byte
 
+	nonExistingManifest []byte = nil
+
+	//go:embed testdata/empty.txt
+	emptyManifest []byte
+
+	//go:embed testdata/invalid.txt
+	invalidDPKGManifest []byte
+)
+
+func TestDpkgParseResultsManifest(t *testing.T) {
 	t.Run("valid manifest", func(t *testing.T) {
 		expectedMap := map[string]string{
 			"apt":        "1.8.2.3",
 			"base-files": "10.3+deb10u13",
 		}
-		actualMap, err := dpkgParseResultsManifest(manifestPath)
+		actualMap, err := dpkgParseResultsManifest(validDPKGManifest)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -209,8 +201,8 @@ func TestDpkgParseResultsManifest(t *testing.T) {
 	})
 
 	t.Run("non-existing manifest file", func(t *testing.T) {
-		expectedErr := fmt.Errorf("%s could not be opened", nonExistingManifestPath)
-		_, actualErr := dpkgParseResultsManifest(nonExistingManifestPath)
+		expectedErr := fmt.Errorf("%s could not be opened", nonExistingManifest)
+		_, actualErr := dpkgParseResultsManifest(nonExistingManifest)
 		if errors.Is(actualErr, expectedErr) {
 			t.Fatalf("Expected error: %v, Actual error: %v", expectedErr, actualErr)
 		}
@@ -218,7 +210,7 @@ func TestDpkgParseResultsManifest(t *testing.T) {
 
 	t.Run("empty manifest file", func(t *testing.T) {
 		expectedMap := map[string]string{}
-		actualMap, err := dpkgParseResultsManifest(emptyManifestPath)
+		actualMap, err := dpkgParseResultsManifest(emptyManifest)
 		if err != nil {
 			t.Fatalf("Unexpected error: %v", err)
 		}
@@ -229,7 +221,7 @@ func TestDpkgParseResultsManifest(t *testing.T) {
 
 	t.Run("invalid manifest file", func(t *testing.T) {
 		expectedErr := fmt.Errorf("unexpected results.manifest file entry: invalid")
-		_, actualErr := dpkgParseResultsManifest(invalidManifestPath)
+		_, actualErr := dpkgParseResultsManifest(invalidDPKGManifest)
 		if errors.Is(actualErr, expectedErr) {
 			t.Fatalf("Expected error: %v, Actual error: %v", expectedErr, actualErr)
 		}
@@ -243,7 +235,7 @@ func TestValidateDebianPackageVersions(t *testing.T) {
 		name            string
 		updates         unversioned.UpdatePackages
 		cmp             VersionComparer
-		resultsPath     string
+		resultsBytes    []byte
 		ignoreErrors    bool
 		expectedError   string
 		expectedErrPkgs []string
@@ -252,7 +244,7 @@ func TestValidateDebianPackageVersions(t *testing.T) {
 			name:         "no updates",
 			updates:      unversioned.UpdatePackages{},
 			cmp:          dpkgComparer,
-			resultsPath:  "testdata/dpkg_valid.txt",
+			resultsBytes: validDPKGManifest,
 			ignoreErrors: false,
 		},
 		{
@@ -261,7 +253,7 @@ func TestValidateDebianPackageVersions(t *testing.T) {
 				{Name: "not-installed", FixedVersion: "1.0.0"},
 			},
 			cmp:          dpkgComparer,
-			resultsPath:  "testdata/dpkg_valid.txt",
+			resultsBytes: validDPKGManifest,
 			ignoreErrors: false,
 		},
 		{
@@ -270,9 +262,9 @@ func TestValidateDebianPackageVersions(t *testing.T) {
 				{Name: "base-files", FixedVersion: "1.0.0"},
 			},
 			cmp:           dpkgComparer,
-			resultsPath:   "testdata/dpkg_invalid.txt",
+			resultsBytes:  invalidDPKGManifest,
 			ignoreErrors:  false,
-			expectedError: `invalid version`,
+			expectedError: `unexpected results.manifest file entry`,
 		},
 		{
 			name: "invalid version with ignore errors",
@@ -280,7 +272,7 @@ func TestValidateDebianPackageVersions(t *testing.T) {
 				{Name: "base-files", FixedVersion: "1.0.0"},
 			},
 			cmp:          dpkgComparer,
-			resultsPath:  "testdata/dpkg_valid.txt",
+			resultsBytes: validDPKGManifest,
 			ignoreErrors: true,
 		},
 		{
@@ -289,7 +281,7 @@ func TestValidateDebianPackageVersions(t *testing.T) {
 				{Name: "apt", FixedVersion: "2.0"},
 			},
 			cmp:          dpkgComparer,
-			resultsPath:  "testdata/dpkg_valid.txt",
+			resultsBytes: validDPKGManifest,
 			ignoreErrors: false,
 			expectedError: `1 error occurred:
 	* downloaded package apt version 1.8.2.3 lower than required 2.0 for update`,
@@ -301,7 +293,7 @@ func TestValidateDebianPackageVersions(t *testing.T) {
 				{Name: "apt", FixedVersion: "2.0"},
 			},
 			cmp:          dpkgComparer,
-			resultsPath:  "testdata/dpkg_valid.txt",
+			resultsBytes: validDPKGManifest,
 			ignoreErrors: true,
 		},
 		{
@@ -310,7 +302,7 @@ func TestValidateDebianPackageVersions(t *testing.T) {
 				{Name: "apt", FixedVersion: "1.8.2.3"},
 			},
 			cmp:          dpkgComparer,
-			resultsPath:  "testdata/dpkg_valid.txt",
+			resultsBytes: validDPKGManifest,
 			ignoreErrors: false,
 		},
 		{
@@ -319,14 +311,14 @@ func TestValidateDebianPackageVersions(t *testing.T) {
 				{Name: "apt", FixedVersion: "0.9"},
 			},
 			cmp:          dpkgComparer,
-			resultsPath:  "testdata/dpkg_valid.txt",
+			resultsBytes: validDPKGManifest,
 			ignoreErrors: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			errorPkgs, err := validateDebianPackageVersions(tc.updates, tc.cmp, tc.resultsPath, tc.ignoreErrors)
+			errorPkgs, err := validateDebianPackageVersions(tc.updates, tc.cmp, tc.resultsBytes, tc.ignoreErrors)
 			if tc.expectedError != "" {
 				if !strings.Contains(err.Error(), tc.expectedError) {
 					t.Errorf("expected error %v, got %v", tc.expectedError, err.Error())

--- a/pkg/pkgmgr/dpkg_test.go
+++ b/pkg/pkgmgr/dpkg_test.go
@@ -176,7 +176,8 @@ var (
 	//go:embed testdata/dpkg_valid.txt
 	validDPKGManifest []byte
 
-	nonExistingManifest []byte = nil
+	// initialized to `nil`; tests error handling.
+	nonExistingManifest []byte
 
 	//go:embed testdata/empty.txt
 	emptyManifest []byte

--- a/pkg/pkgmgr/pkgmgr.go
+++ b/pkg/pkgmgr/pkgmgr.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	copaPrefix     = "copa-"
+	inputPath      = "/" + copaPrefix + "input"
 	resultsPath    = "/" + copaPrefix + "out"
 	downloadPath   = "/" + copaPrefix + "downloads"
 	unpackPath     = "/" + copaPrefix + "unpacked"

--- a/pkg/pkgmgr/rpm.go
+++ b/pkg/pkgmgr/rpm.go
@@ -128,7 +128,7 @@ func parseRPMTools(b []byte) (rpmToolPaths, error) {
 	return rpmTools, nil
 }
 
-// Check the RPM DB type given image probe results
+// Check the RPM DB type given image probe results.
 func getRPMDBType(b []byte) rpmDBType {
 	buf := bytes.NewBuffer(b)
 	s := bufio.NewScanner(buf)
@@ -235,8 +235,8 @@ func (rm *rpmManager) probeRPMStatus(ctx context.Context, toolImage string) erro
 	toolListPath := filepath.Join(resultsPath, "tool_list")
 	dbListPath := filepath.Join(resultsPath, "rpm_db_list")
 
-	probed := buildkit.WithArrayFile(mkFolders, toolListPath, toolList)
-	probed = buildkit.WithArrayFile(probed, dbListPath, rpmDBList)
+	probed := buildkit.WithArrayFile(&mkFolders, toolListPath, toolList)
+	probed = buildkit.WithArrayFile(&probed, dbListPath, rpmDBList)
 	probed = probed.Run(llb.Args([]string{
 		`/usr/sbin/busybox`, `env`,
 		buildkit.Env("TOOL_LIST_PATH", toolListPath),
@@ -282,7 +282,12 @@ func (rm *rpmManager) probeRPMStatus(ctx context.Context, toolImage string) erro
 	// Parse rpmTools File if not distroless
 	if !rm.isDistroless {
 		log.Info("Checking for available RPM tools in non-distroless image ...")
+
 		toolsFileBytes, err := buildkit.ExtractFileFromState(ctx, rm.config.Client, &outState, filepath.Join(resultsPath, rpmToolsFile))
+		if err != nil {
+			return err
+		}
+
 		rpmTools, err := parseRPMTools(toolsFileBytes)
 		if err != nil {
 			return err

--- a/pkg/pkgmgr/rpm.go
+++ b/pkg/pkgmgr/rpm.go
@@ -233,7 +233,6 @@ func (rm *rpmManager) probeRPMStatus(ctx context.Context, toolImage string) erro
 		filepath.Join(rpmManifestPath, rpmManifest2),
 	}
 
-	// probed := mkFolders.Run(llb.Shlex(probeToolsCmd)).Run(llb.Shlex(probeDBCmd)).Root()
 	toolListPath := filepath.Join(inputPath, "tool_list")
 	dbListPath := filepath.Join(inputPath, "rpm_db_list")
 

--- a/pkg/pkgmgr/rpm.go
+++ b/pkg/pkgmgr/rpm.go
@@ -2,10 +2,10 @@ package pkgmgr
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -17,10 +17,12 @@ import (
 	"github.com/project-copacetic/copacetic/pkg/types/unversioned"
 	"github.com/project-copacetic/copacetic/pkg/utils"
 	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
 	rpmToolsFile        = "rpmTools"
+	rpmDBFile           = "rpmDB"
 	rpmLibPath          = "/var/lib/rpm"
 	rpmSQLLiteDB        = "rpmdb.sqlite"
 	rpmNDB              = "Packages.db"
@@ -52,6 +54,9 @@ const (
 	RPMDBSqlLite
 	RPMDBManifests
 	RPMDBMixed
+	RPMDBInvalid // must be the last in the list
+
+	RPMDBSize = RPMDBInvalid
 )
 
 func (st rpmDBType) String() string {
@@ -102,20 +107,13 @@ func getRPMImageName(manifest *unversioned.UpdateManifest) string {
 	return fmt.Sprintf("%s:%s", image, version)
 }
 
-func parseRPMTools(path string) (rpmToolPaths, error) {
-	// Open result file
-	f, err := os.Open(path)
-	if err != nil {
-		log.Errorf("%s could not be opened", path)
-		return nil, err
-	}
-	defer f.Close()
-
+func parseRPMTools(b []byte) (rpmToolPaths, error) {
+	buf := bytes.NewBuffer(b)
 	// rpmTools file is expected contain a string map in the format of:
 	// <tool name>:<tool path | `notfound`>
 	// ...
 	rpmTools := rpmToolPaths{}
-	fs := bufio.NewScanner(f)
+	fs := bufio.NewScanner(buf)
 	for fs.Scan() {
 		kv := strings.Split(fs.Text(), `:`)
 		if len(kv) != 2 {
@@ -130,28 +128,44 @@ func parseRPMTools(path string) (rpmToolPaths, error) {
 	return rpmTools, nil
 }
 
-// Check the RPM DB type given image probe output path.
-func getRPMDBType(dir string) rpmDBType {
-	out := RPMDBNone
-	rpmDBs := []rpmDBType{}
-	if utils.IsNonEmptyFile(dir, rpmBDB) {
+// Check the RPM DB type given image probe results
+func getRPMDBType(b []byte) rpmDBType {
+	buf := bytes.NewBuffer(b)
+	s := bufio.NewScanner(buf)
+
+	set := sets.New[string]()
+	for s.Scan() {
+		fullPath := s.Text()
+		base := filepath.Base(fullPath)
+		set.Insert(base)
+	}
+
+	rpmDBs := make([]rpmDBType, 0, RPMDBSize)
+
+	if set.Has(rpmBDB) {
 		rpmDBs = append(rpmDBs, RPMDBBerkley)
 	}
-	if utils.IsNonEmptyFile(dir, rpmNDB) {
+
+	if set.Has(rpmNDB) {
 		rpmDBs = append(rpmDBs, RPMDBNative)
 	}
-	if utils.IsNonEmptyFile(dir, rpmSQLLiteDB) {
+
+	if set.Has(rpmSQLLiteDB) {
 		rpmDBs = append(rpmDBs, RPMDBSqlLite)
 	}
-	if utils.IsNonEmptyFile(dir, rpmManifest1) && utils.IsNonEmptyFile(dir, rpmManifest2) {
+
+	if set.Has(rpmManifest1) && set.Has(rpmManifest2) {
 		rpmDBs = append(rpmDBs, RPMDBManifests)
 	}
-	if len(rpmDBs) == 1 {
-		out = rpmDBs[0]
-	} else if len(rpmDBs) > 1 {
-		out = RPMDBMixed
+
+	switch len(rpmDBs) {
+	case 0:
+		return RPMDBNone
+	case 1:
+		return rpmDBs[0]
+	default:
+		return RPMDBMixed
 	}
-	return out
 }
 
 func (rm *rpmManager) InstallUpdates(ctx context.Context, manifest *unversioned.UpdateManifest, ignoreErrors bool) (*llb.State, []string, error) {
@@ -174,21 +188,21 @@ func (rm *rpmManager) InstallUpdates(ctx context.Context, manifest *unversioned.
 	}
 
 	var updatedImageState *llb.State
+	var resultManifestBytes []byte
 	if rm.isDistroless {
-		updatedImageState, err = rm.unpackAndMergeUpdates(ctx, updates, toolImageName)
+		updatedImageState, resultManifestBytes, err = rm.unpackAndMergeUpdates(ctx, updates, toolImageName)
 		if err != nil {
 			return nil, nil, err
 		}
 	} else {
-		updatedImageState, err = rm.installUpdates(ctx, updates)
+		updatedImageState, resultManifestBytes, err = rm.installUpdates(ctx, updates)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
 
 	// Validate that the deployed packages are of the requested version or better
-	resultManifestPath := filepath.Join(rm.workingFolder, resultsPath, resultManifest)
-	errPkgs, err := validateRPMPackageVersions(updates, rpmComparer, resultManifestPath, ignoreErrors)
+	errPkgs, err := validateRPMPackageVersions(updates, rpmComparer, resultManifestBytes, ignoreErrors)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -208,19 +222,6 @@ func (rm *rpmManager) probeRPMStatus(ctx context.Context, toolImage string) erro
 	mkFolders := toolsApplied.File(llb.Mkdir(resultsPath, 0o744, llb.WithParents(true)))
 
 	toolList := []string{"dnf", "microdnf", "rpm", "yum"}
-	toolStr := strings.Join(toolList, " ")
-	const probeToolsTemplate = `/usr/sbin/busybox sh -c '
-		TOOL_LIST="%s";	n=1;
-		while [ $n -le %d ];
-		do TOOL=$(echo "$TOOL_LIST" | /usr/sbin/busybox cut -d " " -f $n);
-			TOOL_PATH=$(/usr/sbin/busybox which $TOOL);
-			if [ -n "$TOOL_PATH" ];
-			then echo "$TOOL:$TOOL_PATH";
-			else echo "$TOOL:notfound";
-			fi;
-			n=$(($n+1));
-		done> %s'`
-	probeToolsCmd := fmt.Sprintf(probeToolsTemplate, toolStr, len(toolList), filepath.Join(resultsPath, rpmToolsFile))
 
 	rpmDBList := []string{
 		filepath.Join(rpmLibPath, rpmBDB),
@@ -229,28 +230,45 @@ func (rm *rpmManager) probeRPMStatus(ctx context.Context, toolImage string) erro
 		filepath.Join(rpmManifestPath, rpmManifest1),
 		filepath.Join(rpmManifestPath, rpmManifest2),
 	}
-	rpmDBStr := strings.Join(rpmDBList, " ")
-	const probeDBTemplate = `/usr/sbin/busybox sh -c '
-		DB_LIST="%s"; n=1;
-		while [ $n -le %d ];
-		do DB=$(echo "$DB_LIST" | /usr/sbin/busybox cut -d " " -f $n);
-			echo $DB;
-			if [ -f $DB ];
-			then /usr/sbin/busybox cp $DB %s;
-			fi;
-			n=$(($n+1));
-		done'`
-	probeDBCmd := fmt.Sprintf(probeDBTemplate, rpmDBStr, len(rpmDBList), resultsPath)
 
-	probed := mkFolders.Run(llb.Shlex(probeToolsCmd)).Run(llb.Shlex(probeDBCmd)).Root()
+	// probed := mkFolders.Run(llb.Shlex(probeToolsCmd)).Run(llb.Shlex(probeDBCmd)).Root()
+	toolListPath := filepath.Join(resultsPath, "tool_list")
+	dbListPath := filepath.Join(resultsPath, "rpm_db_list")
+
+	probed := buildkit.WithArrayFile(mkFolders, toolListPath, toolList)
+	probed = buildkit.WithArrayFile(probed, dbListPath, rpmDBList)
+	probed = probed.Run(llb.Args([]string{
+		`/usr/sbin/busybox`, `env`,
+		buildkit.Env("TOOL_LIST_PATH", toolListPath),
+		buildkit.Env("DB_LIST_PATH", dbListPath),
+		buildkit.Env("RESULTS_PATH", resultsPath),
+		buildkit.Env("RPM_TOOLS_OUTPUT_FILENAME", rpmToolsFile),
+		buildkit.Env("RPM_DB_LIST_OUTPUT_FILENAME", rpmDBFile),
+		buildkit.Env("BUSYBOX", "/usr/sbin/busybox"),
+		`/usr/sbin/busybox`, `sh`, `-c`, `
+            while IFS= read -r tool; do
+                tool_path="$($BUSYBOX which "$tool")"
+                echo "${tool}:${tool_path:-notfound}" >> "${RESULTS_PATH}/${RPM_TOOLS_OUTPUT_FILENAME}"
+            done < "$TOOL_LIST_PATH"
+
+            while IFS= read -r db; do
+                echo "$db"
+                if [ -f "$db" ]; then
+                    $BUSYBOX cp "$db" "$RESULTS_PATH"
+                    echo "$db" >> "${RESULTS_PATH}/${RPM_DB_LIST_OUTPUT_FILENAME}"
+                fi
+            done < "$DB_LIST_PATH"
+        `,
+	})).Root()
 	outState := llb.Diff(toolsApplied, probed)
-	if err := buildkit.SolveToLocal(ctx, rm.config.Client, &outState, rm.workingFolder); err != nil {
-		return err
+
+	rpmDBListOutputBytes, err := buildkit.ExtractFileFromState(ctx, rm.config.Client, &outState, filepath.Join(resultsPath, rpmDBFile))
+	if err != nil {
+		return nil
 	}
 
 	// Check type of RPM DB on image to infer Mariner Distroless
-	outStatePath := filepath.Join(rm.workingFolder, resultsPath)
-	rpmDB := getRPMDBType(outStatePath)
+	rpmDB := getRPMDBType(rpmDBListOutputBytes)
 	log.Debugf("RPM DB Type in image is: %s", rpmDB)
 	switch rpmDB {
 	case RPMDBManifests:
@@ -264,8 +282,8 @@ func (rm *rpmManager) probeRPMStatus(ctx context.Context, toolImage string) erro
 	// Parse rpmTools File if not distroless
 	if !rm.isDistroless {
 		log.Info("Checking for available RPM tools in non-distroless image ...")
-		toolsFilePath := filepath.Join(outStatePath, rpmToolsFile)
-		rpmTools, err := parseRPMTools(toolsFilePath)
+		toolsFileBytes, err := buildkit.ExtractFileFromState(ctx, rm.config.Client, &outState, filepath.Join(resultsPath, rpmToolsFile))
+		rpmTools, err := parseRPMTools(toolsFileBytes)
 		if err != nil {
 			return err
 		}
@@ -297,7 +315,7 @@ func (rm *rpmManager) probeRPMStatus(ctx context.Context, toolImage string) erro
 //
 // TODO: Support RPM-based images with valid rpm status but missing tools. (e.g. calico images > v3.21.0)
 // i.e. extra RunOption to mount a copy of rpm tools installed into the image and invoking that.
-func (rm *rpmManager) installUpdates(ctx context.Context, updates unversioned.UpdatePackages) (*llb.State, error) {
+func (rm *rpmManager) installUpdates(ctx context.Context, updates unversioned.UpdatePackages) (*llb.State, []byte, error) {
 	// Format the requested updates into a space-separated string
 	pkgStrings := []string{}
 	for _, u := range updates {
@@ -319,7 +337,7 @@ func (rm *rpmManager) installUpdates(ctx context.Context, updates unversioned.Up
 		installCmd = fmt.Sprintf(microdnfInstallTemplate, rm.rpmTools["microdnf"], pkgs)
 	default:
 		err := errors.New("unexpected: no package manager tools were found for patching")
-		return nil, err
+		return nil, nil, err
 	}
 	installed := rm.config.ImageState.Run(llb.Shlex(installCmd), llb.WithProxy(utils.GetProxy())).Root()
 
@@ -329,17 +347,18 @@ func (rm *rpmManager) installUpdates(ctx context.Context, updates unversioned.Up
 	resultsWritten := installed.Dir(resultsPath).Run(llb.Shlex(outputResultsCmd)).Root()
 	resultsDiff := llb.Diff(installed, resultsWritten)
 
-	if err := buildkit.SolveToLocal(ctx, rm.config.Client, &resultsDiff, rm.workingFolder); err != nil {
-		return nil, err
+	resultBytes, err := buildkit.ExtractFileFromState(ctx, rm.config.Client, &resultsDiff, filepath.Join(resultsPath, resultManifest))
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Diff the installed updates and merge that into the target image
 	patchDiff := llb.Diff(rm.config.ImageState, installed)
 	patchMerge := llb.Merge([]llb.State{rm.config.ImageState, patchDiff})
-	return &patchMerge, nil
+	return &patchMerge, resultBytes, nil
 }
 
-func (rm *rpmManager) unpackAndMergeUpdates(ctx context.Context, updates unversioned.UpdatePackages, toolImage string) (*llb.State, error) {
+func (rm *rpmManager) unpackAndMergeUpdates(ctx context.Context, updates unversioned.UpdatePackages, toolImage string) (*llb.State, []byte, error) {
 	// Spin up a build tooling container to fetch and unpack packages to create patch layer.
 	// Pull family:version -> need to create version to base image map
 	toolingBase := llb.Image(toolImage,
@@ -409,29 +428,30 @@ func (rm *rpmManager) unpackAndMergeUpdates(ctx context.Context, updates unversi
 	resultsWritten := fieldsWritten.Dir(resultsPath).Run(llb.Shlex(writeResultsCmd)).Root()
 
 	resultsDiff := llb.Diff(fieldsWritten, resultsWritten)
-	if err := buildkit.SolveToLocal(ctx, rm.config.Client, &resultsDiff, rm.workingFolder); err != nil {
-		return nil, err
+	resultBytes, err := buildkit.ExtractFileFromState(ctx, rm.config.Client, &resultsDiff, filepath.Join(resultsPath, resultManifest))
+	if err != nil {
+		return nil, nil, err
 	}
+
 	// Diff unpacked packages layers from previous and merge with target
 	manifestsDiff := llb.Diff(manifestsUpdated, manifestsPlaced)
 	merged := llb.Merge([]llb.State{rm.config.ImageState, patchedRoot, manifestsDiff})
-	return &merged, nil
+	return &merged, resultBytes, nil
 }
 
 func (rm *rpmManager) GetPackageType() string {
 	return "rpm"
 }
 
-func rpmReadResultsManifest(path string) ([]string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		log.Errorf("%s could not be opened", path)
-		return nil, err
+func rpmReadResultsManifest(b []byte) ([]string, error) {
+	if b == nil {
+		return nil, fmt.Errorf("nil result manifest buffer")
 	}
-	defer f.Close()
+
+	buf := bytes.NewBuffer(b)
 
 	var lines []string
-	fs := bufio.NewScanner(f)
+	fs := bufio.NewScanner(buf)
 	for fs.Scan() {
 		lines = append(lines, fs.Text())
 	}
@@ -439,8 +459,8 @@ func rpmReadResultsManifest(path string) ([]string, error) {
 	return lines, nil
 }
 
-func validateRPMPackageVersions(updates unversioned.UpdatePackages, cmp VersionComparer, resultsPath string, ignoreErrors bool) ([]string, error) {
-	lines, err := rpmReadResultsManifest(resultsPath)
+func validateRPMPackageVersions(updates unversioned.UpdatePackages, cmp VersionComparer, resultsBytes []byte, ignoreErrors bool) ([]string, error) {
+	lines, err := rpmReadResultsManifest(resultsBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pkgmgr/rpm_test.go
+++ b/pkg/pkgmgr/rpm_test.go
@@ -203,10 +203,8 @@ func TestGetRPMDBType(t *testing.T) {
 	}
 }
 
-var (
-	//go:embed testdata/rpm_valid.txt
-	rpmValidManifest []byte
-)
+//go:embed testdata/rpm_valid.txt
+var rpmValidManifest []byte
 
 func TestRpmReadResultsManifest(t *testing.T) {
 	// Test cases

--- a/pkg/pkgmgr/rpm_test.go
+++ b/pkg/pkgmgr/rpm_test.go
@@ -1,14 +1,14 @@
 package pkgmgr
 
 import (
+	"bytes"
+	_ "embed"
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
-	testutils "github.com/project-copacetic/copacetic/pkg/test_utils"
 	"github.com/project-copacetic/copacetic/pkg/types/unversioned"
 	"github.com/stretchr/testify/assert"
 )
@@ -155,22 +155,14 @@ func TestGetRPMImageName(t *testing.T) {
 // TestParseRPMTools tests the parseRPMTools function with a sample file.
 func TestParseRPMTools(t *testing.T) {
 	// Create a temporary file with some sample data
-	tmpfile, err := os.CreateTemp("", "rpmtools")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tmpfile.Name()) // clean up
+	var tmpfile bytes.Buffer
 
-	fmt.Fprintln(tmpfile, "tool1:/path/to/tool1")
-	fmt.Fprintln(tmpfile, "tool2:notfound")
-	fmt.Fprintln(tmpfile, "tool3:/path/to/tool3")
-
-	if err := tmpfile.Close(); err != nil {
-		t.Fatal(err)
-	}
+	tmpfile.WriteString("tool1:/path/to/tool1\n")
+	tmpfile.WriteString("tool2:notfound\n")
+	tmpfile.WriteString("tool3:/path/to/tool3\n")
 
 	// Call the parseRPMTools function with the temporary file name
-	rpmTools, err := parseRPMTools(tmpfile.Name())
+	rpmTools, err := parseRPMTools(tmpfile.Bytes())
 	if err != nil {
 		t.Errorf("parseRPMTools failed: %v", err)
 	}
@@ -189,33 +181,16 @@ func TestParseRPMTools(t *testing.T) {
 
 // TestGetRPMDBType tests the getRPMDBType function with different input directories.
 func TestGetRPMDBType(t *testing.T) {
-	// Create some temporary directories with different files
-	dir1 := t.TempDir() // empty directory
-
-	dir2 := t.TempDir() // directory with rpmBDB file
-	testutils.CreateTempFileWithContent(dir2, rpmBDB)
-	defer os.Remove(dir2)
-
-	dir3 := t.TempDir() // directory with rpmNDB and rpmSQLLiteDB files
-	testutils.CreateTempFileWithContent(dir3, rpmNDB)
-	testutils.CreateTempFileWithContent(dir3, rpmSQLLiteDB)
-	defer os.Remove(dir3)
-
-	dir4 := t.TempDir() // directory with rpmManifest1 and rpmManifest2 files
-	testutils.CreateTempFileWithContent(dir4, rpmManifest1)
-	testutils.CreateTempFileWithContent(dir4, rpmManifest2)
-	defer os.Remove(dir4)
-
 	// Define some test cases with expected output
 	testCases := []struct {
 		name     string
-		input    string
+		input    []byte
 		expected rpmDBType
 	}{
-		{"empty dir", dir1, RPMDBNone},
-		{"dir with berkeley db", dir2, RPMDBBerkley},
-		{"dir with mixed db", dir3, RPMDBMixed},
-		{"dir with manifests", dir4, RPMDBManifests},
+		{"empty dir", []byte{}, RPMDBNone},
+		{"dir with berkeley db", []byte(fmt.Sprintf("%s\n", rpmBDB)), RPMDBBerkley},
+		{"dir with mixed db", []byte(fmt.Sprintf("%s\n%s\n", rpmBDB, rpmNDB)), RPMDBMixed},
+		{"dir with manifests", []byte(fmt.Sprintf("%s\n%s\n", rpmManifest1, rpmManifest2)), RPMDBManifests},
 	}
 
 	for _, tc := range testCases {
@@ -228,23 +203,28 @@ func TestGetRPMDBType(t *testing.T) {
 	}
 }
 
+var (
+	//go:embed testdata/rpm_valid.txt
+	rpmValidManifest []byte
+)
+
 func TestRpmReadResultsManifest(t *testing.T) {
 	// Test cases
 	tests := []struct {
 		name    string
-		path    string
+		input   []byte
 		want    []string
 		wantErr bool
 	}{
 		{
 			name:    "valid path",
-			path:    "testdata/rpm_valid.txt",
+			input:   rpmValidManifest,
 			want:    []string{"openssl	2.1.1k-21.cm2	x86_64", "openssl-libs	2.1.1k-21.cm2	x86_64"},
 			wantErr: false,
 		},
 		{
 			name:    "invalid path",
-			path:    "testdata/nonexistent.txt",
+			input:   nonExistingManifest,
 			want:    nil,
 			wantErr: true,
 		},
@@ -252,13 +232,13 @@ func TestRpmReadResultsManifest(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := rpmReadResultsManifest(tc.path)
+			got, err := rpmReadResultsManifest(tc.input)
 			if (err != nil) != tc.wantErr {
-				t.Errorf("rpmReadResultsManifest(%v) error = %v, wantErr %v", tc.path, err, tc.wantErr)
+				t.Errorf("rpmReadResultsManifest(%v) error = %v, wantErr %v", tc.input, err, tc.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("rpmReadResultsManifest(%v) = %v, want %v", tc.path, got, tc.want)
+				t.Errorf("rpmReadResultsManifest(%v) = %v, want %v", tc.input, got, tc.want)
 			}
 		})
 	}
@@ -271,7 +251,7 @@ func TestValidateRPMPackageVersions(t *testing.T) {
 		name            string
 		updates         unversioned.UpdatePackages
 		cmp             VersionComparer
-		resultsPath     string
+		resultsBytes    []byte
 		ignoreErrors    bool
 		expectedError   string
 		expectedErrPkgs []string
@@ -283,7 +263,7 @@ func TestValidateRPMPackageVersions(t *testing.T) {
 				{Name: "openssl-libs", FixedVersion: "1.1.1k-21.cm2"},
 			},
 			cmp:          rpmComparer,
-			resultsPath:  "testdata/rpm_valid.txt",
+			resultsBytes: rpmValidManifest,
 			ignoreErrors: false,
 		},
 		{
@@ -293,7 +273,7 @@ func TestValidateRPMPackageVersions(t *testing.T) {
 				{Name: "openssl-libs", FixedVersion: "3.1.1k-21.cm2"},
 			},
 			cmp:          rpmComparer,
-			resultsPath:  "testdata/rpm_valid.txt",
+			resultsBytes: rpmValidManifest,
 			ignoreErrors: false,
 			expectedError: `2 errors occurred:
 	* downloaded package openssl version 2.1.1k-21.cm2 lower than required 3.1.1k-21.cm2 for update
@@ -307,7 +287,7 @@ func TestValidateRPMPackageVersions(t *testing.T) {
 				{Name: "openssl-libs", FixedVersion: "3.1.1k-21.cm2"},
 			},
 			cmp:          rpmComparer,
-			resultsPath:  "testdata/rpm_valid.txt",
+			resultsBytes: rpmValidManifest,
 			ignoreErrors: true,
 		},
 		{
@@ -316,14 +296,14 @@ func TestValidateRPMPackageVersions(t *testing.T) {
 				{Name: "openssl", FixedVersion: "1.1.1k-21.cm2"},
 			},
 			cmp:           rpmComparer,
-			resultsPath:   "testdata/rpm_valid.txt",
+			resultsBytes:  rpmValidManifest,
 			expectedError: `expected 1 updates, installed 2`,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			errorPkgs, err := validateRPMPackageVersions(tc.updates, tc.cmp, tc.resultsPath, tc.ignoreErrors)
+			errorPkgs, err := validateRPMPackageVersions(tc.updates, tc.cmp, tc.resultsBytes, tc.ignoreErrors)
 			if tc.expectedError != "" {
 				if !strings.Contains(err.Error(), tc.expectedError) {
 					t.Errorf("expected error %v, got %v", tc.expectedError, err.Error())

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -11,7 +11,7 @@ This sample illustrates how to patch containers using vulnerability reports with
   * [buildkit](https://github.com/moby/buildkit/#quick-start) daemon installed & pathed. [Examples](#buildkit-connection-examples)
     * The `docker` daemon runs a buildkit service in-process. If you are using this for your buildkit instance, Docker must have the
       [containerd snapshotter feature](https://docs.docker.com/storage/containerd/) enabled.
-    * If you are using a buildx instance, or using buildkitd directly, there is no need to enable the containerd snapshotter.
+    * If you are using a buildx instance, or using buildkitd directly, there is no need to enable the containerd image store. However, only images in a remote registry can be patched using these methods.
   * [docker](https://docs.docker.com/desktop/linux/install/#generic-installation-steps) daemon running and CLI installed & pathed.
   * [trivy CLI](https://aquasecurity.github.io/trivy/latest/getting-started/installation/) installed & pathed.
 

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -101,8 +101,13 @@ This sample illustrates how to patch containers using vulnerability reports with
     > ensure that the credentials are configured in the default Docker config.json before running `copa patch`,
     > for example, via `sudo docker login -u <user> -p <password> <registry>`.
 
-> [!NOTE]
-> if you're scanning and patching an image that is local-only (i.e. built or tagged locally but not pushed to a registry), `copa` is limited to using `docker`'s built-in buildkit service, and must use [`containerd image store`](https://docs.docker.com/storage/containerd/) feature. See [Prerequisites][#prerequisites] for more information.
+    > [!NOTE]
+    > if you're scanning and patching an image that is local-only (i.e. built or
+    > tagged locally but not pushed to a registry), `copa` is limited to using
+    > `docker`'s built-in buildkit service, and must use the [`containerd image
+    > store`](https://docs.docker.com/storage/containerd/) feature. This is because
+    > only `docker`'s built-in buildkit service has access to the docker image
+    > store (see [Prerequisites][#prerequisites] for more information.)
 
 3. Scan the patched image and verify that the vulnerabilities have been patched:
 

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -101,10 +101,8 @@ This sample illustrates how to patch containers using vulnerability reports with
     > ensure that the credentials are configured in the default Docker config.json before running `copa patch`,
     > for example, via `sudo docker login -u <user> -p <password> <registry>`.
 
-    > **NOTE:** if you're scanning and patching an image that is local-only
-    > (i.e. built or tagged locally but not pushed to a registry), you are
-    > limited to using `docker`'s built-in buildkit service. See
-    > [Prerequisites][#prerequisites] for more information.
+> [!NOTE]
+> if you're scanning and patching an image that is local-only (i.e. built or tagged locally but not pushed to a registry), `copa` is limited to using `docker`'s built-in buildkit service, and must use [`containerd image store`](https://docs.docker.com/storage/containerd/) feature. See [Prerequisites][#prerequisites] for more information.
 
 3. Scan the patched image and verify that the vulnerabilities have been patched:
 

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -10,7 +10,7 @@ This sample illustrates how to patch containers using vulnerability reports with
   * `copa` tool [built & pathed](./installation.md).
   * [buildkit](https://github.com/moby/buildkit/#quick-start) daemon installed & pathed. [Examples](#buildkit-connection-examples)
     * The `docker` daemon runs a buildkit service in-process. If you are using this for your buildkit instance, Docker must have the
-      [containerd snapshotter feature](https://docs.docker.com/storage/containerd/) enabled.
+      [containerd image store feature](https://docs.docker.com/storage/containerd/) enabled.
     * If you are using a buildx instance, or using buildkitd directly, there is no need to enable the containerd image store. However, only images in a remote registry can be patched using these methods.
   * [docker](https://docs.docker.com/desktop/linux/install/#generic-installation-steps) daemon running and CLI installed & pathed.
   * [trivy CLI](https://aquasecurity.github.io/trivy/latest/getting-started/installation/) installed & pathed.

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -9,6 +9,9 @@ This sample illustrates how to patch containers using vulnerability reports with
 * An Ubuntu 22.04 VM configured through the [setup instructions](./installation.md). This includes:
   * `copa` tool [built & pathed](./installation.md).
   * [buildkit](https://github.com/moby/buildkit/#quick-start) daemon installed & pathed. [Examples](#buildkit-connection-examples)
+    * The `docker` daemon runs a buildkit service in-process. If you are using this for your buildkit instance, Docker must have the
+      [containerd snapshotter feature](https://docs.docker.com/storage/containerd/) enabled.
+    * If you are using a buildx instance, or using buildkitd directly, there is no need to enable the containerd snapshotter.
   * [docker](https://docs.docker.com/desktop/linux/install/#generic-installation-steps) daemon running and CLI installed & pathed.
   * [trivy CLI](https://aquasecurity.github.io/trivy/latest/getting-started/installation/) installed & pathed.
 
@@ -97,6 +100,11 @@ This sample illustrates how to patch containers using vulnerability reports with
     > **NOTE:** if you're running this sample against an image from a private registry instead,
     > ensure that the credentials are configured in the default Docker config.json before running `copa patch`,
     > for example, via `sudo docker login -u <user> -p <password> <registry>`.
+
+    > **NOTE:** if you're scanning and patching an image that is local-only
+    > (i.e. built or tagged locally but not pushed to a registry), you are
+    > limited to using `docker`'s built-in buildkit service. See
+    > [Prerequisites][#prerequisites] for more information.
 
 3. Scan the patched image and verify that the vulnerabilities have been patched:
 


### PR DESCRIPTION
Use gateway client for config resolution

Implement `buildkit.ExtractFileFromState`
This code will still not compile, since the signature of `buildkit.SolveToLocal` is not satisfied by its calls.
Replace `SolveToLocal` in `probeDPKGStatus` method
In this case, we will write the status type to a file, which we thereafter read from the state as a single byte.
Fix error in awk script
Use `ExtractFileFromState` for dpkg `installUpdates`
Use `ExtractFileFromState` in `unpackAndMergeUpdates`
APK: Use `ExtractFileFromState` for `upgradePackages`
Do not use `SolveToLocal`.
Use `ExtractFileFromState` for `probeRPMStatus`
Replace `buildkit.SolveToLocal` in rpm.go
Update `patchWithContext` to pass the correct client
Fix errors and achieve parity with `main` branch
Update unit tests

Closes #177 
