### PR TITLE
docs: Clarify no VEX Document generation with update all

### DIFF
--- a/website/versioned_docs/version-v0.10.x/output.md
+++ b/website/versioned_docs/version-v0.10.x/output.md
@@ -29,6 +29,11 @@ To generate a VEX document using OpenVEX, use `--format="openvex"` flag, and use
 ```bash
 copa patch -i docker.io/library/nginx:1.21.6 -r nginx.1.21.6.json -t 1.21.6-patched --format="openvex" --output "nginx.1.21.6-vex.json"
 ```
+:::warning[note]
+
+VEX output requires a vulnerability report. If `-r <report_file>` flag (the "update all" mode) is not specified, no VEX document is generated.
+
+:::
 
 This will generate a VEX Document that looks like:
 


### PR DESCRIPTION
fixes: #744

This PR adds a clarification note to the VEX output documentation. I've added this as a separate `:::note` admonition, as this felt clearer than incorporating it into the existing `:::tip`. 
Please let me know if any changes are needed!

