### PR TITLE
fix: Copa hangs when InstallUpdates fails

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -45,7 +45,7 @@ func Patch(ctx context.Context, timeout time.Duration, image, reportFile, patche
 
 	ch := make(chan error)
 	go func() {
-		ch <- patchWithContext(timeoutCtx, image, reportFile, patchedTag, workingFolder, scanner, format, output, ignoreError, bkOpts)
+		ch <- patchWithContext(timeoutCtx, ch, image, reportFile, patchedTag, workingFolder, scanner, format, output, ignoreError, bkOpts)
 	}()
 
 	select {
@@ -70,7 +70,7 @@ func removeIfNotDebug(workingFolder string) {
 	}
 }
 
-func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workingFolder, scanner, format, output string, ignoreError bool, bkOpts buildkit.Opts) error {
+func patchWithContext(ctx context.Context, ch chan error, image, reportFile, patchedTag, workingFolder, scanner, format, output string, ignoreError bool, bkOpts buildkit.Opts) error {
 	imageName, err := reference.ParseNormalizedNamed(image)
 	if err != nil {
 		return err
@@ -81,7 +81,7 @@ func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workin
 	}
 	taggedName, ok := imageName.(reference.Tagged)
 	if !ok {
-		err := errors.New("unexpected: TagNameOnly did create Tagged ref")
+		err := errors.New("unexpected: TagNameOnly did not create Tagged ref")
 		log.Error(err)
 		return err
 	}
@@ -156,7 +156,7 @@ func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workin
 		return err
 	}
 
-	ch := make(chan *client.SolveStatus)
+	buildChannel := make(chan *client.SolveStatus)
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		_, err := bkClient.Build(ctx, solveOpt, copaProduct, func(ctx context.Context, c gwclient.Client) (*gwclient.Result, error) {
@@ -176,11 +176,13 @@ func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workin
 			// TODO: Add support for other output modes as buildctl does.
 			patchedImageState, errPkgs, err := pkgmgr.InstallUpdates(ctx, updates, ignoreError)
 			if err != nil {
+				ch <- err
 				return nil, err
 			}
 
 			def, err := patchedImageState.Marshal(ctx)
 			if err != nil {
+				ch <- err
 				return nil, err
 			}
 
@@ -191,6 +193,7 @@ func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workin
 
 			res.AddMeta(exptypes.ExporterImageConfigKey, config.ConfigData)
 			if err != nil {
+				ch <- err
 				return nil, err
 			}
 
@@ -220,7 +223,7 @@ func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workin
 			}
 
 			return res, nil
-		}, ch)
+		}, buildChannel)
 
 		return err
 	})
@@ -231,7 +234,7 @@ func patchWithContext(ctx context.Context, image, reportFile, patchedTag, workin
 			c = cn
 		}
 		// not using shared context to not disrupt display but let us finish reporting errors
-		_, err = progressui.DisplaySolveStatus(context.TODO(), c, os.Stdout, ch)
+		_, err = progressui.DisplaySolveStatus(context.TODO(), c, os.Stdout, buildChannel)
 		return err
 	})
 


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Describe the changes in this pull request using active verbs such as _Add_, _Remove_, _Replace_ ...

Errors in the `patchWithContext` function's `bkClient.Build ` call within the goroutine were not being propagated up to the calling Patch function. This PR adds communication to the original channel to throw an error from within the function its coming from.

Closes #503

Instead of hanging and reaching timeout error, this is the output of scanning ngxin:1.21.6 image after changes:
`
...
INFO[0017] Validated package perl-base version 5.32.1-4+deb11u3 meets requested version 5.32.1-4+deb11u3 
INFO[0017] Validated package tar version 1.34+dfsg-1+deb11u1 meets requested version 1.34+dfsg-1+deb11u1 
**ERRO[0017] downloaded package libgnutls30 version 3.7.1-5+deb11u4 lower than required 3.7.1-5+deb11u5 for update** 
INFO[0017] Validated package libkrb5-3 version 1.18.3-6+deb11u4 meets requested version 1.18.3-6+deb11u4 
INFO[0017] Validated package libsystemd0 version 247.3-7+deb11u4 meets requested version 247.3-7+deb11u2 
INFO[0017] Validated package libwebp6 version 0.6.1-2.1+deb11u2 meets requested version 0.6.1-2.1+deb11u2 
INFO[0017] Validated package libx11-data version 2:1.7.2-1+deb11u2 meets requested version 2:1.7.2-1+deb11u2 
INFO[0017] Validated package libxslt1.1 version 1.1.34-4+deb11u1 meets requested version 1.1.34-4+deb11u1 
INFO[0017] Validated package zlib1g version 1:1.2.11.dfsg-2+deb11u2 meets requested version 1:1.2.11.dfsg-2+deb11u2 
INFO[0017] Validated package curl version 7.74.0-1.3+deb11u11 meets requested version 7.74.0-1.3+deb11u11 
INFO[0017] Validated package libgssapi-krb5-2 version 1.18.3-6+deb11u4 meets requested version 1.18.3-6+deb11u4 
INFO[0017] Validated package libtasn1-6 version 4.16.0-2+deb11u1 meets requested version 4.16.0-2+deb11u1 
INFO[0017] Validated package libtinfo6 version 6.2+20201114-2+deb11u2 meets requested version 6.2+20201114-2+deb11u2 
**Error: 1 error occurred:
        * downloaded package libgnutls30 version 3.7.1-5+deb11u4 lower than required 3.7.1-5+deb11u5 for update**
`
