### PR TITLE
chore: update openvex dependency to v0.2.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/moby/buildkit v0.24.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
-	github.com/openvex/go-vex v0.2.5
+	github.com/openvex/go-vex v0.2.6
 	github.com/quay/claircore v1.5.39
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/opencontainers/runtime-spec v1.2.1 h1:S4k4ryNgEpxW1dzyqffOmhI1BHYcjzU
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.12.0 h1:6n5JV4Cf+4y0KNXW48TLj5DwfXpvWlxXplUkdTrmPb8=
 github.com/opencontainers/selinux v1.12.0/go.mod h1:BTPX+bjVbWGXw7ZZWUbdENt8w0htPSrlgOOysQaU62U=
-github.com/openvex/go-vex v0.2.5 h1:41utdp2rHgAGCsG+UbjmfMG5CWQxs15nGqir1eRgSrQ=
-github.com/openvex/go-vex v0.2.5/go.mod h1:j+oadBxSUELkrKh4NfNb+BPo77U3q7gdKME88IO/0Wo=
+github.com/openvex/go-vex v0.2.6 h1:Elv6fIOmxOrYQcQohxI3OS0OI6w1mZGAT5LWsIi2I8g=
+github.com/openvex/go-vex v0.2.6/go.mod h1:ZyQC3NXl9jjS53JOpBG3LAUXySkW8IlJ/GIhsnf5D54=
 github.com/package-url/packageurl-go v0.1.3 h1:4juMED3hHiz0set3Vq3KeQ75KD1avthoXLtmE3I0PLs=
 github.com/package-url/packageurl-go v0.1.3/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=

--- a/pkg/vex/openvex_test.go
+++ b/pkg/vex/openvex_test.go
@@ -65,7 +65,6 @@ func TestOpenVex_CreateVEXDocument(t *testing.T) {
   "@context": "https://openvex.dev/ns",
   "@id": "https://openvex.dev/test",
   "author": "test author",
-  "timestamp": "2009-11-17T20:34:58.651387237Z",
   "version": 1,
   "tooling": "Project Copacetic",
   "statements": [
@@ -83,9 +82,11 @@ func TestOpenVex_CreateVEXDocument(t *testing.T) {
           ]
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": ""
     }
-  ]
+  ],
+  "timestamp": "2009-11-17T20:34:58Z"
 }
 `,
 			wantErr: false,
@@ -125,7 +126,6 @@ func TestOpenVex_CreateVEXDocument(t *testing.T) {
   "@context": "https://openvex.dev/ns",
   "@id": "https://openvex.dev/test",
   "author": "test author",
-  "timestamp": "2009-11-17T20:34:58.651387237Z",
   "version": 1,
   "tooling": "Project Copacetic",
   "statements": [
@@ -146,7 +146,8 @@ func TestOpenVex_CreateVEXDocument(t *testing.T) {
           ]
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": ""
     },
     {
       "vulnerability": {
@@ -162,9 +163,11 @@ func TestOpenVex_CreateVEXDocument(t *testing.T) {
           ]
         }
       ],
-      "status": "fixed"
+      "status": "fixed",
+      "timestamp": ""
     }
-  ]
+  ],
+  "timestamp": "2009-11-17T20:34:58Z"
 }
 `,
 			wantErr: false,


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

  1. Statement timestamps: VEX statements now always include a "timestamp": "" field in the JSON output, even when no timestamp is set, due to the custom MarshalJSON method in the Statement
  struct.
  2. Document timestamp format: The document-level timestamp uses RFC3339 format (without nanoseconds), while statement-level timestamps use RFC3339Nano format (with nanoseconds).
