### PR TITLE
chore: Fix some issues with docker and buildx connections

### DIFF
--- a/pkg/buildkit/connhelpers/docker.go
+++ b/pkg/buildkit/connhelpers/docker.go
@@ -1,12 +1,19 @@
 package connhelpers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
+	"strings"
 
 	"github.com/cpuguy83/go-docker/transport"
 	"github.com/cpuguy83/go-docker/version"
@@ -35,7 +42,85 @@ func getDockerTransport(addr string) (transport.Doer, error) {
 		addr = os.Getenv("DOCKER_HOST")
 	}
 	if addr == "" {
-		return transport.DefaultTransport()
+		var err error
+		addr, err = AddrFromDockerContext()
+		if err != nil {
+			if errors.Is(err, errNoDockerContext) {
+				return transport.DefaultTransport()
+			}
+			return nil, fmt.Errorf("error getting docker context: %w", err)
+		}
+	}
+
+	if !strings.Contains(addr, "://") {
+		// This is probably a docker context name
+		var err error
+		addr, err = addrFromContext(addr)
+		if err != nil {
+			return nil, fmt.Errorf("error getting docker context %q: %w", addr, err)
+		}
 	}
 	return transport.FromConnectionString(addr)
+}
+
+var errNoDockerContext = fmt.Errorf("no docker context found")
+
+func addrFromContext(name string) (string, error) {
+	cmd := exec.Command("docker", "context", "inspect", name, "--format", "{{.Endpoints.docker.Host}}")
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("error inspecting docker context %q: %w: %s", name, err, out)
+	}
+
+	addr := strings.TrimSpace(string(out))
+	return addr, nil
+}
+
+func AddrFromDockerContext() (_ string, retErr error) {
+	cmd := exec.Command("docker", "context", "ls", "--format", "json")
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("error creating stdout pipe: %w", err)
+	}
+	defer stdout.Close()
+
+	stderr := bytes.NewBuffer((nil))
+	cmd.Stderr = stderr
+
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("error starting docker context ls: %w", err)
+	}
+
+	defer func() {
+
+		err := cmd.Wait()
+		if retErr == nil {
+			retErr = err
+			return
+		}
+		retErr = fmt.Errorf("%w: %w: %s", err, retErr, stderr)
+	}()
+
+	type contextEntry struct {
+		Endpoint string `json:"DockerEndpoint"`
+		Current  bool   `json:"Current"`
+	}
+
+	var entry contextEntry
+
+	dec := json.NewDecoder(stdout)
+	for {
+		if err := dec.Decode(&entry); err != nil {
+			if err == io.EOF {
+				return "", errNoDockerContext
+			}
+			return "", fmt.Errorf("error decoding docker context ls output: %w", err)
+		}
+
+		if entry.Current {
+			return entry.Endpoint, nil
+		}
+	}
 }

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -485,7 +485,8 @@ func getOSVersion(ctx context.Context, osreleaseBytes []byte) (string, error) {
 
 func newDockerClient() (dockerClient.APIClient, error) {
 	hostOpt := func(c *dockerClient.Client) error {
-		if os.Getenv("DOCKER_HOST") != "" {
+		if os.Getenv(dockerClient.EnvOverrideHost) != "" {
+			// Fallback to just keep dockerClient.FromEnv whatever was set from
 			return nil
 		}
 		addr, err := connhelpers.AddrFromDockerContext()
@@ -493,8 +494,7 @@ func newDockerClient() (dockerClient.APIClient, error) {
 			log.WithError(err).Error("Error loading docker context, falling back to env")
 			return nil
 		}
-		dockerClient.WithHost(addr)(c)
-		return nil
+		return dockerClient.WithHost(addr)(c)
 	}
 
 	cli, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv, hostOpt, dockerClient.WithAPIVersionNegotiation())

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -28,6 +28,7 @@ import (
 	"github.com/moby/buildkit/session/auth/authprovider"
 	"github.com/moby/buildkit/util/progress/progressui"
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
+	"github.com/project-copacetic/copacetic/pkg/buildkit/connhelpers"
 	"github.com/project-copacetic/copacetic/pkg/pkgmgr"
 	"github.com/project-copacetic/copacetic/pkg/report"
 	"github.com/project-copacetic/copacetic/pkg/types/unversioned"
@@ -483,7 +484,20 @@ func getOSVersion(ctx context.Context, osreleaseBytes []byte) (string, error) {
 }
 
 func newDockerClient() (dockerClient.APIClient, error) {
-	cli, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv, dockerClient.WithAPIVersionNegotiation())
+	hostOpt := func(c *dockerClient.Client) error {
+		if os.Getenv("DOCKER_HOST") != "" {
+			return nil
+		}
+		addr, err := connhelpers.AddrFromDockerContext()
+		if err != nil {
+			log.WithError(err).Error("Error loading docker context, falling back to env")
+			return nil
+		}
+		dockerClient.WithHost(addr)(c)
+		return nil
+	}
+
+	cli, err := dockerClient.NewClientWithOpts(dockerClient.FromEnv, hostOpt, dockerClient.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create docker client: %w", err)
 	}


### PR DESCRIPTION
1. Get the docker addr from "docker context ls" when `DOCKER_HOST` is not set
2. Fix issue when buildx metadata specifies a docker context name rather than a docker connection string
3. Add support for `buildx dial-stdio` which will proxy connections to buildkit for us rather than manually setting up the connection.

This makes it so `copa` works with Docker Desktop out of the box (no extra settings need to be changed).
It also removes the limitation on the type of buildx instances it can connect to when the installed buildx supports the "dial-stdio" command (which has been around for awhile now).

Closes #543