### PR TITLE
fix: apt apk images fail tooling images missing

### DIFF
--- a/pkg/pkgmgr/dpkg_test.go
+++ b/pkg/pkgmgr/dpkg_test.go
@@ -132,7 +132,7 @@ func TestGetAPTImageName(t *testing.T) {
 	// Run test cases
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := getAPTImageName(tc.manifest, tc.manifest.Metadata.OS.Version)
+			got := getAPTImageName(tc.manifest, tc.manifest.Metadata.OS.Version, true)
 			if got != tc.want {
 				t.Errorf("getAPTImageName() = %v, want %v", got, tc.want)
 			}

--- a/pkg/pkgmgr/pkgmgr.go
+++ b/pkg/pkgmgr/pkgmgr.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/moby/buildkit/client/llb"
+	"github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
 	"github.com/project-copacetic/copacetic/pkg/types/unversioned"
 	log "github.com/sirupsen/logrus"
@@ -159,4 +160,24 @@ func GetValidatedUpdatesMap(updates unversioned.UpdatePackages, cmp VersionCompa
 		return nil, allErrors.ErrorOrNil()
 	}
 	return m, nil
+}
+
+// tryImage attempts to create an llb.Image reference and call c.Solve() on it
+// to confirm it exists. If it doesn't, it will return an error so we can fallback.
+func tryImage(ctx context.Context, imageRef string, c client.Client) (llb.State, error) {
+	st := llb.Image(imageRef)
+	def, err := st.Marshal(ctx)
+	if err != nil {
+		return llb.State{}, err
+	}
+
+	// Evaluate the solve to see if BuildKit can actually resolve it
+	_, err = c.Solve(ctx, client.SolveRequest{
+		Definition: def.ToPB(),
+		Evaluate:   true,
+	})
+	if err != nil {
+		return llb.State{}, fmt.Errorf("failed to resolve %s: %w", imageRef, err)
+	}
+	return st, nil
 }


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Adds fallback mechanisms to the apk and apt based package managers

Closes #980

Should be merged after #978
