### PR TITLE
feat: Add Multi Arch Enhancements

### DIFF
--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -209,6 +209,15 @@ func DiscoverPlatformsFromReference(manifestRef string) ([]types.PatchPlatform, 
 	return nil, nil
 }
 
+func PlatformKey(pl ispec.Platform) string {
+	// if platform is present in list from reference and report, then we should patch that platform
+	key := pl.OS + "/" + pl.Architecture
+	if pl.Variant != "" {
+		key += "/" + pl.Variant
+	}
+	return key
+}
+
 func DiscoverPlatforms(manifestRef, reportDir, scanner string) ([]types.PatchPlatform, error) {
 	var platforms []types.PatchPlatform
 
@@ -228,18 +237,13 @@ func DiscoverPlatforms(manifestRef, reportDir, scanner string) ([]types.PatchPla
 		}
 		log.WithField("platforms", p2).Debug("Discovered platforms from report")
 
-		// if platform is present in list from reference and report, then we should patch that platform
-		key := func(pl ispec.Platform) string {
-			return pl.OS + "/" + pl.Architecture + "/" + pl.Variant
-		}
-
 		reportSet := make(map[string]string, len(p2))
 		for _, pl := range p2 {
-			reportSet[key(pl.Platform)] = pl.ReportFile
+			reportSet[PlatformKey(pl.Platform)] = pl.ReportFile
 		}
 
 		for _, pl := range p {
-			if rp, ok := reportSet[key(pl.Platform)]; ok {
+			if rp, ok := reportSet[PlatformKey(pl.Platform)]; ok {
 				pl.ReportFile = rp
 				platforms = append(platforms, pl)
 			}

--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -209,6 +209,7 @@ func DiscoverPlatformsFromReference(manifestRef string) ([]types.PatchPlatform, 
 	return nil, nil
 }
 
+//nolint:gocritic
 func PlatformKey(pl ispec.Platform) string {
 	// if platform is present in list from reference and report, then we should patch that platform
 	key := pl.OS + "/" + pl.Architecture

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -774,10 +774,7 @@ func patchMultiPlatformImage(
 	for _, p := range platforms {
 		// rebind
 		p := p //nolint
-		platformKey := p.OS + "/" + p.Architecture
-		if p.Variant != "" {
-			platformKey += "/" + p.Variant
-		}
+		platformKey := buildkit.PlatformKey(p.Platform)
 		g.Go(func() error {
 			select {
 			case sem <- struct{}{}:
@@ -872,10 +869,7 @@ func patchMultiPlatformImage(
 	fmt.Fprintln(w, "PLATFORM\tSTATUS\tREFERENCE\tERROR")
 
 	for _, p := range platforms {
-		platformKey := p.OS + "/" + p.Architecture
-		if p.Variant != "" {
-			platformKey += "/" + p.Variant
-		}
+		platformKey := buildkit.PlatformKey(p.Platform)
 		s := summaryMap[platformKey]
 		if s != nil {
 			ref := s.Ref

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -785,6 +785,7 @@ func patchMultiPlatformImage(
 
 			res, err := patchSingleArchImage(gctx, ch, image, p.ReportFile, patchedTag, suffix, workingFolder, scanner, format, output, p, ignoreError, push, bkOpts, true)
 			mu.Lock()
+			defer mu.Unlock()
 			if err != nil {
 				status := "Error"
 				if ignoreError {
@@ -795,6 +796,9 @@ func patchMultiPlatformImage(
 					Status:   status,
 					Ref:      "",
 					Error:    err.Error(),
+				}
+				if !ignoreError {
+					return err
 				}
 				return nil
 			} else if res == nil {
@@ -814,7 +818,6 @@ func patchMultiPlatformImage(
 				Ref:      res.PatchedRef.String(),
 				Error:    "",
 			}
-			mu.Unlock()
 			log.Infof("Patched image (%s): %s\n", p.OS+"/"+p.Architecture, res.PatchedRef.String())
 			return nil
 		})

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -879,7 +879,7 @@ func patchMultiPlatformImage(
 
 	var b strings.Builder
 	w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "PLATFORM\tSTATUS\tREFERNCE\tERROR")
+	fmt.Fprintln(w, "PLATFORM\tSTATUS\tREFERENCE\tERROR")
 
 	for _, p := range platforms {
 		platformKey := p.OS + "/" + p.Architecture

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -769,14 +769,6 @@ func patchMultiPlatformImage(
 	var mu sync.Mutex
 	patchResults := []types.PatchResult{}
 
-	handlePlatformErr := func(p types.PatchPlatform, err error) error {
-		if ignoreError {
-			log.Warnf("Ignoring error for platform %s: %v", p.OS+"/"+p.Architecture, err)
-			return nil
-		}
-		log.Warnf("Error for platform %s: %v", p.OS+"/"+p.Architecture, err)
-		return fmt.Errorf("platform %s failed: %w", p.OS+"/"+p.Architecture, err)
-	}
 	summaryMap := make(map[string]*types.MultiArchSummary)
 
 	for _, p := range platforms {
@@ -798,9 +790,7 @@ func patchMultiPlatformImage(
 			mu.Lock()
 			if err != nil {
 				status := "Error"
-				if platformSpecificErrors == "skip" {
-					status = "Skipped"
-				} else if platformSpecificErrors == "ignore" {
+				if ignoreError {
 					status = "Ignored"
 				}
 				summaryMap[platformKey] = &types.MultiArchSummary{

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	buildkitclient "github.com/moby/buildkit/client"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestRemoveIfNotDebug(t *testing.T) {
@@ -607,7 +608,7 @@ func TestMultiArchSummaryTable(t *testing.T) {
 		},
 		"linux/arm/v7": {
 			Platform: "linux/arm/v7",
-			Status:   "Skipped",
+			Status:   "Ignored",
 			Ref:      "",
 			Error:    "",
 		},
@@ -617,10 +618,11 @@ func TestMultiArchSummaryTable(t *testing.T) {
 	w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
 	_, _ = w.Write([]byte("PLATFORM\tSTATUS\tREFERENCE\tERROR\n"))
 	for _, p := range platforms {
-		platformKey := p.OS + "/" + p.Architecture
-		if p.Variant != "" {
-			platformKey += "/" + p.Variant
-		}
+		platformKey := buildkit.PlatformKey(ispec.Platform{
+			OS:           p.OS,
+			Architecture: p.Architecture,
+			Variant:      p.Variant,
+		})
 		s := summaryMap[platformKey]
 		if s != nil {
 			ref := s.Ref
@@ -638,7 +640,7 @@ func TestMultiArchSummaryTable(t *testing.T) {
 	expected := `PLATFORM      STATUS   REFERENCE                              ERROR
 linux/amd64   Patched  docker.io/library/nginx:patched-amd64  
 linux/arm64   Error    -                                      emulation is not enabled for platform linux/arm64
-linux/arm/v7  Skipped  -                                      
+linux/arm/v7  Ignored  -                                      
 `
 
 	if got != expected {

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"text/tabwriter"
 	"time"
 
 	"github.com/distribution/reference"
@@ -577,5 +578,70 @@ func TestNormalizeConfigForPlatform(t *testing.T) {
 	}
 	if _, ok := m2["variant"]; ok {
 		t.Errorf("variant key should be dropped when empty")
+	}
+}
+
+func TestMultiArchSummaryTable(t *testing.T) {
+	platforms := []struct {
+		OS           string
+		Architecture string
+		Variant      string
+	}{
+		{"linux", "amd64", ""},
+		{"linux", "arm64", ""},
+		{"linux", "arm", "v7"},
+	}
+
+	summaryMap := map[string]*types.MultiArchSummary{
+		"linux/amd64": {
+			Platform: "linux/amd64",
+			Status:   "Patched",
+			Ref:      "docker.io/library/nginx:patched-amd64",
+			Error:    "",
+		},
+		"linux/arm64": {
+			Platform: "linux/arm64",
+			Status:   "Error",
+			Ref:      "",
+			Error:    "emulation is not enabled for platform linux/arm64",
+		},
+		"linux/arm/v7": {
+			Platform: "linux/arm/v7",
+			Status:   "Skipped",
+			Ref:      "",
+			Error:    "",
+		},
+	}
+
+	var b strings.Builder
+	w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+	_, _ = w.Write([]byte("PLATFORM\tSTATUS\tREFERENCE\tERROR\n"))
+	for _, p := range platforms {
+		platformKey := p.OS + "/" + p.Architecture
+		if p.Variant != "" {
+			platformKey += "/" + p.Variant
+		}
+		s := summaryMap[platformKey]
+		if s != nil {
+			ref := s.Ref
+			if ref == "" {
+				ref = "-"
+			}
+			_, _ = w.Write([]byte(
+				s.Platform + "\t" + s.Status + "\t" + ref + "\t" + s.Error + "\n",
+			))
+		}
+	}
+	w.Flush()
+
+	got := b.String()
+	expected := `PLATFORM      STATUS   REFERENCE                              ERROR
+linux/amd64     Patched  docker.io/library/nginx:patched-amd64  
+linux/arm64     Error    -                                      emulation is not enabled for platform linux/arm64
+linux/arm/v7    Skipped  -                                      
+`
+
+	if got != expected {
+		t.Errorf("summary table output mismatch:\ngot:\n%s\nwant:\n%s", got, expected)
 	}
 }

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -636,9 +636,9 @@ func TestMultiArchSummaryTable(t *testing.T) {
 
 	got := b.String()
 	expected := `PLATFORM      STATUS   REFERENCE                              ERROR
-linux/amd64     Patched  docker.io/library/nginx:patched-amd64  
-linux/arm64     Error    -                                      emulation is not enabled for platform linux/arm64
-linux/arm/v7    Skipped  -                                      
+linux/amd64   Patched  docker.io/library/nginx:patched-amd64  
+linux/arm64   Error    -                                      emulation is not enabled for platform linux/arm64
+linux/arm/v7  Skipped  -                                      
 `
 
 	if got != expected {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -41,3 +41,10 @@ type PatchResult struct {
 	PatchedDesc *ispec.Descriptor
 	PatchedRef  reference.Named
 }
+
+type MultiArchSummary struct {
+	Platform string
+	Status   string
+	Ref      string
+	Error    string
+}


### PR DESCRIPTION
Added table summary for Multi-Arch Patching with Platform, Status, Ref, Error as fields. Wanted feedback on how can I test this code. I'm confused on how to simulate multi-arch patching locally using docker and trivy to test the credibility and making sure the logs are as expected.
Please review the code and let me know this is how we wanted the logs to look. Thanks!

closes: #992
