### PR TITLE
chore(security): ignore irrelevant vulnerabilities in osv-scanner.toml

### DIFF
--- a/website/osv-scanner.toml
+++ b/website/osv-scanner.toml
@@ -1,19 +1,19 @@
 [[ignore]]
 id = "GHSA-pxg6-pf52-xh8x"
-reason = "Not applicable to core COPA; used in static website generation only."
+reason = "Not applicable to core Copa; used in static website generation only."
 
 [[ignore]]
 id = "GHSA-rhx6-c78j-4q9w"
-reason = "Not applicable to core COPA; used in static website generation only."
+reason = "Not applicable to core Copa; used in static website generation only."
 
 [[ignore]]
 id = "GHSA-9wv6-86v2-598j"
-reason = "Not applicable to core COPA; used in static website generation only."
+reason = "Not applicable to core Copa; used in static website generation only."
 
 [[ignore]]
 id = "GHSA-4v9v-hfq4-rm2v"
-reason = "Not applicable to core COPA; used in static website generation only."
+reason = "Not applicable to core Copa; used in static website generation only."
 
 [[ignore]]
 id = "GHSA-9jgg-88mc-972h"
-reason = "Not applicable to core COPA; used in static website generation only."
+reason = "Not applicable to core Copa; used in static website generation only."


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests for guidelines.
-->

Add `osv-scanner.toml` to ignore known vulnerabilities (GHSA advisories) that are not relevant to COPA's core functionality.

These CVEs originate from dependencies used only in static website generation and do not impact runtime security.

Closes #1161
