### PR TITLE
feat: Add flag to specify custom apk config path

### DIFF
--- a/pkg/patch/cmd.go
+++ b/pkg/patch/cmd.go
@@ -30,6 +30,7 @@ type patchArgs struct {
 	bkOpts                 buildkit.Opts
 	platformSpecificErrors string
 	push                   bool
+	apkConfig              string
 }
 
 func NewPatchCmd() *cobra.Command {
@@ -59,6 +60,7 @@ func NewPatchCmd() *cobra.Command {
 				ua.output,
 				ua.ignoreError,
 				ua.push,
+				ua.apkConfig,
 				bkopts)
 		},
 	}
@@ -80,6 +82,7 @@ func NewPatchCmd() *cobra.Command {
 	flags.StringVarP(&ua.reportDirectory, "report-directory", "", "", "Directory with multi-arch report files")
 	flags.StringVarP(&ua.platformSpecificErrors, "platform-specific-errors", "", "skip", "Behavior for error in patching any of sub-images for multi-arch patching: 'skip', 'warn', or 'fail'")
 	flags.BoolVarP(&ua.push, "push", "p", false, "Push patched image to destination registry")
+	flags.StringVarP(&ua.apkConfig, "apk-config", "", "", "Path to custom APK configuration file")
 
 	if err := patchCmd.MarkFlagRequired("image"); err != nil {
 		panic(err)

--- a/pkg/pkgmgr/apk.go
+++ b/pkg/pkgmgr/apk.go
@@ -20,6 +20,7 @@ import (
 type apkManager struct {
 	config        *buildkit.Config
 	workingFolder string
+	configPath    string
 }
 
 // Depending on go-apk-version lib for APK version comparison rules.
@@ -126,6 +127,17 @@ func (am *apkManager) InstallUpdates(ctx context.Context, manifest *unversioned.
 		}
 		// add validation in the future
 		return updatedImageState, nil, nil
+	}
+
+	imageStateCurrent := am.config.ImageState
+	if am.configPath != "" {
+		imageStateCurrent = imageStateCurrent.File(
+			llb.Mkfile{
+				"/etc/apk/repositories",
+				0644, // is this permission correct
+				[]byte(readFile(am.configPath))
+			}
+		)
 	}
 
 	// Resolve set of unique packages to update

--- a/pkg/pkgmgr/apk_test.go
+++ b/pkg/pkgmgr/apk_test.go
@@ -270,6 +270,17 @@ func Test_InstallUpdates_APK(t *testing.T) {
 			expectedPkgs:  []string{"package1"},
 			expectedError: "",
 		},
+		{
+			name: "Use Custom APK config path",
+			manifest: nil
+			ignoreErrors: false
+			mockSetup: nil
+			expectedState: false
+			expectedPkgs: nil
+			expectedError: nil
+			
+
+		}
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add --apk-config flag to specify the config path for apk manager.

To solve the issue I considered doing the following please guide me through the changes I need to make:
- Added the functionality to get path string from the user
- Modified the apk manager structure to include configPath
- Modified patch.go to store apkConfig string to configPath
- Also changed install updated in apk.go to add  the config path to /etc/apk/repositories path.

I will complete writing tests after receiving feedback on the present work and propagate with the development of the code to get a clear picture of what I need to test. I created this PR to get guidance on my approach of solving this issue.

Closes #597 
