### PR TITLE
fix: add version validation and improve release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,38 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set Version Variables
+        id: vars
+        run: |
+          # Remove the 'refs/tags/v' prefix.
+          VERSION_TAG=$(echo "${{ github.ref }}" | sed 's,refs/tags/v,,')
+          echo "version_tag=${VERSION_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Version Order
+        run: |
+          PUSHED_TAG="v${{ steps.vars.outputs.version_tag }}"
+          
+          # Get the immediate previous tag.
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 "${PUSHED_TAG}^" 2>/dev/null || echo "v0.0.0")
+          
+          echo "Validating pushed tag: ${PUSHED_TAG}"
+          echo "Comparing against previous tag: ${PREVIOUS_TAG}"
+
+          # Create a list of the two tags and sort them. The pushed tag must be the last one.
+          LATEST_SORTED=$(printf "%s\n%s" "$PUSHED_TAG" "$PREVIOUS_TAG" | sort -V | tail -n1)
+
+          if [ "$LATEST_SORTED" != "$PUSHED_TAG" ] || [ "$PUSHED_TAG" == "$PREVIOUS_TAG" ]; then
+            echo "::error::Validation Failed: Pushed tag '${PUSHED_TAG}' is not strictly greater than the previous tag '${PREVIOUS_TAG}'."
+            echo "::error::This could be a typo. Did you mean to release a different version?"
+            exit 1
+          fi
+
+          echo "✅ Version validation passed."
+
       - name: Create release branch
         run: |
-          # Extract version from tag (e.g., v0.11.0 -> 0.11)
-          VERSION=$(echo "${{ github.ref }}" | sed 's/refs\/tags\/v//' | \
-            sed 's/\.[0-9]*\(-.*\)*$//')
+          # Extract version from tag (e.g., v0.11.0 -> 0.11 or v0.12.0-rc.1 -> 0.12)
+          VERSION=$(echo "${{ steps.vars.outputs.version_tag }}" | cut -d'.' -f1,2)
           BRANCH_NAME="release-${VERSION}"
           
           # Check if release branch already exists
@@ -60,7 +87,8 @@ jobs:
       - name: Checkout copa-action repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          repository: project-copacetic/copa-action
+          repository: ${{ github.repository_owner }}/copa-action
+          path: copa-action
           ref: main
 
       - name: Set up Docker
@@ -75,13 +103,15 @@ jobs:
 
       - name: Build and push copa-action image with new version
         run: |
-          tag="$(echo "${{ github.ref }}" | tr -d 'refs/tags/v')"
-          docker buildx build --build-arg copa_version=${tag} -t ghcr.io/project-copacetic/copa-action:v"$tag" --push .
+          tag="${{ steps.vars.outputs.version_tag }}"
+          image_owner="${{ github.repository_owner }}"
+          docker buildx build --build-arg copa_version=${tag} -t "ghcr.io/${image_owner}/copa-action:v${tag}" --push ./copa-action
 
       - name: Checkout copa-extension repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          repository: project-copacetic/copa-extension
+          repository: ${{ github.repository_owner }}/copa-extension
+          path: copa-extension
           ref: main
 
       - name: Set up Docker for copa-extension
@@ -96,5 +126,6 @@ jobs:
 
       - name: Build and push copa-extension image with new version
         run: |
-          tag="$(echo "${{ github.ref }}" | tr -d 'refs/tags/v')"
-          docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg copa_version=${tag} -t ghcr.io/project-copacetic/copa-extension:v"$tag" container/copa-extension
+          tag="${{ steps.vars.outputs.version_tag }}"
+          image_owner="${{ github.repository_owner }}"
+          docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg copa_version=${tag} -t "ghcr.io/${image_owner}/copa-extension:v${tag}" ./copa-extension/container/copa-extension


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Adds validation that the current release tag version comes after the previous tag in semver order
Fixes a bug whereby `tr -d 'refs/tags/v'` will cause `refs/tags/v0.12.0-rc.1` to be malformed to `0.12.0-c.1` instead of `0.12.0-rc.1`

Tested on my own fork:
https://github.com/robert-cronin/copacetic/actions/runs/18521966593/job/52784375981
https://github.com/robert-cronin/copacetic/releases/tag/v0.12.0-rc.1

Verifying the version order validation logic:
https://github.com/robert-cronin/copacetic/actions/runs/18520983753/job/52780674898

Closes #1343