### PR TITLE
docs: clarify copa does not support wolfi-based images

### DIFF
--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -37,6 +37,7 @@ This approach is motivated by the core principles of making direct container pat
 - **Copa supports patching _existing_ container images**.
   - Devs don't need to build their images using specific tools or modify them in some way just to support container patching.
 - **Copa supports containers without package managers _including_ distroless containers**
+  - Copa does not support Chainguard's wolfi-based images
 - **Copa works with the existing vulnerability scanning and mitigation ecosystems**.
   - Image publishers don't need to create new workflows for container patching since Copa supports patching container images using the security update packages already being published today.
   - Consumers do not need to migrate to a new and potentially more limited support ecosystem for custom distros or change their container vulnerability scanning pipelines to include remediation, since Copa can be integrated seamlessly as an extra step to patch containers based on those scanning reports.


### PR DESCRIPTION
After investigation, the Copa team has determined that Wolfi support will not be added at this time due to the complexities required to support this image type.

Closes #596 #38 