### PR TITLE
fix: debian tooling image missing platforms

### DIFF
--- a/integration/multiarch/fixtures/test-images.json
+++ b/integration/multiarch/fixtures/test-images.json
@@ -9,9 +9,7 @@
     "push": true,
     "platforms": [
       "linux/amd64",
-      "linux/arm/v5",
       "linux/386",
-      "linux/mips64le",
       "linux/s390x",
       "linux/arm64"
     ]
@@ -26,7 +24,7 @@
     "push": false,
     "platforms": [
       "linux/amd64",
-      "linux/arm/v5"
+      "linux/arm64"
     ]
   },
   {


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Removes linux/arm/v5 and `linux/mips64le` from the multiarch tests

Closes #1254 
