### PR TITLE
docs: update MIT license headers to Apache 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,3 @@
-# Copyright (c) Project Copacetic authors.
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-#   http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: Build
 on:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,16 @@
-# ------------------------------------------------------------
 # Copyright (c) Project Copacetic authors.
-# Licensed under the MIT License.
-# ------------------------------------------------------------
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: Build
 on:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,7 +1,16 @@
-# ------------------------------------------------------------
 # Copyright (c) Project Copacetic authors.
-# Licensed under the MIT License.
-# ------------------------------------------------------------
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 name: Run golangci-lint
 on:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,17 +1,3 @@
-# Copyright (c) Project Copacetic authors.
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-#    http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: Run golangci-lint
 on:
   push:

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,3 @@
-# Copyright (c) Project Copacetic authors.
-
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-
-#    http://www.apache.org/licenses/LICENSE-2.0
-
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 ################################################################################
 # Global: Variables                                                            #
 ################################################################################

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
-# ------------------------------------------------------------
 # Copyright (c) Project Copacetic authors.
-# Licensed under the MIT License.
-# ------------------------------------------------------------
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ################################################################################
 # Global: Variables                                                            #

--- a/main.go
+++ b/main.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package main
 

--- a/main.go
+++ b/main.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package main
 
 import (

--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package buildkit
 

--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package buildkit
 
 import (

--- a/pkg/patch/cmd.go
+++ b/pkg/patch/cmd.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package patch
 

--- a/pkg/patch/cmd.go
+++ b/pkg/patch/cmd.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package patch
 
 import (

--- a/pkg/patch/cmd_test.go
+++ b/pkg/patch/cmd_test.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package patch
 

--- a/pkg/patch/cmd_test.go
+++ b/pkg/patch/cmd_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package patch
 
 import "testing"

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package patch
 

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package patch
 
 import (

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package patch
 

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package patch
 
 import (

--- a/pkg/pkgmgr/apk.go
+++ b/pkg/pkgmgr/apk.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package pkgmgr
 

--- a/pkg/pkgmgr/apk.go
+++ b/pkg/pkgmgr/apk.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package pkgmgr
 
 import (

--- a/pkg/pkgmgr/apk_test.go
+++ b/pkg/pkgmgr/apk_test.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package pkgmgr
 

--- a/pkg/pkgmgr/apk_test.go
+++ b/pkg/pkgmgr/apk_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package pkgmgr
 
 import (

--- a/pkg/pkgmgr/dpkg.go
+++ b/pkg/pkgmgr/dpkg.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package pkgmgr
 

--- a/pkg/pkgmgr/dpkg.go
+++ b/pkg/pkgmgr/dpkg.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package pkgmgr
 
 import (

--- a/pkg/pkgmgr/dpkg_test.go
+++ b/pkg/pkgmgr/dpkg_test.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package pkgmgr
 

--- a/pkg/pkgmgr/dpkg_test.go
+++ b/pkg/pkgmgr/dpkg_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package pkgmgr
 
 import (

--- a/pkg/pkgmgr/pkgmgr.go
+++ b/pkg/pkgmgr/pkgmgr.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package pkgmgr
 

--- a/pkg/pkgmgr/pkgmgr.go
+++ b/pkg/pkgmgr/pkgmgr.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package pkgmgr
 
 import (

--- a/pkg/pkgmgr/pkgmgr_test.go
+++ b/pkg/pkgmgr/pkgmgr_test.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package pkgmgr
 

--- a/pkg/pkgmgr/pkgmgr_test.go
+++ b/pkg/pkgmgr/pkgmgr_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package pkgmgr
 
 import (

--- a/pkg/pkgmgr/rpm.go
+++ b/pkg/pkgmgr/rpm.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package pkgmgr
 

--- a/pkg/pkgmgr/rpm.go
+++ b/pkg/pkgmgr/rpm.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package pkgmgr
 
 import (

--- a/pkg/pkgmgr/rpm_test.go
+++ b/pkg/pkgmgr/rpm_test.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package pkgmgr
 

--- a/pkg/pkgmgr/rpm_test.go
+++ b/pkg/pkgmgr/rpm_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package pkgmgr
 
 import (

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package report
 
 import (

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package report
 

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package report
 
 import (

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package report
 

--- a/pkg/report/trivy.go
+++ b/pkg/report/trivy.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package report
 
 import (

--- a/pkg/report/trivy.go
+++ b/pkg/report/trivy.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package report
 

--- a/pkg/report/trivy_test.go
+++ b/pkg/report/trivy_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package report
 
 import (

--- a/pkg/report/trivy_test.go
+++ b/pkg/report/trivy_test.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package report
 

--- a/pkg/test_utils/utils.go
+++ b/pkg/test_utils/utils.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package testutils
 
 import (

--- a/pkg/test_utils/utils.go
+++ b/pkg/test_utils/utils.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package testutils
 

--- a/pkg/test_utils/utils_test.go
+++ b/pkg/test_utils/utils_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package testutils
 
 import (

--- a/pkg/test_utils/utils_test.go
+++ b/pkg/test_utils/utils_test.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package testutils
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package types
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package types
 
 type UpdatePackage struct {

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package utils
 

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package utils
 
 import (

--- a/pkg/utils/log_test.go
+++ b/pkg/utils/log_test.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package utils
 

--- a/pkg/utils/log_test.go
+++ b/pkg/utils/log_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package utils
 
 import (

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package utils
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package utils
 
 import (

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,7 +1,18 @@
-// ------------------------------------------------------------
-// Copyright (c) Project Copacetic authors.
-// Licensed under the MIT License.
-// ------------------------------------------------------------
+/*
+Copyright (c) Project Copacetic authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package utils
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright (c) Project Copacetic authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package utils
 
 import (


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Remove old MIT license headers and replace with Apache 2

Closes #351 
