### PR TITLE
fix: oci media type should be respected

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -1,13 +1,14 @@
 package patch
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -33,6 +34,9 @@ import (
 	"github.com/project-copacetic/copacetic/pkg/utils"
 	"github.com/project-copacetic/copacetic/pkg/vex"
 	"github.com/quay/claircore/osrelease"
+
+	dockerTypes "github.com/docker/docker/api/types"
+	dockerClient "github.com/docker/docker/client"
 )
 
 const (
@@ -146,6 +150,30 @@ func patchWithContext(ctx context.Context, ch chan error, image, reportFile, rep
 	}
 	defer bkClient.Close()
 
+	var ref string
+	if reference.IsNameOnly(imageName) {
+		log.Warnf("Image name has no tag or digest, using latest as tag")
+		ref = fmt.Sprintf("%s:%s", imageName.Name(), defaultTag)
+	} else {
+		log.Debugf("Image name has tag or digest, using %s as tag", imageName.String())
+		ref = imageName.String()
+	}
+
+	// get the original media type of the image to determine if we should export as OCI or Docker
+	mt, err := utils.GetMediaType(ref)
+	shouldExportOCI := err == nil && strings.Contains(mt, "vnd.oci.image")
+
+	switch {
+	case shouldExportOCI:
+		log.Debug("resolved media type is OCI")
+
+	case err != nil:
+		log.Warnf("unable to determine media type, defaulting to docker, err: %v", err)
+
+	default:
+		log.Warnf("unable to determine media type, defaulting to docker")
+	}
+
 	pipeR, pipeW := io.Pipe()
 	dockerConfig := config.LoadDefaultConfigFile(os.Stderr)
 	cfg := authprovider.DockerAuthProviderConfig{ConfigFile: dockerConfig}
@@ -157,24 +185,26 @@ func patchWithContext(ctx context.Context, ch chan error, image, reportFile, rep
 		Session:  attachable, // used for authprovider, sshagentprovider and secretprovider
 	}
 
-	// set the export options based on push flag
+	// determine which attributes to set for the export
+	attrs := map[string]string{
+		"name": patchedImageName,
+	}
+	if shouldExportOCI {
+		attrs["oci-mediatypes"] = "true"
+	}
 	if push {
+		attrs["push"] = "true"
 		solveOpt.Exports = []client.ExportEntry{
 			{
-				Type: client.ExporterImage,
-				Attrs: map[string]string{
-					"name": patchedImageName,
-					"push": "true",
-				},
+				Type:  client.ExporterImage,
+				Attrs: attrs,
 			},
 		}
 	} else {
 		solveOpt.Exports = []client.ExportEntry{
 			{
-				Type: client.ExporterDocker,
-				Attrs: map[string]string{
-					"name": patchedImageName,
-				},
+				Type:  client.ExporterDocker,
+				Attrs: attrs,
 				Output: func(_ map[string]string) (io.WriteCloser, error) {
 					return pipeW, nil
 				},
@@ -351,8 +381,17 @@ func patchWithContext(ctx context.Context, ch chan error, image, reportFile, rep
 	// only load to docker if not pushing
 	if !push {
 		eg.Go(func() error {
-			if err := dockerLoad(ctx, pipeR); err != nil {
-				return err
+			dockerCli, err := newDockerClient()
+			if err != nil {
+				pipeR.CloseWithError(fmt.Errorf("failed to create docker client for loading: %w", err))
+				return fmt.Errorf("failed to create docker client for loading: %w", err)
+			}
+			defer dockerCli.Close()
+
+			err = dockerLoadWithClient(ctx, dockerCli, pipeR)
+			if err != nil {
+				pipeR.CloseWithError(fmt.Errorf("dockerLoadWithClient failed: %w", err))
+				return fmt.Errorf("dockerLoadWithClient failed: %w", err)
 			}
 			return pipeR.Close()
 		})
@@ -443,25 +482,62 @@ func getOSVersion(ctx context.Context, osreleaseBytes []byte) (string, error) {
 	return osData["VERSION_ID"], nil
 }
 
-func dockerLoad(ctx context.Context, pipeR io.Reader) error {
-	cmd := exec.CommandContext(ctx, "docker", "load")
-	cmd.Stdin = pipeR
-
-	stdout, err := cmd.StdoutPipe()
+func newDockerClient() (dockerClient.APIClient, error) {
+	cli, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv, dockerClient.WithAPIVersionNegotiation())
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("failed to create docker client: %w", err)
 	}
-	stderr, err := cmd.StderrPipe()
+	log.Debug("Docker client initialized successfully")
+	return cli, nil
+}
+
+func dockerLoadWithClient(ctx context.Context, cli dockerClient.APIClient, pipeR io.Reader) error {
+	log.Debugf("Loading image stream using Docker API client")
+	resp, err := cli.ImageLoad(ctx, pipeR, dockerClient.ImageLoadWithQuiet(false))
 	if err != nil {
-		return err
+		log.Errorf("Docker API ImageLoad failed: %v", err)
+		return fmt.Errorf("docker client ImageLoad: %w", err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	lastLine := ""
+	for scanner.Scan() {
+		line := scanner.Text()
+		lastLine = line
+		log.Debugf("ImageLoad response stream: %s", line)
 	}
 
-	// Pipe run errors to WarnLevel since execution continues asynchronously
-	// Caller should log a separate ErrorLevel on completion based on err
-	go utils.LogPipe(stderr, log.WarnLevel)
-	go utils.LogPipe(stdout, log.InfoLevel)
+	if err := scanner.Err(); err != nil {
+		log.Warnf("Error reading ImageLoad response body stream: %v", err)
+	}
 
-	return cmd.Run()
+	if resp.JSON && lastLine != "" {
+		var jsonResp struct {
+			ErrorResponse *dockerTypes.ErrorResponse `json:"errorResponse"`
+			Error         string                     `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(lastLine), &jsonResp); err == nil {
+			if jsonResp.ErrorResponse != nil {
+				msg := fmt.Sprintf("ImageLoad reported error: %s", jsonResp.ErrorResponse.Message)
+				log.Error(msg)
+				return errors.New(msg)
+			}
+			if jsonResp.Error != "" {
+				// Sometimes the error is directly in the 'error' field
+				msg := fmt.Sprintf("ImageLoad reported error: %s", jsonResp.Error)
+				log.Error(msg)
+				return errors.New(msg)
+			}
+		} else {
+			log.Debugf("Final ImageLoad response line (non-JSON or parse error): %s", lastLine)
+		}
+	} else if lastLine != "" {
+		log.Debugf("Final ImageLoad response line (non-JSON): %s", lastLine)
+	}
+
+	log.Info("Image loaded successfully via Docker API")
+	return nil
 }
 
 // e.g. "docker.io/library/nginx:1.21.6-patched".

--- a/pkg/utils/mediatype.go
+++ b/pkg/utils/mediatype.go
@@ -1,0 +1,71 @@
+package utils
+
+import (
+	"context"
+	"errors"
+
+	dockerClient "github.com/docker/docker/client"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	log "github.com/sirupsen/logrus"
+)
+
+// For testing.
+var (
+	remoteGet = remote.Get
+	newClient = func() (dockerClient.APIClient, error) {
+		return dockerClient.NewClientWithOpts(
+			dockerClient.FromEnv,
+			dockerClient.WithAPIVersionNegotiation(),
+		)
+	}
+)
+
+// GetMediaType returns the manifest’s media type for an image reference
+// It prefers a local inspection and falls back to a registry lookup.
+func GetMediaType(imageRef string) (string, error) {
+	// Check if the image is local first
+	// If it is, use the local media type
+	mt, err := localMediaType(imageRef)
+	if err == nil && mt != "" {
+		log.Debugf("local media type found for %s: %s", imageRef, mt)
+		return mt, nil
+	}
+	log.Debugf("local media type not found for %s: %v", imageRef, err)
+
+	// If the image is not local, use the remote media type
+	return remoteMediaType(imageRef)
+}
+
+func localMediaType(imageRef string) (string, error) {
+	cli, err := newClient()
+	if err != nil {
+		return "", err
+	}
+	defer cli.Close()
+
+	distInspect, err := cli.ImageInspect(context.Background(), imageRef)
+	if err != nil {
+		return "", err
+	}
+	if distInspect.Descriptor == nil {
+		return "", errors.New("descriptor is nil")
+	}
+	return distInspect.Descriptor.MediaType, nil
+}
+
+func remoteMediaType(imageRef string) (string, error) {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		log.Debugf("failed to parse reference %s: %v", imageRef, err)
+		return "", err
+	}
+	desc, err := remoteGet(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		log.Debugf("failed to get remote media type for %s: %v", imageRef, err)
+		return "", err
+	}
+	log.Debugf("remote media type found for %s: %s", imageRef, desc.MediaType)
+	return string(desc.MediaType), nil
+}

--- a/pkg/utils/mediatype_test.go
+++ b/pkg/utils/mediatype_test.go
@@ -1,0 +1,165 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/registry"
+	dockerClient "github.com/docker/docker/client"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockDockerClient struct {
+	mock.Mock
+	dockerClient.APIClient
+}
+
+func (m *mockDockerClient) ImageInspect(ctx context.Context, ref string, _ ...dockerClient.ImageInspectOption) (image.InspectResponse, error) {
+	args := m.Called(ctx, ref)
+	di, _ := args.Get(0).(image.InspectResponse)
+	return di, args.Error(1)
+}
+
+func (m *mockDockerClient) Close() error {
+	return nil
+}
+
+type mockRemote struct {
+	mock.Mock
+}
+
+func (m *mockRemote) Get(ref name.Reference, opts ...remote.Option) (*remote.Descriptor, error) {
+	args := m.Called(ref, opts)
+	desc, _ := args.Get(0).(*remote.Descriptor)
+	return desc, args.Error(1)
+}
+
+func TestLocalMediaType(t *testing.T) {
+	md := new(mockDockerClient)
+	fakeMediaType := "application/vnd.docker.distribution.manifest.v2+json"
+	md.On("ImageInspect", mock.Anything, "alpine:latest", mock.Anything).Return().Return(
+		image.InspectResponse{
+			Descriptor: &ocispec.Descriptor{
+				MediaType: fakeMediaType,
+			},
+		},
+		nil,
+	)
+
+	origNewClient := newClient
+	defer func() { newClient = origNewClient }()
+	newClient = func() (dockerClient.APIClient, error) { return md, nil }
+
+	mt, err := localMediaType("alpine:latest")
+	require.NoError(t, err)
+	require.Equal(t, fakeMediaType, mt)
+}
+
+func TestLocalMediaTypeFailure(t *testing.T) {
+	md := new(mockDockerClient)
+	md.On("ImageInspect", mock.Anything, "bad:tag", mock.Anything).Return(
+		image.InspectResponse{},
+		errors.New("failed to inspect"),
+	)
+
+	origNewClient := newClient
+	defer func() { newClient = origNewClient }()
+	newClient = func() (dockerClient.APIClient, error) { return md, nil }
+
+	mt, err := localMediaType("bad:tag")
+	require.Error(t, err)
+	require.Empty(t, mt)
+}
+
+func TestRemoteMediaType_Success(t *testing.T) {
+	mr := new(mockRemote)
+	fakeRemoteType := types.MediaType("application/vnd.oci.image.config.v1+json")
+	mr.On("Get", mock.Anything, mock.Anything).Return(
+		&remote.Descriptor{Descriptor: v1.Descriptor{MediaType: fakeRemoteType}},
+		nil,
+	)
+
+	origRemoteGet := remoteGet
+	defer func() { remoteGet = origRemoteGet }()
+	remoteGet = func(ref name.Reference, opts ...remote.Option) (*remote.Descriptor, error) {
+		return mr.Get(ref, opts...)
+	}
+
+	mt, err := remoteMediaType("alpine:latest")
+	require.NoError(t, err)
+	require.Equal(t, string(fakeRemoteType), mt)
+}
+
+func TestRemoteMediaType_Failure(t *testing.T) {
+	mr := new(mockRemote)
+	mr.On("Get", mock.Anything, mock.Anything).Return(nil, errors.New("network down"))
+
+	origRemoteGet := remoteGet
+	defer func() { remoteGet = origRemoteGet }()
+	remoteGet = func(ref name.Reference, opts ...remote.Option) (*remote.Descriptor, error) {
+		return mr.Get(ref, opts...)
+	}
+
+	_, err := remoteMediaType("alpine:latest")
+	require.Error(t, err)
+}
+
+func TestGetMediaType_LocalSuccess(t *testing.T) {
+	md := new(mockDockerClient)
+	fakeLocalType := "application/vnd.docker.distribution.manifest.v2+json"
+	md.On("ImageInspect", mock.Anything, "alpine:latest", mock.Anything).Return(
+		image.InspectResponse{
+			Descriptor: &ocispec.Descriptor{
+				MediaType: fakeLocalType,
+			},
+		},
+		nil,
+	)
+
+	origNewClient := newClient
+	defer func() { newClient = origNewClient }()
+	newClient = func() (dockerClient.APIClient, error) { return md, nil }
+
+	mt, err := GetMediaType("alpine:latest")
+	require.NoError(t, err)
+	require.Equal(t, fakeLocalType, mt)
+}
+
+func TestGetMediaType_RemoteFallback(t *testing.T) {
+	// Force local lookup to fail
+	md := new(mockDockerClient)
+	md.On("ImageInspect", mock.Anything, "alpine:latest", mock.Anything).Return(
+		registry.DistributionInspect{},
+		errors.New("local lookup failed"),
+	)
+
+	origNewClient := newClient
+	defer func() { newClient = origNewClient }()
+	newClient = func() (dockerClient.APIClient, error) { return md, nil }
+
+	// Mock remote lookup
+	mr := new(mockRemote)
+	fakeRemoteType := types.MediaType("application/vnd.oci.image.config.v1+json")
+	mr.On("Get", mock.Anything, mock.Anything).Return(
+		&remote.Descriptor{Descriptor: v1.Descriptor{MediaType: fakeRemoteType}},
+		nil,
+	)
+
+	origRemoteGet := remoteGet
+	defer func() { remoteGet = origRemoteGet }()
+	remoteGet = func(ref name.Reference, opts ...remote.Option) (*remote.Descriptor, error) {
+		return mr.Get(ref, opts...)
+	}
+
+	mt, err := GetMediaType("alpine:latest")
+	require.NoError(t, err)
+	require.Equal(t, string(fakeRemoteType), mt)
+}


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Adds `getExporterType` to map media type to exporter type directly via a resolution of the descriptor using oras

Closes #842
