### PR TITLE
feat: allow change to BINS_OUT_DIR in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 # Build output variables
 CLI_BINARY        := copa
 OUT_DIR           := ./dist
-BINS_OUT_DIR      := $(OUT_DIR)/$(GOOS)_$(GOARCH)/$(BUILDTYPE_DIR)
+BINS_OUT_DIR      ?= $(OUT_DIR)/$(GOOS)_$(GOARCH)/$(BUILDTYPE_DIR)
 
 ################################################################################
 # Target: build (default action)                                               #


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Allow `BINS_OUT_DIR` in Makefile to be configured during call.

Describe the changes in this pull request using active verbs such as _Add_, _Remove_, _Replace_ ...

Closes #<_issue_ID_>
