### PR TITLE
docs: improve multiplatform docs

### DIFF
--- a/pkg/patch/patch.go
+++ b/pkg/patch/patch.go
@@ -774,7 +774,7 @@ func patchMultiPlatformImage(
 	var mu sync.Mutex
 	patchResults := []types.PatchResult{}
 
-	summaryMap := make(map[string]*types.MultiArchSummary)
+	summaryMap := make(map[string]*types.MultiPlatformSummary)
 
 	for _, p := range platforms {
 		// rebind
@@ -822,7 +822,7 @@ func patchMultiPlatformImage(
 				mu.Lock()
 				patchResults = append(patchResults, result)
 				// Add summary entry for unpatched platform
-				summaryMap[platformKey] = &types.MultiArchSummary{
+				summaryMap[platformKey] = &types.MultiPlatformSummary{
 					Platform: platformKey,
 					Status:   "Not Patched",
 					Ref:      originalRef.String() + " (original reference)",
@@ -841,7 +841,7 @@ func patchMultiPlatformImage(
 				if ignoreError {
 					status = "Ignored"
 				}
-				summaryMap[platformKey] = &types.MultiArchSummary{
+				summaryMap[platformKey] = &types.MultiPlatformSummary{
 					Platform: platformKey,
 					Status:   status,
 					Ref:      "",
@@ -852,7 +852,7 @@ func patchMultiPlatformImage(
 				}
 				return nil
 			} else if res == nil {
-				summaryMap[platformKey] = &types.MultiArchSummary{
+				summaryMap[platformKey] = &types.MultiPlatformSummary{
 					Platform: platformKey,
 					Status:   "Error",
 					Ref:      "",
@@ -862,7 +862,7 @@ func patchMultiPlatformImage(
 			}
 
 			patchResults = append(patchResults, *res)
-			summaryMap[platformKey] = &types.MultiArchSummary{
+			summaryMap[platformKey] = &types.MultiPlatformSummary{
 				Platform: platformKey,
 				Status:   "Patched",
 				Ref:      res.PatchedRef.String(),

--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -582,7 +582,7 @@ func TestNormalizeConfigForPlatform(t *testing.T) {
 	}
 }
 
-func TestMultiArchSummaryTable(t *testing.T) {
+func TestMultiPlatformSummaryTable(t *testing.T) {
 	platforms := []struct {
 		OS           string
 		Architecture string
@@ -593,7 +593,7 @@ func TestMultiArchSummaryTable(t *testing.T) {
 		{"linux", "arm", "v7"},
 	}
 
-	summaryMap := map[string]*types.MultiArchSummary{
+	summaryMap := map[string]*types.MultiPlatformSummary{
 		"linux/amd64": {
 			Platform: "linux/amd64",
 			Status:   "Patched",

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -42,7 +42,7 @@ type PatchResult struct {
 	PatchedRef  reference.Named
 }
 
-type MultiArchSummary struct {
+type MultiPlatformSummary struct {
 	Platform string
 	Status   string
 	Ref      string

--- a/test/e2e/multiplatform-plugin/multiplatform_plugin_test.go
+++ b/test/e2e/multiplatform-plugin/multiplatform_plugin_test.go
@@ -29,7 +29,7 @@ type testImage struct {
 	Platforms     []string `json:"platforms"`
 }
 
-func TestMultiArchPluginPatch(t *testing.T) {
+func TestMultiPlatformPluginPatch(t *testing.T) {
 	var images []testImage
 	err := json.Unmarshal(testImages, &images)
 	require.NoError(t, err)

--- a/website/docs/multiplatform-patching.md
+++ b/website/docs/multiplatform-patching.md
@@ -50,6 +50,14 @@ If you don't provide a `--report` flag pointing to a directory, Copa will not pe
 
 If `--push` is not specified, the individual patched images will be saved locally, and you can push them to your registry later using `docker push` and then `docker manifest create/push` to create the multi-platform manifest.
 
+:::note
+Copa copies over unpatched platforms as a passthrough - only platforms with vulnerability reports are patched, while other platforms remain unchanged in the final multi-platform image.
+:::
+
+:::warning
+Build attestations, signatures, and OCI referrers from the original image are not preserved or copied to the patched image.
+:::
+
 ---
 
 ## Emulation and QEMU for Cross-Platform Patching ⚙️

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -82,8 +82,9 @@ const config = {
         darkTheme: darkCodeTheme,
       },
       algolia: {
-        appId: process.env.ALGOLIA_ID,
-        apiKey: process.env.ALGOLIA_API_KEY,
+        // For forked PRs, secrets arent available, so we use dummy values to allow build checks to complete
+        appId: process.env.ALGOLIA_ID || 'DUMMY_APP_ID_FOR_BUILDS',
+        apiKey: process.env.ALGOLIA_API_KEY || 'DUMMY_API_KEY_FOR_BUILDS',
         indexName: 'project-copaceticio',
         contextualSearch: true,
       }

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -37,7 +37,7 @@ const sidebars = {
         'custom-address',
         'output',
         'scanner-plugins',
-        "multiarch-patching",
+        "multiplatform-patching",
       ],
     },
     {


### PR DESCRIPTION
Add notes to multiplatform documentation explaining:
- Unpatched platforms are passed through unchanged
- Build attestations and referrers are not preserved

And change multiarch to multiplatform in various places to be consistent