### PR TITLE
fix: add shorthand flag for report-dir

### DIFF
--- a/pkg/patch/cmd.go
+++ b/pkg/patch/cmd.go
@@ -77,7 +77,7 @@ func NewPatchCmd() *cobra.Command {
 	flags.BoolVar(&ua.ignoreError, "ignore-errors", false, "Ignore errors and continue patching")
 	flags.StringVarP(&ua.format, "format", "f", "openvex", "Output format, defaults to 'openvex'")
 	flags.StringVarP(&ua.output, "output", "o", "", "Output file path")
-	flags.StringVarP(&ua.reportDirectory, "report-directory", "", "", "Directory with multi-arch report files")
+	flags.StringVarP(&ua.reportDirectory, "report-directory", "d", "", "Directory with multi-arch report files")
 	flags.StringVarP(&ua.platformSpecificErrors, "platform-specific-errors", "", "skip", "Behavior for error in patching any of sub-images for multi-arch patching: 'skip', 'warn', or 'fail'")
 	flags.BoolVarP(&ua.push, "push", "p", false, "Push patched image to destination registry")
 


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Since report-directory flag had no shorthand, it was putting it under "-r" by default which was confusing with the report-file. Changes shorthand flag to `-d`  for report directory.

```
copa patch --help                             
Patch container images with upgrade packages specified by a vulnerability report

Usage:
  copa patch [flags]

Examples:
copa patch -i images/python:3.7-alpine -r trivy.json -t 3.7-alpine-patched

Flags:
  -a, --addr string                       Address of buildkitd service, defaults to local docker daemon with fallback to unix:///run/buildkit/buildkitd.sock
      --cacert string                     Absolute path to buildkitd CA certificate
      --cert string                       Absolute path to buildkit client certificate
  -f, --format string                     Output format, defaults to 'openvex' (default "openvex")
  -h, --help                              help for patch
      --ignore-errors                     Ignore errors and continue patching
  -i, --image string                      Application image name and tag to patch
      --key string                        Absolute path to buildkit client key
  -o, --output string                     Output file path
      --platform-specific-errors string   Behavior for error in patching any of sub-images for multi-arch patching: 'skip', 'warn', or 'fail' (default "skip")
  -p, --push                              Push patched image to destination registry
  -r, --report string                     Vulnerability report file path
      --report-directory string           Directory with multi-arch report files
  -s, --scanner string                    Scanner used to generate the report, defaults to 'trivy' (default "trivy")
  -t, --tag string                        Tag for the patched image
      --tag-suffix string                 Suffix for the patched image (if no explicit --tag provided) (default "patched")
      --timeout duration                  Timeout for the operation, defaults to '5m' (default 5m0s)
  -w, --working-folder string             Working folder, defaults to system temp folder
```


Describe the changes in this pull request using active verbs such as _Add_, _Remove_, _Replace_ ...

Closes #<_issue_ID_>
