### PR TITLE
fix: retain multiplatform manifest list annotations

### DIFF
--- a/integration/multiarch/fixtures/test-images.json
+++ b/integration/multiarch/fixtures/test-images.json
@@ -36,6 +36,7 @@
     "description": "Multi-platform .NET 6.0 runtime, with push",
     "ignoreErrors": false,
     "push": true,
+    "skipAnnotations": true,
     "platforms": [
       "linux/arm/v7",
       "linux/arm64"

--- a/integration/multiarch/patch_test.go
+++ b/integration/multiarch/patch_test.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/project-copacetic/copacetic/integration/common"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/project-copacetic/copacetic/integration/common"
 	"github.com/project-copacetic/copacetic/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -388,8 +388,8 @@ func verifyAnnotations(t *testing.T, patchedRef string, platforms []string, repo
 
 	// Check index-level annotations (Copa metadata)
 	assert.NotEmpty(t, manifest.Annotations, "index-level annotations should not be empty")
-	assert.Equal(t, "true", manifest.Annotations["copacetic.patched"], "should have Copa patched annotation")
-	assert.NotEmpty(t, manifest.Annotations["copacetic.patched.timestamp"], "should have Copa timestamp annotation")
+	assert.Equal(t, "true", manifest.Annotations["sh.copa.patched"], "should have Copa patched annotation")
+	assert.NotEmpty(t, manifest.Annotations["sh.copa.patched.timestamp"], "should have Copa timestamp annotation")
 	assert.NotEmpty(t, manifest.Annotations["org.opencontainers.image.created"], "should have created annotation")
 
 	t.Logf("found %d index-level annotations", len(manifest.Annotations))

--- a/integration/multiarch/patch_test.go
+++ b/integration/multiarch/patch_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -13,6 +14,9 @@ import (
 	"testing"
 
 	"github.com/project-copacetic/copacetic/integration/common"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/project-copacetic/copacetic/pkg/utils"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,6 +85,11 @@ func TestPatch(t *testing.T) {
 
 			t.Log("patching image with multiple architectures")
 			patchMultiPlatform(t, ref, tagPatched, reportDir, img.IgnoreErrors, img.Push)
+
+			if img.Push {
+				t.Log("verifying OCI annotations are preserved")
+				verifyAnnotations(t, patchedRef, img.Platforms, reportDir)
+			}
 
 			t.Log("scanning patched image for each platform")
 			wg = sync.WaitGroup{}
@@ -339,4 +348,165 @@ func copyImage(t *testing.T, src, dst string) {
 	cmd.Env = append(cmd.Env, common.DockerDINDAddress.Env()...)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, string(out))
+}
+
+// ManifestData represents the JSON structure returned by docker buildx imagetools inspect.
+type ManifestData struct {
+	Annotations map[string]string `json:"annotations"`
+	Manifests   []ManifestEntry   `json:"manifests"`
+}
+
+type ManifestEntry struct {
+	Platform    PlatformInfo      `json:"platform"`
+	Annotations map[string]string `json:"annotations"`
+}
+
+type PlatformInfo struct {
+	Architecture string `json:"architecture"`
+	OS           string `json:"os"`
+	Variant      string `json:"variant,omitempty"`
+}
+
+// verifyAnnotations checks that Copa properly preserves OCI annotations.
+// This function verifies:
+// 1. Index-level annotations: Copa metadata (copacetic.patched, timestamps)
+// 2. Manifest-level annotations: Original platform-specific annotations are preserved
+// 3. Updated timestamps: Patched platforms get updated creation timestamps.
+func verifyAnnotations(t *testing.T, patchedRef string, platforms []string, reportDir string) {
+	t.Log("checking index-level annotations")
+
+	// Get the raw manifest using docker buildx imagetools
+	cmd := exec.Command("docker", "buildx", "imagetools", "inspect", patchedRef, "--raw")
+	cmd.Env = append(cmd.Env, os.Environ()...)
+	cmd.Env = append(cmd.Env, common.DockerDINDAddress.Env()...)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "failed to inspect patched image: %s", string(out))
+
+	var manifest ManifestData
+	err = json.Unmarshal(out, &manifest)
+	require.NoError(t, err, "failed to parse manifest JSON")
+
+	// Check index-level annotations (Copa metadata)
+	assert.NotEmpty(t, manifest.Annotations, "index-level annotations should not be empty")
+	assert.Equal(t, "true", manifest.Annotations["copacetic.patched"], "should have Copa patched annotation")
+	assert.NotEmpty(t, manifest.Annotations["copacetic.patched.timestamp"], "should have Copa timestamp annotation")
+	assert.NotEmpty(t, manifest.Annotations["org.opencontainers.image.created"], "should have created annotation")
+
+	t.Logf("found %d index-level annotations", len(manifest.Annotations))
+
+	// Check manifest-level annotations for each platform
+	t.Log("checking manifest-level annotations for patched platforms")
+
+	for _, manifestEntry := range manifest.Manifests {
+		platformStr := formatPlatform(manifestEntry.Platform)
+
+		// Only check platforms that actually have vulnerability reports (were patched)
+		if isPatchablePlatform(platformStr, platforms, reportDir) {
+			t.Logf("checking manifest annotations for patched platform %s", platformStr)
+
+			// Verify that if original nginx annotations exist, they are preserved
+			commonAnnotations := []string{
+				"org.opencontainers.image.source",
+				"org.opencontainers.image.url",
+				"org.opencontainers.image.version",
+				"org.opencontainers.image.revision",
+				"org.opencontainers.image.base.name",
+				"org.opencontainers.image.base.digest",
+			}
+
+			foundAnnotations := 0
+			for _, expectedKey := range commonAnnotations {
+				if value, exists := manifestEntry.Annotations[expectedKey]; exists {
+					assert.NotEmpty(t, value, "annotation %s should not be empty for platform %s", expectedKey, platformStr)
+					t.Logf("platform %s has annotation %s=%s", platformStr, expectedKey, value)
+					foundAnnotations++
+				}
+			}
+
+			// We expect at least some annotations to be preserved for nginx images
+			assert.Greater(t, foundAnnotations, 0, "platform %s should have at least some preserved annotations", platformStr)
+
+			// The created timestamp should be updated for patched platforms
+			if createdTime, exists := manifestEntry.Annotations["org.opencontainers.image.created"]; exists {
+				assert.NotEmpty(t, createdTime, "created timestamp should not be empty for patched platform %s", platformStr)
+				t.Logf("platform %s has updated created timestamp: %s", platformStr, createdTime)
+			}
+
+			t.Logf("platform %s has %d manifest-level annotations", platformStr, len(manifestEntry.Annotations))
+
+			// Verify that ALL original annotations are preserved
+			// Get the original image reference
+			originalRef := strings.Replace(patchedRef, "-patched", "", 1)
+
+			// Get original platform annotations
+			// Create platform object from manifestEntry
+			platform := &ocispec.Platform{
+				OS:           manifestEntry.Platform.OS,
+				Architecture: manifestEntry.Platform.Architecture,
+				Variant:      manifestEntry.Platform.Variant,
+			}
+			originalAnnotations, err := utils.GetPlatformManifestAnnotations(context.Background(), originalRef, platform)
+			require.NoError(t, err, "failed to get original annotations for platform %s", platformStr)
+
+			// Check that every original annotation is present in the patched manifest
+			// Some annotations are expected to change during patching
+			annotationsThatChange := map[string]bool{
+				"org.opencontainers.image.created": true,
+				"org.opencontainers.image.version": true,
+			}
+
+			for key, originalValue := range originalAnnotations {
+				patchedValue, exists := manifestEntry.Annotations[key]
+				assert.True(t, exists, "original annotation %s is missing in patched manifest for platform %s", key, platformStr)
+
+				if exists && !annotationsThatChange[key] {
+					// For annotations that shouldn't change, verify the values are equal
+					assert.Equal(t, originalValue, patchedValue, "annotation %s value changed for platform %s: original=%s, patched=%s", key, platformStr, originalValue, patchedValue)
+				}
+			}
+
+			t.Logf("verified %d original annotations are preserved for platform %s", len(originalAnnotations), platformStr)
+		} else {
+			t.Logf("skipping platform %s (no vulnerability report, not patched)", platformStr)
+		}
+	}
+}
+
+// formatPlatform creates a platform string from PlatformInfo.
+func formatPlatform(p PlatformInfo) string {
+	platform := p.OS + "/" + p.Architecture
+	if p.Variant != "" {
+		platform += "/" + p.Variant
+	}
+	return platform
+}
+
+// isPatchablePlatform checks if a platform actually has a vulnerability report file
+// and therefore should have been patched by Copa.
+func isPatchablePlatform(platform string, allPlatforms []string, reportDir string) bool {
+	// First verify this platform is in the test's platform list
+	found := false
+	for _, testPlatform := range allPlatforms {
+		if testPlatform == platform {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return false
+	}
+
+	// Check if a vulnerability report exists for this platform
+	// Report files are named like "report-linux-amd64.json"
+	suffix := strings.ReplaceAll(platform, "/", "-")
+	reportPath := filepath.Join(reportDir, "report-"+suffix+".json")
+
+	// Check if the report file exists and is not empty
+	if info, err := os.Stat(reportPath); err == nil && info.Size() > 0 {
+		// A non-empty vulnerability report exists, so this platform should be patched
+		return true
+	}
+
+	// No vulnerability report or empty report means platform was not patched
+	return false
 }

--- a/integration/multiarch/patch_test.go
+++ b/integration/multiarch/patch_test.go
@@ -23,6 +23,8 @@ import (
 //go:embed fixtures/test-images.json
 var testImages []byte
 
+const lastPatchedAnnotation = "sh.copa.image.patched"
+
 type testImage struct {
 	OriginalImage   string   `json:"originalImage"`
 	LocalImage      string   `json:"localImage"`
@@ -409,11 +411,11 @@ func verifyAnnotations(t *testing.T, patchedRef string, platforms []string, repo
 				t.Logf("platform %s has updated created timestamp: %s", platformStr, createdTime)
 			}
 
-			// Check for Copa last.patched annotation on patched platforms
-			lastPatched, exists := manifestEntry.Annotations["sh.copa.last.patched"]
-			assert.True(t, exists, "patched platform %s should have sh.copa.last.patched annotation", platformStr)
-			assert.NotEmpty(t, lastPatched, "sh.copa.last.patched timestamp should not be empty for patched platform %s", platformStr)
-			t.Logf("platform %s has Copa last.patched timestamp: %s", platformStr, lastPatched)
+			// Check for Copa image.patched annotation on patched platforms
+			lastPatched, exists := manifestEntry.Annotations[lastPatchedAnnotation]
+			assert.True(t, exists, "patched platform %s should have %s annotation", platformStr, lastPatchedAnnotation)
+			assert.NotEmpty(t, lastPatched, "%s timestamp should not be empty for patched platform %s", lastPatchedAnnotation, platformStr)
+			t.Logf("platform %s has %s timestamp: %s", platformStr, lastPatchedAnnotation, lastPatched)
 
 			t.Logf("platform %s has %d manifest-level annotations", platformStr, len(manifestEntry.Annotations))
 
@@ -452,9 +454,9 @@ func verifyAnnotations(t *testing.T, patchedRef string, platforms []string, repo
 		} else {
 			t.Logf("checking platform %s (no vulnerability report, not patched)", platformStr)
 
-			// Non-patched platforms should NOT have the Copa last.patched annotation
-			_, exists := manifestEntry.Annotations["sh.copa.last.patched"]
-			assert.False(t, exists, "non-patched platform %s should not have sh.copa.last.patched annotation", platformStr)
+			// Non-patched platforms should NOT have the Copa image.patched annotation
+			_, exists := manifestEntry.Annotations[lastPatchedAnnotation]
+			assert.False(t, exists, "non-patched platform %s should not have %s annotation", platformStr, lastPatchedAnnotation)
 		}
 	}
 }

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"maps"
 	"os"
 	"runtime"
 	"strings"
@@ -52,6 +53,7 @@ const (
 	defaultTag      = "latest"
 	LINUX           = "linux"
 	ARM64           = "arm64"
+	trueString      = "true"
 )
 
 // for testing.
@@ -98,10 +100,125 @@ func createMultiPlatformManifest(
 	ctx context.Context,
 	imageName reference.NamedTagged,
 	items []types.PatchResult,
+	originalImage string,
 ) error {
 	resolver := imagetools.New(imagetools.Opt{
 		Auth: config.LoadDefaultConfigFile(os.Stderr),
 	})
+
+	// fetch annotations from the original image
+	annotations := make(map[exptypes.AnnotationKey]string)
+
+	// get the original image index manifest annotations
+	originalAnnotations, err := utils.GetIndexManifestAnnotations(ctx, originalImage)
+	if err != nil {
+		log.Warnf("Failed to get original image annotations: %v", err)
+		// continue without annotations rather than failing
+	} else {
+		log.Infof("Retrieved %d annotations from original image %s", len(originalAnnotations), originalImage)
+		if len(originalAnnotations) > 0 {
+			// copy all annotations from the original image
+			for k, v := range originalAnnotations {
+				// create an AnnotationKey for index level annotations
+				ak := exptypes.AnnotationKey{
+					Type: exptypes.AnnotationIndex,
+					Key:  k,
+				}
+				annotations[ak] = v
+			}
+
+			// update annotations that should reflect the patched state
+			// update the created timestamp to reflect when the patch was applied
+			createdKey := exptypes.AnnotationKey{
+				Type: exptypes.AnnotationIndex,
+				Key:  "org.opencontainers.image.created",
+			}
+			annotations[createdKey] = time.Now().UTC().Format(time.RFC3339)
+
+			// if theres a version annotation, update it to reflect the patched tag
+			versionKey := exptypes.AnnotationKey{
+				Type: exptypes.AnnotationIndex,
+				Key:  "org.opencontainers.image.version",
+			}
+			if version, ok := annotations[versionKey]; ok {
+				// Extract the tag from the patched image name to determine what suffix to use
+				patchedTag := imageName.Tag()
+
+				// Try to determine what was added to the original version
+				// If the patched tag contains the original version, extract the suffix
+				if strings.Contains(patchedTag, version) {
+					// Use the full patched tag as the new version
+					annotations[versionKey] = patchedTag
+				} else {
+					// Fallback: append the patched tag as a suffix
+					annotations[versionKey] = version + "-" + patchedTag
+				}
+			}
+
+			// add a custom annotation to indicate this image was patched by Copa
+			patchedKey := exptypes.AnnotationKey{
+				Type: exptypes.AnnotationIndex,
+				Key:  "copacetic.patched",
+			}
+			annotations[patchedKey] = trueString
+
+			patchedTimestampKey := exptypes.AnnotationKey{
+				Type: exptypes.AnnotationIndex,
+				Key:  "copacetic.patched.timestamp",
+			}
+			annotations[patchedTimestampKey] = time.Now().UTC().Format(time.RFC3339)
+
+			log.Debugf("Preserving %d annotations from original image", len(annotations))
+		} else {
+			log.Info("No annotations found in original image, adding Copa annotations only")
+			// add Copa-specific annotations even if there are no original annotations
+			createdKey := exptypes.AnnotationKey{
+				Type: exptypes.AnnotationIndex,
+				Key:  "org.opencontainers.image.created",
+			}
+			annotations[createdKey] = time.Now().UTC().Format(time.RFC3339)
+
+			patchedKey := exptypes.AnnotationKey{
+				Type: exptypes.AnnotationIndex,
+				Key:  "copacetic.patched",
+			}
+			annotations[patchedKey] = trueString
+
+			patchedTimestampKey := exptypes.AnnotationKey{
+				Type: exptypes.AnnotationIndex,
+				Key:  "copacetic.patched.timestamp",
+			}
+			annotations[patchedTimestampKey] = time.Now().UTC().Format(time.RFC3339)
+		}
+	}
+
+	// add manifest descriptor level annotations for each platform
+	for _, it := range items {
+		if it.PatchedDesc != nil && it.PatchedDesc.Platform != nil {
+			// use annotations that are already preserved in PatchedDesc.Annotations
+			// this works for both patched and pass-through platforms
+			if len(it.PatchedDesc.Annotations) > 0 {
+				// add each annotation as a manifest-descriptor annotation
+				for k, v := range it.PatchedDesc.Annotations {
+					ak := exptypes.AnnotationKey{
+						Type:     exptypes.AnnotationManifestDescriptor,
+						Platform: it.PatchedDesc.Platform,
+						Key:      k,
+					}
+					// for patched platforms, update creation timestamp to reflect patching
+					// for other platforms, preserve original timestamps
+					if k == "org.opencontainers.image.created" && it.PatchedRef != it.OriginalRef {
+						// this is a patched platform, update the timestamp
+						annotations[ak] = time.Now().UTC().Format(time.RFC3339)
+					} else {
+						// this is a platform with preserved or non-timestamp annotation
+						annotations[ak] = v
+					}
+				}
+				log.Debugf("Added %d manifest-descriptor annotations for platform %s", len(it.PatchedDesc.Annotations), platforms.Format(*it.PatchedDesc.Platform))
+			}
+		}
+	}
 
 	// Source references (repo@sha256:digest) – one per architecture.
 	srcRefs := make([]*imagetools.Source, 0, len(items))
@@ -109,13 +226,14 @@ func createMultiPlatformManifest(
 		if it.PatchedDesc == nil {
 			return fmt.Errorf("patched descriptor is nil for %s", it.OriginalRef.String())
 		}
+
 		srcRefs = append(srcRefs, &imagetools.Source{
 			Ref:  it.PatchedRef,
 			Desc: *it.PatchedDesc,
 		})
 	}
 
-	idxBytes, desc, err := resolver.Combine(ctx, srcRefs, map[exptypes.AnnotationKey]string{}, false)
+	idxBytes, desc, err := resolver.Combine(ctx, srcRefs, annotations, false)
 	if err != nil {
 		return fmt.Errorf("failed to combine sources into manifest list: %w", err)
 	}
@@ -620,6 +738,34 @@ func patchSingleArchImage(
 		log.Warnf("failed to get patched image descriptor for platform '%s':  %v", prettyPlatform, err)
 	}
 
+	// if we have a patched descriptor then augment it with original manifest level annotations
+	if patchedDesc != nil {
+		// get the original manifest level annotations for this platform
+		originalAnnotations, err := utils.GetPlatformManifestAnnotations(ctx, image, &ispec.Platform{
+			OS:           targetPlatform.OS,
+			Architecture: targetPlatform.Architecture,
+			Variant:      targetPlatform.Variant,
+		})
+		if err != nil {
+			log.Warnf("Failed to get original manifest level annotations for platform %s: %v", targetPlatform.Platform, err)
+		} else if len(originalAnnotations) > 0 {
+			// create a new descriptor that includes the original manifest level annotations
+			augmentedDesc := *patchedDesc
+			if augmentedDesc.Annotations == nil {
+				augmentedDesc.Annotations = make(map[string]string)
+			}
+
+			// copy original annotations
+			maps.Copy(augmentedDesc.Annotations, originalAnnotations)
+
+			// update creation timestamp to reflect patching
+			augmentedDesc.Annotations["org.opencontainers.image.created"] = time.Now().UTC().Format(time.RFC3339)
+
+			patchedDesc = &augmentedDesc
+			log.Debugf("Preserved %d manifest level annotations for platform %s", len(originalAnnotations), targetPlatform.Platform)
+		}
+	}
+
 	patchedRef, err := reference.ParseNamed(patchedImageName)
 	log.Debugf("Patched image name: %s", patchedImageName)
 	if err != nil {
@@ -860,7 +1006,7 @@ func patchMultiPlatformImage(
 	}
 
 	if push {
-		err = createMultiPlatformManifest(ctx, patchedImageName, patchResults)
+		err = createMultiPlatformManifest(ctx, patchedImageName, patchResults, image)
 		if err != nil {
 			return fmt.Errorf("manifest list creation failed: %w", err)
 		}
@@ -901,7 +1047,7 @@ func patchMultiPlatformImage(
 
 			log.Infof("  docker buildx imagetools create --tag %s %s", patchedImageName.String(), strings.Join(refs, " "))
 		} else {
-			return fmt.Errorf("no patched images were created, check the logs for errors")
+			return fmt.Errorf("no images were processed, check the logs for errors")
 		}
 	}
 

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -7,8 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"maps"
+	"net/url"
 	"os"
 	"runtime"
 	"strings"
@@ -48,12 +48,13 @@ import (
 )
 
 const (
-	copaProduct     = "copa"
-	defaultRegistry = "docker.io"
-	defaultTag      = "latest"
-	LINUX           = "linux"
-	ARM64           = "arm64"
-	trueString      = "true"
+	copaProduct             = "copa"
+	defaultRegistry         = "docker.io"
+	defaultTag              = "latest"
+	LINUX                   = "linux"
+	trueString              = "true"
+	ARM64                   = "arm64"
+	copaAnnotationKeyPrefix = "sh.copa"
 )
 
 // for testing.
@@ -158,13 +159,13 @@ func createMultiPlatformManifest(
 			// add a custom annotation to indicate this image was patched by Copa
 			patchedKey := exptypes.AnnotationKey{
 				Type: exptypes.AnnotationIndex,
-				Key:  "copacetic.patched",
+				Key:  copaAnnotationKeyPrefix + ".patched",
 			}
 			annotations[patchedKey] = trueString
 
 			patchedTimestampKey := exptypes.AnnotationKey{
 				Type: exptypes.AnnotationIndex,
-				Key:  "copacetic.patched.timestamp",
+				Key:  copaAnnotationKeyPrefix + ".patched.timestamp",
 			}
 			annotations[patchedTimestampKey] = time.Now().UTC().Format(time.RFC3339)
 
@@ -180,13 +181,13 @@ func createMultiPlatformManifest(
 
 			patchedKey := exptypes.AnnotationKey{
 				Type: exptypes.AnnotationIndex,
-				Key:  "copacetic.patched",
+				Key:  copaAnnotationKeyPrefix + ".patched",
 			}
 			annotations[patchedKey] = trueString
 
 			patchedTimestampKey := exptypes.AnnotationKey{
 				Type: exptypes.AnnotationIndex,
-				Key:  "copacetic.patched.timestamp",
+				Key:  copaAnnotationKeyPrefix + ".patched.timestamp",
 			}
 			annotations[patchedTimestampKey] = time.Now().UTC().Format(time.RFC3339)
 		}

--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -468,7 +468,7 @@ func patchSingleArchImage(
 	// determine which attributes to set for the export
 	attrs := map[string]string{
 		"name": patchedImageName,
-		"annotation." + copaAnnotationKeyPrefix + ".last.patched": time.Now().UTC().Format(time.RFC3339),
+		"annotation." + copaAnnotationKeyPrefix + ".image.patched": time.Now().UTC().Format(time.RFC3339),
 	}
 	if shouldExportOCI {
 		attrs["oci-mediatypes"] = "true"
@@ -737,8 +737,8 @@ func patchSingleArchImage(
 			// update creation timestamp to reflect patching
 			augmentedDesc.Annotations["org.opencontainers.image.created"] = time.Now().UTC().Format(time.RFC3339)
 
-			// add Copa last.patched annotation for patched platforms
-			augmentedDesc.Annotations[copaAnnotationKeyPrefix+".last.patched"] = time.Now().UTC().Format(time.RFC3339)
+			// add Copa image.patched annotation for patched platforms
+			augmentedDesc.Annotations[copaAnnotationKeyPrefix+".image.patched"] = time.Now().UTC().Format(time.RFC3339)
 
 			patchedDesc = &augmentedDesc
 			log.Debugf("Preserved %d manifest level annotations for platform %s", len(originalAnnotations), targetPlatform.Platform)


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Retain multiplatform manifest list annotations
Add annotation verification to multiplatform integration tests

Closes #1119

Example of patched image now with annotations retained: https://oci.dag.dev/?image=ghcr.io%2Frobert-cronin%2Fnginx%3A1.27.0-patched-annotations
