### PR TITLE
chore: remove ignore errors for cbl mariner imgs and ignore CVE-2025-3576

### DIFF
--- a/integration/common/fixtures/trivy_ignore.rego
+++ b/integration/common/fixtures/trivy_ignore.rego
@@ -21,3 +21,12 @@ shadow_cves := {
 ignore {
     input.VulnerabilityID == shadow_cves[_]
 }
+
+# CBL Mariner CVEs to ignore
+cbl_mariner_cves := {
+    "CVE-2025-3576",
+}
+
+ignore {
+    input.VulnerabilityID == cbl_mariner_cves[_]
+}

--- a/integration/common/fixtures/trivy_ignore.rego
+++ b/integration/common/fixtures/trivy_ignore.rego
@@ -24,7 +24,7 @@ ignore {
 
 # CBL Mariner CVEs to ignore
 cbl_mariner_cves := {
-    "CVE-2025-3576",
+    "CVE-2025-3576", # due to krb5 1.19.4-4 not found in PMC
 }
 
 ignore {

--- a/integration/singlearch/fixtures/test-images.json
+++ b/integration/singlearch/fixtures/test-images.json
@@ -97,7 +97,7 @@
         "digest": "sha256:60323975ec3aabe1840920a65237950a54c5fef6ffc811a5d26bb6bd130f1cc3",
         "distro": "Mariner",
         "description": "Valid rpm DB, tdnf, yum & rpm present",
-        "ignoreErrors": true,
+        "ignoreErrors": false,
         "isManifestList": true
     },
     {
@@ -106,7 +106,7 @@
         "digest": "sha256:c85680df0ddccfd5bf0cd60ff7d0c07b0ea783bcee9ce5dc748b68c0d36e280a",
         "distro": "Mariner",
         "description": "Valid rpm DB, tdnf, yum & rpm present, arm64 cross-arch",
-        "ignoreErrors": true,
+        "ignoreErrors": false,
         "isManifestList": false
     },
     {


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->
Ignores CVE-2025-3576 until krb5 `1.19.4-4` is available.

Describe the changes in this pull request using active verbs such as _Add_, _Remove_, _Replace_ ...

Closes #1303
