### PR TITLE
refactor: patch with context

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -221,7 +221,8 @@ func patchWithContext(ctx context.Context, ch chan error, image, reportFile, use
 	})
 
 	eg.Go(func() error {
-		if err := dockerLoad(ctx, pipeR); err != nil {
+		err = dockerLoad(ctx, pipeR)
+		if err != nil {
 			return err
 		}
 		return pipeR.Close()
@@ -358,7 +359,7 @@ func generatePatchedTag(dockerNormalizedImageName reference.Named, userSuppliedP
 	}
 
 	if userSuppliedPatchTag != "" {
-		copaTag = fmt.Sprintf("%s-%s", officialTag, userSuppliedPatchTag)
+		copaTag = userSuppliedPatchTag
 		return copaTag
 	} else if officialTag == "" {
 		log.Warnf("No output tag specified for digest-referenced image, defaulting to `%s`", defaultPatchedTagSuffix)

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -217,6 +217,7 @@ func patchWithContext(ctx context.Context, ch chan error, image, reportFile, use
 			}
 
 			// Export the patched image state to Docker
+			// TODO: Add support for other output modes as buildctl does.
 			patchedImageState, errPkgs, err := manager.InstallUpdates(ctx, updates, ignoreError)
 			if err != nil {
 				ch <- err

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/distribution/reference"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -301,6 +303,44 @@ func TestGetOSVersion(t *testing.T) {
 			// Use testify package to assert that the output manifest and error match the expected ones
 			assert.Equal(t, tc.expectedOSVersion, osVersion)
 			assert.Equal(t, tc.errMsg, errMsg)
+		})
+	}
+}
+
+func TestGeneratePatchedTag(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		dockerImageName      string
+		userSuppliedPatchTag string
+		expectedPatchedTag   string
+	}{
+		{
+			name:                 "NoTag_NoUserSupplied",
+			dockerImageName:      "docker.io/library/alpine",
+			userSuppliedPatchTag: "",
+			expectedPatchedTag:   defaultPatchedTagSuffix,
+		},
+		{
+			name:                 "WithTag_NoUserSupplied",
+			dockerImageName:      "docker.io/redhat/ubi9:latest",
+			userSuppliedPatchTag: "",
+			expectedPatchedTag:   "latest-patched",
+		},
+		{
+			name:                 "WithTag_UserSupplied",
+			dockerImageName:      "docker.io/librari/ubuntu:jammy-20231004",
+			userSuppliedPatchTag: "01",
+			expectedPatchedTag:   "jammy-20231004-01",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			named, _ := reference.ParseNormalizedNamed(tc.dockerImageName)
+			patchedTag := generatePatchedTag(named, tc.userSuppliedPatchTag)
+			if patchedTag != tc.expectedPatchedTag {
+				t.Errorf("expected patchedTag to be %s but got %s", tc.expectedPatchedTag, patchedTag)
+			}
 		})
 	}
 }

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -489,7 +489,7 @@ func TestHandleError(t *testing.T) {
 	}
 }
 
-// define a mock reader
+// define a mock reader.
 type mockReader struct {
 	data []byte
 	err  error

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -346,6 +346,18 @@ func TestGeneratePatchedTag(t *testing.T) {
 			userSuppliedPatchTag: "20231004-custom-tag",
 			expectedPatchedTag:   "20231004-custom-tag",
 		},
+		{
+			name:                 "NoTag_WithDigest_NoUserSupplied",
+			dockerImageName:      "docker.io/library/debian@sha256:540ebf19fb0bbc243e1314edac26b9fe7445e9c203357f27968711a45ea9f1d4",
+			userSuppliedPatchTag: "",
+			expectedPatchedTag:   defaultPatchedTagSuffix,
+		},
+		{
+			name:                 "NoTag_WithDigest_UserSupplied",
+			dockerImageName:      "docker.io/library/debian@sha256:540ebf19fb0bbc243e1314edac26b9fe7445e9c203357f27968711a45ea9f1d4",
+			userSuppliedPatchTag: "stable-patched",
+			expectedPatchedTag:   "stable-patched",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Closes #723 

This PR primarily addresses the untestability of the core patch function within Copa. By breaking the code into smaller blocks, the core functionality of Copa can more easily be tested and extended in the future, and bugs should be easier to find.