### PR TITLE
feat: handle update all and local manifests for multi-arch patching

### DIFF
--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -153,15 +153,6 @@ func isSupportedOsType(osType string) bool {
 	}
 }
 
-// Represents a platform manifest entry
-type manifestEntry struct {
-	Platform struct {
-		Architecture string `json:"architecture"`
-		OS           string `json:"os"`
-		Variant      string `json:"variant,omitempty"`
-	} `json:"platform"`
-}
-
 // DiscoverPlatformsFromReference discovers platforms from either a remote or local image reference
 func DiscoverPlatformsFromReference(manifestRef string) ([]types.PatchPlatform, error) {
 	// using CLI allows us to check for local manifest lists in addition to remote, but these local manifest lists have references to remote images
@@ -169,10 +160,10 @@ func DiscoverPlatformsFromReference(manifestRef string) ([]types.PatchPlatform, 
 	output, err := cmd.Output()
 	if err != nil {
 		// check docker image inspect
-		cmd := exec.Command("docker", "manifest", "inspect", manifestRef)
+		cmd := exec.Command("docker", "image", "inspect", manifestRef)
 		_, err := cmd.Output()
 		if err == nil {
-			// this is a single image manifest, not a manifest list
+			// this is a single image reference, not a manifest list
 			return nil, nil
 		}
 		return nil, fmt.Errorf("no image or manifest list found: %w", err)


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Wanted feedback on if we want a flag to specify multi-architecture patching? Right now, if no reportFile or reportDirectory is provided, it checks if it is a manifest list or a single arch image and patches it accordingly.

Describe the changes in this pull request using active verbs such as _Add_, _Remove_, _Replace_ ...

Closes #1071
