### PR TITLE
docs: update supported OS types in FAQ (#903)

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -21,6 +21,19 @@ If you find that your storage is rapidly being taken up after working with Copa,
 
 All images being passed into Copa have their versioning data carefully extracted and stripped so that an appropriate tooling image can be obtained from a container repository.
 
+### Supported OS Types
+Copacetic supports the following operating systems:  
+- Alpine  
+- Debian  
+- Ubuntu  
+- CBL-Mariner  
+- Azure Linux  
+- CentOS  
+- Oracle Linux  
+- Red Hat  
+- Rocky Linux  
+- Amazon Linux  
+
 ### DPKG
 
 #### Debian

--- a/website/versioned_docs/version-v0.1.x/faq.md
+++ b/website/versioned_docs/version-v0.1.x/faq.md
@@ -16,3 +16,10 @@ To patch vulnerabilities for applications, you can package these applications an
 ## After Copa patched the image, why does the scanner still show patched OS package vulnerabilities?
 
 After scanning the patched image, if you’re still seeing vulnerabilities that have already been addressed in the patch layer, it could be due to the scanner reporting issues on each individual layer. Please reach out to your scanner vendor for assistance in resolving this.
+
+## What Operating Systems Are Supported?
+Copa is officially supported on:
+- **macOS** – Install via Homebrew.
+- **Linux** – Generic Linux installations are supported via Homebrew, with **Ubuntu 22.04** recommended for the development environment.
+
+> **Note:** Windows is not natively supported. However, Windows users can run Copa using WSL2 for Docker integration.

--- a/website/versioned_docs/version-v0.10.x/faq.md
+++ b/website/versioned_docs/version-v0.10.x/faq.md
@@ -103,3 +103,22 @@ Yes, see [best practices](best-practices.md#dependabot) to learn more about usin
 
 ## Does Copa cause a buildup of patched layers on each patch?
 No. To prevent a buildup of layers, Copa discards the previous patch layer with each new patch. Each subsequent patch removes the earlier patch layer and creates a new one, which includes all patches applied since the original base image Copa started with. Essentially, Copa is creating a new layer with the latest patch, based on the base/original image. This new layer is a combination (or squash) of both the previous updates and the new updates requested. Discarding the patch layer also reduces the size of the resulting patched images in the future.
+
+## What Operating Systems Are Supported?
+- **Host Installation:**
+  - **macOS** – Install via [Homebrew](https://brew.sh/).
+  - **Linux** – Generic Linux installations are supported via Homebrew.
+
+**Container Image Patching:**
+- **DPKG-based (Debian/Ubuntu):**
+  - Debian
+  - Ubuntu
+
+- **RPM-based:**
+  - Azure Linux 3.0+
+  - CBL-Mariner (Azure Linux 1 and 2)
+  - CentOS
+  - Oracle Linux
+  - Rocky Linux
+  - Alma Linux
+  - Amazon Linux

--- a/website/versioned_docs/version-v0.2.x/faq.md
+++ b/website/versioned_docs/version-v0.2.x/faq.md
@@ -16,3 +16,10 @@ To patch vulnerabilities for applications, you can package these applications an
 ## After Copa patched the image, why does the scanner still show patched OS package vulnerabilities?
 
 After scanning the patched image, if you’re still seeing vulnerabilities that have already been addressed in the patch layer, it could be due to the scanner reporting issues on each individual layer. Please reach out to your scanner vendor for assistance in resolving this.
+
+## What Operating Systems Are Supported?
+Copa is officially supported on:
+- **macOS** – Install via Homebrew.
+- **Linux** – Generic Linux installations are supported via Homebrew, with **Ubuntu 22.04** recommended for the development environment.
+
+> **Note:** Windows is not natively supported. However, Windows users can run Copa using WSL2 for Docker integration.

--- a/website/versioned_docs/version-v0.3.x/faq.md
+++ b/website/versioned_docs/version-v0.3.x/faq.md
@@ -16,3 +16,10 @@ To patch vulnerabilities for applications, you can package these applications an
 ## After Copa patched the image, why does the scanner still show patched OS package vulnerabilities?
 
 After scanning the patched image, if you’re still seeing vulnerabilities that have already been addressed in the patch layer, it could be due to the scanner reporting issues on each individual layer. Please reach out to your scanner vendor for assistance in resolving this.
+
+## What Operating Systems Are Supported?
+Copa is officially supported on:
+- **macOS** – Install via Homebrew.
+- **Linux** – Generic Linux installations are supported via Homebrew, with **Ubuntu 22.04** recommended for the development environment.
+
+> **Note:** Windows is not natively supported. However, Windows users can run Copa using WSL2 for Docker integration.

--- a/website/versioned_docs/version-v0.4.x/faq.md
+++ b/website/versioned_docs/version-v0.4.x/faq.md
@@ -16,3 +16,10 @@ To patch vulnerabilities for applications, you can package these applications an
 ## After Copa patched the image, why does the scanner still show patched OS package vulnerabilities?
 
 After scanning the patched image, if you’re still seeing vulnerabilities that have already been addressed in the patch layer, it could be due to the scanner reporting issues on each individual layer. Please reach out to your scanner vendor for assistance in resolving this.
+
+## What Operating Systems Are Supported?
+Copa is officially supported on:
+- **macOS** – Install via Homebrew.
+- **Linux** – Generic Linux installations are supported via Homebrew, with **Ubuntu 22.04** recommended for the development environment.
+
+> **Note:** Windows is not natively supported. However, Windows users can run Copa using WSL2 for Docker integration.

--- a/website/versioned_docs/version-v0.5.x/faq.md
+++ b/website/versioned_docs/version-v0.5.x/faq.md
@@ -52,3 +52,10 @@ export EXPERIMENTAL_BUILDKIT_SOURCE_POLICY=source-policy.json
 > Tooling image for Debian-based images are `docker.io/library/debian:11-slim` and RPM-based repos are `mcr.microsoft.com/cbl-mariner/base/core:2.0`.
 
 For more information on source policies, see [Buildkit Source Policies](https://docs.docker.com/build/building/env-vars/#experimental_buildkit_source_policy).
+
+## What Operating Systems Are Supported?
+Copa is officially supported on:
+- **macOS** – Install via Homebrew.
+- **Linux** – Generic Linux installations are supported via Homebrew, with **Ubuntu 22.04** recommended for the development environment.
+
+> **Note:** Windows is not natively supported. However, Windows users can run Copa using WSL2 for Docker integration.

--- a/website/versioned_docs/version-v0.6.x/faq.md
+++ b/website/versioned_docs/version-v0.6.x/faq.md
@@ -52,3 +52,10 @@ export EXPERIMENTAL_BUILDKIT_SOURCE_POLICY=source-policy.json
 > Tooling image for Debian-based images are `docker.io/library/debian:11-slim` and RPM-based repos are `mcr.microsoft.com/cbl-mariner/base/core:2.0`.
 
 For more information on source policies, see [Buildkit Source Policies](https://docs.docker.com/build/building/env-vars/#experimental_buildkit_source_policy).
+
+## What Operating Systems Are Supported?
+Copa is officially supported on:
+- **macOS** – Install via Homebrew.
+- **Linux** – Generic Linux installations are supported via Homebrew, with **Ubuntu 22.04** recommended for the development environment.
+
+> **Note:** Windows is not natively supported. However, Windows users can run Copa using WSL2 for Docker integration.

--- a/website/versioned_docs/version-v0.7.x/faq.md
+++ b/website/versioned_docs/version-v0.7.x/faq.md
@@ -56,3 +56,17 @@ export EXPERIMENTAL_BUILDKIT_SOURCE_POLICY=source-policy.json
 > The tooling image for Debian-based images can be `docker.io/library/debian:11-slim` or `docker.io/library/debian:12-slim` depending on the target image version. RPM-based repos use `mcr.microsoft.com/cbl-mariner/base/core:2.0`.
 
 For more information on source policies, see [Buildkit Source Policies](https://docs.docker.com/build/building/env-vars/#experimental_buildkit_source_policy).
+
+## What Operating Systems Are Supported?
+**Host Installation:**
+  - **macOS** – Install via Homebrew.
+  - **Linux** – Generic Linux installations are supported via Homebrew, with **Ubuntu 22.04** recommended for the development environment.
+
+**Container Image Patching:**
+  - **DPKG-based Images (Debian/Ubuntu):**
+    - Uses the appropriate tooling images (e.g., Ubuntu images use the same version passed in, such as `ubuntu:22.04`).
+  - **RPM-based Images:**
+    - Supports RPM-based distributions such as CentOS, Rocky Linux, and Amazon Linux.
+    - *Note:* Official support for Oracle Linux was introduced later in v0.8.x.
+  - **APK-based Images (Alpine):**
+    - Alpine-based images are not patched by Copacetic.

--- a/website/versioned_docs/version-v0.8.x/faq.md
+++ b/website/versioned_docs/version-v0.8.x/faq.md
@@ -73,3 +73,24 @@ For more information on source policies, see [Buildkit Source Policies](https://
 
 ## Does Copa cause a buildup of patched layers on each patch?
 No. To prevent a buildup of layers, Copa discards the previous patch layer with each new patch. Each subsequent patch removes the earlier patch layer and creates a new one, which includes all patches applied since the original base image Copa started with. Essentially, Copa is creating a new layer with the latest patch, based on the base/original image. This new layer is a combination (or squash) of both the previous updates and the new updates requested. Discarding the patch layer also reduces the size of the resulting patched images in the future.
+
+## What Operating Systems Are Supported?
+-**Host Installation:**
+    - **macOS** – Install via [Homebrew](https://brew.sh/).
+    - **Linux** – Generic Linux installations are supported via Homebrew.
+
+**Container Image Patching:**
+- **DPKG-based (Debian/Ubuntu):**
+    - Uses tooling images matching the base OS version (e.g., `ubuntu:22.04`).
+
+- **RPM-based:**
+    - CentOS
+    - Oracle Linux
+    - Rocky Linux
+    - AlmaLinux
+    - Amazon Linux
+    - CBL-Mariner (Azure Linux 1 & 2)
+    - Azure Linux 3.0+ (newly supported in v8)
+
+- **Alpine (APK-based):**
+    - **Not supported** – Copa does not patch distroless Alpine-based images.

--- a/website/versioned_docs/version-v0.9.x/faq.md
+++ b/website/versioned_docs/version-v0.9.x/faq.md
@@ -103,3 +103,22 @@ Yes, see [best practices](best-practices.md#dependabot) to learn more about usin
 
 ## Does Copa cause a buildup of patched layers on each patch?
 No. To prevent a buildup of layers, Copa discards the previous patch layer with each new patch. Each subsequent patch removes the earlier patch layer and creates a new one, which includes all patches applied since the original base image Copa started with. Essentially, Copa is creating a new layer with the latest patch, based on the base/original image. This new layer is a combination (or squash) of both the previous updates and the new updates requested. Discarding the patch layer also reduces the size of the resulting patched images in the future.
+
+## What Operating Systems Are Supported?
+- **Host Installation:**
+  - **macOS** – Install via [Homebrew](https://brew.sh/).
+  - **Linux** – Generic Linux installations are supported via Homebrew.
+
+**Container Image Patching:**
+- **DPKG-based (Debian/Ubuntu):**
+  - Debian
+  - Ubuntu
+
+- **RPM-based:**
+  - Azure Linux 3.0+
+  - CBL-Mariner (Azure Linux 1 and 2)
+  - CentOS
+  - Oracle Linux
+  - Rocky Linux
+  - Alma Linux
+  - Amazon Linux


### PR DESCRIPTION
This PR updates the FAQ to accurately reflect the supported operating systems for both host installation and container image patching in Copa.

**Changes include:**
- Adding a "Host Installation" section that lists:
  - macOS – Install via Homebrew.
  - Linux – Generic Linux installations via Homebrew.
- Updating the "Container Image Patching Support" section to include:
  - DPKG-based (Debian/Ubuntu) images.
  - RPM-based images for Azure Linux 3.0+, CBL-Mariner (Azure Linux 1 & 2), CentOS, Oracle Linux, Rocky Linux, Alma Linux, and Amazon Linux.
  - Clarifying that APK-based (Alpine) images are not supported.

Closes #903.
