### PR TITLE
feat: Add Alma Linux Support

### DIFF
--- a/integration/fixtures/test-images.json
+++ b/integration/fixtures/test-images.json
@@ -179,10 +179,18 @@
     },
     {
         "image": "docker.io/grafana/grafana-image-renderer",
-        "tag" : "3.4.0",
+        "tag": "3.4.0",
         "digest": "sha256:205a39f5b58f96b9ff81a0b523a60c26c86e88e76575696fcd6debde9de02197",
         "distro": "Alpine",
         "description": "Valid apk/db, apk present, fail to patch libssl/libcryto",
         "ignoreErrors": true
+    },
+    {
+        "image": "docker.io/almalinux",
+        "tag": "9.4",
+        "digest": "sha256:1c718a4cd7bab3bdb069ddbbd1eb593a390e6932d51d0048a2f6556303bafba7",
+        "distro": "AlmaLinux",
+        "description": "Valid rpm DB, microdnf & rpm present",
+        "ignoreErrors": false
     }
 ]

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -174,6 +174,11 @@ func patchWithContext(ctx context.Context, ch chan error, image, reportFile, pat
 			err = errors.New("RockyLinux is not supported via source policies due to BusyBox not being in the RockyLinux repos\n" +
 				"Please use a different RPM-based image")
 			return err
+
+		case strings.Contains(solveOpt.SourcePolicy.Rules[0].Updates.Identifier, "almalinux"):
+			err = errors.New("AlmaLinux is not supported via source policies due to BusyBox not being in the AlmaLinux repos\n" +
+				"Please use a different RPM-based image")
+			return err
 		}
 	}
 
@@ -343,6 +348,8 @@ func getOSType(ctx context.Context, osreleaseBytes []byte) (string, error) {
 		return "rocky", nil
 	case strings.Contains(osType, "oracle"):
 		return "oracle", nil
+	case strings.Contains(osType, "almalinux"):
+		return "almalinux", nil
 	default:
 		log.Error("unsupported osType ", osType)
 		return "", errors.ErrUnsupported

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -247,6 +247,28 @@ func TestGetOSType(t *testing.T) {
 			err:            errors.ErrUnsupported,
 			expectedOSType: "",
 		},
+		{
+			osRelease: []byte(`NAME="AlmaLinux"
+			VERSION="9.4 (Seafoam Ocelot)"
+			ID="almalinux"
+			ID_LIKE="rhel centos fedora"
+			VERSION_ID="9.4"
+			PLATFORM_ID="platform:el9"
+			PRETTY_NAME="AlmaLinux 9.4 (Seafoam Ocelot)"
+			ANSI_COLOR="0;34"
+			CPE_NAME="cpe:/o:almalinux:almalinux:9::baseos"
+			HOME_URL="https://almalinux.org/"
+			DOCUMENTATION_URL="https://wiki.almalinux.org/"
+			BUG_REPORT_URL="https://bugs.almalinux.org/"
+
+			SUPPORT_END="2032-06-01"
+			ALMALINUX_MANTISBT_PROJECT="AlmaLinux-9"
+    		ALMALINUX_MANTISBT_PROJECT_VERSION="9.4"
+			REDHAT_SUPPORT_PRODUCT="AlmaLinux"
+			REDHAT_SUPPORT_PRODUCT_VERSION="9.4"`),
+			err:            nil,
+			expectedOSType: "almalinux",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/pkgmgr/pkgmgr.go
+++ b/pkg/pkgmgr/pkgmgr.go
@@ -40,7 +40,7 @@ func GetPackageManager(osType string, osVersion string, config *buildkit.Config,
 			workingFolder: workingFolder,
 			osVersion:     osVersion,
 		}, nil
-	case "cbl-mariner", "azurelinux", "centos", "oracle", "redhat", "rocky", "amazon":
+	case "cbl-mariner", "azurelinux", "centos", "oracle", "redhat", "rocky", "amazon", "almalinux":
 		return &rpmManager{
 			config:        config,
 			workingFolder: workingFolder,

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -36,7 +36,7 @@ There is one caveat for Ubuntu-based images. If an Ubuntu-based image is being p
 #### Azure Linux 3.0+
 Azure Linux based images will use `mcr.microsoft.com/azurelinux/base/core` with the same version as the image being patched.
 
-#### CBL-Mariner (Azure Linux 1 and 2), CentOS, Oracle Linux, Rocky Linux, and Amazon Linux
+#### CBL-Mariner (Azure Linux 1 and 2), CentOS, Oracle Linux, Rocky Linux, Alma Linux, and Amazon Linux
 These RPM-based distros will use `mcr.microsoft.com/cbl-mariner/base/core:2.0`
 
 ### APK (Alpine)

--- a/website/versioned_docs/version-v0.9.x/faq.md
+++ b/website/versioned_docs/version-v0.9.x/faq.md
@@ -36,7 +36,7 @@ There is one caveat for Ubuntu-based images. If an Ubuntu-based image is being p
 #### Azure Linux 3.0+
 Azure Linux based images will use `mcr.microsoft.com/azurelinux/base/core` with the same version as the image being patched.
 
-#### CBL-Mariner (Azure Linux 1 and 2), CentOS, Oracle Linux, Rocky Linux, and Amazon Linux
+#### CBL-Mariner (Azure Linux 1 and 2), CentOS, Oracle Linux, Rocky Linux, Alma Linux, and Amazon Linux
 These RPM-based distros will use `mcr.microsoft.com/cbl-mariner/base/core:2.0`
 
 ### APK (Alpine)


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

This PR adds support for Alma Linux. It's a small change as RedHat was already supported and microdnf. I added Alma Linux to the patch tests in `integration/patch_tests.go` & `pkg/patch/patch_test.go`.

Tests ran with the new changes:
```bash
# Before patch alma 8.10
docker.io/almalinux:8-minimal (alma 8.10)

Total: 3 (UNKNOWN: 0, LOW: 2, MEDIUM: 0, HIGH: 1, CRITICAL: 0)


# After patching alma 8.10
docker.io/almalinux:8-minimal-patched (alma 8.10)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```
```bash
# Before patching alma 9.4
docker.io/almalinux:9.4 (alma 9.4)

Total: 25 (UNKNOWN: 0, LOW: 9, MEDIUM: 14, HIGH: 2, CRITICAL: 0)

# After patching alma 9.4
docker.io/almalinux:9.4-patched (alma 9.4)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

```

Closes #904 
