### PR TITLE
fix: guard against error buildkit solve

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -41,6 +41,11 @@ const (
 	defaultTag      = "latest"
 )
 
+// for testing.
+var (
+	bkNewClient = buildkit.NewClient
+)
+
 // Patch command applies package updates to an OCI image given a vulnerability report.
 func Patch(
 	ctx context.Context, timeout time.Duration,
@@ -135,7 +140,7 @@ func patchWithContext(ctx context.Context, ch chan error, image, reportFile, rep
 		log.Debugf("updates to apply: %v", updates)
 	}
 
-	bkClient, err := buildkit.NewClient(ctx, bkOpts)
+	bkClient, err := bkNewClient(ctx, bkOpts)
 	if err != nil {
 		return err
 	}
@@ -313,7 +318,7 @@ func patchWithContext(ctx context.Context, ch chan error, image, reportFile, rep
 		}, buildChannel)
 
 		// Currently can only validate updates if updating via scanner
-		if reportFile != "" && validatedManifest != nil {
+		if err == nil && solveResponse != nil && reportFile != "" && validatedManifest != nil {
 			digest := solveResponse.ExporterResponse[exptypes.ExporterImageDigestKey]
 			nameDigestOrTag := getRepoNameWithDigest(patchedImageName, digest)
 			// vex document must contain at least one statement


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Add nil pointer dereference guard to buildkit solve response
Add regression test

Closes #1036 
