### PR TITLE
docs: Add additional way to signoff commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,14 @@ git commit --amend --no-edit --signoff
 git push --force-with-lease <remote-name> <branch-name>
 ```
 
+or leverage
+
+```bash
+git switch <branch-name>
+git rebase HEAD~<number of commits on branch> --signoff
+git push --force-with-lease <remote-name> <branch-name>
+```
+
 ## Code of Conduct
 
 This project has adopted the [CNCF Code of Conduct](./CODE_OF_CONDUCT)


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Adds an additional way to signoff commits within `CONTRIBUTING.md`

