### PR TITLE
ci: remove grafana-image-renderer 3.4.0 from integration test

### DIFF
--- a/integration/fixtures/test-images.json
+++ b/integration/fixtures/test-images.json
@@ -176,13 +176,5 @@
         "digest": "sha256:9607229894026ebecade4623038fce35bb75bf9371aca7b08ca11b08d103d2ab",
         "distro": "Redhat",
         "description": "Valid microdnf, no yum/dnf/rpm"
-    },
-    {
-        "image": "docker.io/grafana/grafana-image-renderer",
-        "tag" : "3.4.0",
-        "digest": "sha256:205a39f5b58f96b9ff81a0b523a60c26c86e88e76575696fcd6debde9de02197",
-        "distro": "Alpine",
-        "description": "Valid apk/db, apk present, fail to patch libssl/libcryto",
-        "ignoreErrors": true
     }
 ]


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Describe the changes in this pull request using active verbs such as _Add_, _Remove_, _Replace_ ...
Temporarily remove `docker.io/grafana/grafana-image-renderer:3.4.0` from integration tests due to #877

Closes #<_issue_ID_>
