### PR TITLE
ci: Add windows amd64 to goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,9 +4,13 @@ builds:
     goos:
     - linux
     - darwin
+    - windows
     goarch:
     - amd64
     - arm64
+    ignore:
+    - goos: windows
+      goarch: arm64
     env:
       - CGO_ENABLED=0
       - GO111MODULE=on


### PR DESCRIPTION
Adds windows+amd64 to the release configuration so copa can run on windows OS (but still target a linux container).

Tested:

```
⇉ ⇉ ⇉ goreleaser release --snapshot --clean --config .goreleaser.yml                                                                                                                                               • starting release...
... other stuff ...
• building binaries
• building                                       binary=dist/copacetic_darwin_amd64_v1/copa
• building                                       binary=dist/copacetic_linux_amd64_v1/copa
• building                                       binary=dist/copacetic_windows_amd64_v1/copa.exe
• building                                       binary=dist/copacetic_darwin_arm64/copa
• building                                       binary=dist/copacetic_linux_arm64/copa
```

Runs locally using snapshot build:
```
PS C:\Users\ben\Desktop> .\copa.exe -h
Project Copacetic: container patching tool

Usage:
  copa [flags]
  copa [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  patch       Patch container images with upgrade packages specified by a vulnerability report

Flags:
      --debug     enable debug level logging
  -h, --help      help for copa
  -v, --version   version for copa

Use "copa [command] --help" for more information about a command.
PS C:\Users\ben\Desktop> .\copa.exe --version
copa version 0.0.0-SNAPSHOT-67c7e29
PS C:\Users\ben\Downloads>
```