### PR TITLE
feat: add multi arch command changes

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,5 +1,9 @@
 package types
 
+import (
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
 type UpdatePackage struct {
 	Name             string `json:"name"`
 	InstalledVersion string `json:"installedVersion"`
@@ -14,4 +18,17 @@ type UpdateManifest struct {
 	OSVersion string         `json:"osVersion"`
 	Arch      string         `json:"arch"`
 	Updates   UpdatePackages `json:"updates"`
+}
+
+// PatchPlatform is an extension of ispec.Platform but with a reportFile.
+type PatchPlatform struct {
+	ispec.Platform
+	ReportFile string `json:"reportFile"`
+}
+
+// PatchResult represents the result of a single arch patch operation.
+type PatchResult struct {
+	OriginalImage string
+	PatchedImage  string
+	Digest        string
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"context"
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -51,4 +53,21 @@ func GetProxy() llb.ProxyEnv {
 		AllProxy:   getEnvAny("HTTP_PROXY"),
 	}
 	return proxy
+}
+
+func GetLocalImageDigest(ctx context.Context, imageRef string) (string, error) {
+	cli, err := newClient()
+	if err != nil {
+		return "", err
+	}
+	defer cli.Close()
+
+	distInspect, err := cli.ImageInspect(ctx, imageRef)
+	if err != nil {
+		return "", err
+	}
+	if distInspect.Descriptor == nil {
+		return "", errors.New("descriptor is nil")
+	}
+	return distInspect.Descriptor.Digest.String(), nil
 }


### PR DESCRIPTION
- added QemuAvailable() + mapGoArch() helpers to detect binfmt/qemu support for cross-arch builds.
- new helpers for multiarch work:
  - archDigest, archTag(), dockerImageDigest(), createManifestCLI() and normalizeConfigForPlatform()
- split the monolithic patchWithContext() into:
  - patchSingleArchImage() - one arch at a time (returns *types.PatchResult).
  - patchMultiArchImage() - fan-out, run builds in parallel, then stitch a manifest list.
- added new types:
  - PatchPlatform: OCI platform + report path
  - PatchResult: original image, patched ref, digest
- added argument validation: can't pass both report-file and report-dir

Closes #988
