### PR TITLE
docs: fix trailing comma in json

### DIFF
--- a/website/docs/scanner-plugins.md
+++ b/website/docs/scanner-plugins.md
@@ -99,7 +99,7 @@ From the above, we can see that the plugin must return a JSON object via standar
   "metadata": {
     "os": {
         "type": "debian",
-        "version": "11.3",
+        "version": "11.3"
     },
     "config": {
       "arch": "amd64"

--- a/website/versioned_docs/version-v0.5.x/scanner-plugins.md
+++ b/website/versioned_docs/version-v0.5.x/scanner-plugins.md
@@ -99,7 +99,7 @@ From the above, we can see that the plugin must return a JSON object via standar
   "metadata": {
     "os": {
         "type": "debian",
-        "version": "11.3",
+        "version": "11.3"
     },
     "config": {
       "arch": "amd64"

--- a/website/versioned_docs/version-v0.6.x/scanner-plugins.md
+++ b/website/versioned_docs/version-v0.6.x/scanner-plugins.md
@@ -99,7 +99,7 @@ From the above, we can see that the plugin must return a JSON object via standar
   "metadata": {
     "os": {
         "type": "debian",
-        "version": "11.3",
+        "version": "11.3"
     },
     "config": {
       "arch": "amd64"

--- a/website/versioned_docs/version-v0.7.x/scanner-plugins.md
+++ b/website/versioned_docs/version-v0.7.x/scanner-plugins.md
@@ -99,7 +99,7 @@ From the above, we can see that the plugin must return a JSON object via standar
   "metadata": {
     "os": {
         "type": "debian",
-        "version": "11.3",
+        "version": "11.3"
     },
     "config": {
       "arch": "amd64"

--- a/website/versioned_docs/version-v0.8.x/scanner-plugins.md
+++ b/website/versioned_docs/version-v0.8.x/scanner-plugins.md
@@ -99,7 +99,7 @@ From the above, we can see that the plugin must return a JSON object via standar
   "metadata": {
     "os": {
         "type": "debian",
-        "version": "11.3",
+        "version": "11.3"
     },
     "config": {
       "arch": "amd64"

--- a/website/versioned_docs/version-v0.9.x/scanner-plugins.md
+++ b/website/versioned_docs/version-v0.9.x/scanner-plugins.md
@@ -99,7 +99,7 @@ From the above, we can see that the plugin must return a JSON object via standar
   "metadata": {
     "os": {
         "type": "debian",
-        "version": "11.3",
+        "version": "11.3"
     },
     "config": {
       "arch": "amd64"


### PR DESCRIPTION
Removed the trailing comma in the json output example. Copa will error with `Error: error parsing scanner output: invalid character '}' looking for beginning of object key string` with the comma present.
