### PR TITLE
fix: golangci-lint v1 is not supported by golangci-lint-action v7

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -37,4 +37,4 @@ jobs:
       - name: lint
         uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.64.5
+          version: v2.0.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,35 +1,49 @@
-run:
-  timeout: 5m
-
-linters-settings:
-  gocritic:
-    enabled-tags:
-    - performance
-  lll:
-    line-length: 200
-  misspell:
-    locale: US
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    - errcheck
     - copyloopvar
+    - errcheck
     - forcetypeassert
-    - gocritic
     - goconst
+    - gocritic
     - godot
-    - gofmt
-    - gofumpt
-    - goimports
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
     - revive
     - staticcheck
-    - typecheck
     - unused
     - whitespace
+  settings:
+    gocritic:
+      enabled-tags:
+        - performance
+    lll:
+      line-length: 200
+    misspell:
+      locale: US
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
Upgrades golangci-lint version in workflow to v2.0.2
Migrates golangci-lint config to version v2 (migration guide can be found here: https://golangci-lint.run/product/migration-guide/)

Closes #993