### PR TITLE
docs: add --image-src to trivy

### DIFF
--- a/website/docs/multiplatform-patching.md
+++ b/website/docs/multiplatform-patching.md
@@ -46,7 +46,7 @@ for platform in $PLATFORMS; do
   arch=$(echo $platform | cut -d'/' -f2 | sed 's/\//-/g')
   echo "Scanning $platform..."
   trivy image --vuln-type os --scanners vuln --ignore-unfixed \
-    -f json -o reports/${arch}.json --platform $platform $IMAGE || \
+    -f json -o reports/${arch}.json --image-src remote --platform $platform $IMAGE || \
     echo "Warning: Failed to scan $platform"
 done
 

--- a/website/versioned_docs/version-v0.11.x/multiplatform-patching.md
+++ b/website/versioned_docs/version-v0.11.x/multiplatform-patching.md
@@ -46,7 +46,7 @@ for platform in $PLATFORMS; do
   arch=$(echo $platform | cut -d'/' -f2 | sed 's/\//-/g')
   echo "Scanning $platform..."
   trivy image --vuln-type os --scanners vuln --ignore-unfixed \
-    -f json -o reports/${arch}.json --platform $platform $IMAGE || \
+    -f json -o reports/${arch}.json --image-src remote --platform $platform $IMAGE || \
     echo "Warning: Failed to scan $platform"
 done
 


### PR DESCRIPTION
This PR adds the `--image-src` flag to the trivy command snippet in the multi-platform docs. Without this flag, trivy puts the incorrect arch in the report causing cop to skip platforms that are expected to be patched.


Describe the changes in this pull request using active verbs such as _Add_, _Remove_, _Replace_ ...

Closes #1281 
