### PR TITLE
fix: version validation scripts for release tagging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,30 +27,27 @@ jobs:
       - name: Set Version Variables
         id: vars
         run: |
-          # Remove the 'refs/tags/v' prefix.
-          VERSION_TAG=$(echo "${{ github.ref }}" | sed 's,refs/tags/v,,')
-          echo "version_tag=${VERSION_TAG}" >> "$GITHUB_OUTPUT"
+          # Get the version without the 'refs/tags/v' prefix, e.g., "1.2.3"
+          VERSION_TAG_ONLY=$(echo "${{ github.ref }}" | sed 's,refs/tags/v,,')
+          
+          # Reconstruct the full pushed tag, e.g., "v1.2.3"
+          PUSHED_TAG="v${VERSION_TAG_ONLY}"
+          
+          # Get the immediate previous tag relative to the pushed tag.
+          PREVIOUS_TAG=$(git describe --tags --abbrev=0 "${PUSHED_TAG}^" 2>/dev/null || echo "v0.0.0")
+
+          # Output for other steps
+          echo "version_tag=${VERSION_TAG_ONLY}" >> "$GITHUB_OUTPUT"
+          
+          # Outputs for the validation step
+          echo "pushed_tag=${PUSHED_TAG}" >> "$GITHUB_OUTPUT"
+          echo "previous_tag=${PREVIOUS_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Validate Version Order
-        run: |
-          PUSHED_TAG="v${{ steps.vars.outputs.version_tag }}"
-          
-          # Get the immediate previous tag.
-          PREVIOUS_TAG=$(git describe --tags --abbrev=0 "${PUSHED_TAG}^" 2>/dev/null || echo "v0.0.0")
-          
-          echo "Validating pushed tag: ${PUSHED_TAG}"
-          echo "Comparing against previous tag: ${PREVIOUS_TAG}"
-
-          # Create a list of the two tags and sort them. The pushed tag must be the last one.
-          LATEST_SORTED=$(printf "%s\n%s" "$PUSHED_TAG" "$PREVIOUS_TAG" | sort -V | tail -n1)
-
-          if [ "$LATEST_SORTED" != "$PUSHED_TAG" ] || [ "$PUSHED_TAG" == "$PREVIOUS_TAG" ]; then
-            echo "::error::Validation Failed: Pushed tag '${PUSHED_TAG}' is not strictly greater than the previous tag '${PREVIOUS_TAG}'."
-            echo "::error::This could be a typo. Did you mean to release a different version?"
-            exit 1
-          fi
-
-          echo "✅ Version validation passed."
+        run: bash .github/workflows/scripts/release/validate_version.sh
+        env:
+          PUSHED_TAG: ${{ steps.vars.outputs.pushed_tag }}
+          PREVIOUS_TAG: ${{ steps.vars.outputs.previous_tag }}
 
       - name: Create release branch
         run: |

--- a/.github/workflows/scripts/release/test_validation.sh
+++ b/.github/workflows/scripts/release/test_validation.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# test_validation.sh
+#
+# Unit test harness for validate_version.sh
+#
+# This script is "stateless" and does not require a git repository.
+# It tests the logic of validate_version.sh by passing
+# environment variables (PUSHED_TAG, PREVIOUS_TAG) and checking
+# the exit code.
+#
+
+set -e # Exit on first error
+
+# --- Robust Path Detection ---
+# Get the absolute directory where this script is located.
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+VALIDATE_SCRIPT="${SCRIPT_DIR}/validate_version.sh"
+
+if [ ! -f "$VALIDATE_SCRIPT" ]; then
+	echo "Error: Validation script not found at '$VALIDATE_SCRIPT'" >&2
+	echo "Please ensure validate_version.sh is in the same directory as this test script." >&2
+	exit 1
+fi
+
+# --- Test Harness ---
+TEST_COUNT=0
+FAIL_COUNT=0
+
+# Helper to run a test
+# $1: Expected exit code (0 for pass, 1 for fail)
+# $2: The "pushed" tag to test
+# $3: The "previous" tag to simulate
+# $4: Test description
+run_test() {
+	local expected_code="$1"
+	local pushed_tag="$2"
+	local previous_tag="$3"
+	local description="$4"
+	local actual_code=0
+	local output=""
+
+	TEST_COUNT=$((TEST_COUNT + 1))
+	echo -n "Test: $description... "
+
+	# Run the validation script, capturing stdout/stderr and exit code
+	# We pass the tags as environment variables, just like the workflow
+	output=$(
+		PUSHED_TAG="$pushed_tag" \
+			PREVIOUS_TAG="$previous_tag" \
+			"$VALIDATE_SCRIPT" 2>&1
+	) || actual_code=$?
+
+	if [ "$actual_code" -eq "$expected_code" ]; then
+		echo "PASS ✅"
+	else
+		FAIL_COUNT=$((FAIL_COUNT + 1))
+		echo "FAIL ❌"
+		echo "  Expected exit code: $expected_code"
+		echo "  Got exit code: $actual_code"
+		echo "  PUSHED_TAG=$pushed_tag, PREVIOUS_TAG=$previous_tag"
+		echo "  Script output:"
+		echo "$output" | sed 's/^/    /' # Indent output for readability
+	fi
+}
+
+# --- Main Execution ---
+
+echo
+echo "--- Running Validation Logic Tests ---"
+
+# --- PASSING Scenarios (Expected Exit 0) ---
+echo
+echo "Running PASS scenarios (expected exit 0)..."
+run_test 0 "v0.1.0" "v0.0.0" "First release"
+run_test 0 "v0.12.0" "v0.12.0-rc.3" "Special case: Final release (v0.12.0 > v0.12.0-rc.3)"
+run_test 0 "v0.12.0-rc.4" "v0.12.0-rc.3" "Subsequent RC (rc.4 > rc.3)"
+run_test 0 "v0.12.1" "v0.12.0" "Patch bump (v0.12.1 > v0.12.0)"
+run_test 0 "v0.13.0" "v0.12.9" "Minor bump (v0.13.0 > v0.12.9)"
+run_test 0 "v1.0.0" "v0.99.0" "Major bump (v1.0.0 > v0.99.0)"
+run_test 0 "v1.10.0" "v1.9.0" "Version sort check (1.10.0 > 1.9.0)"
+run_test 0 "v2.0.0" "v1.10.5" "Version sort check (2.0.0 > 1.10.5)"
+
+# --- FAILING Scenarios (Expected Exit 1) ---
+echo
+echo "Running FAIL scenarios (expected exit 1)..."
+run_test 1 "v0.12.0-rc.3" "v0.12.0-rc.3" "Same tag (rc.3 == rc.3)"
+run_test 1 "v1.2.3" "v1.2.3" "Same tag (final == final)"
+run_test 1 "v0.12.0-rc.2" "v0.12.0-rc.3" "Lower RC (rc.2 < rc.3)"
+run_test 1 "v0.12.0-beta" "v0.12.0-rc.1" "Lower pre-release type (beta < rc)"
+run_test 1 "v0.11.0" "v0.12.0" "Lower minor version (v0.11.0 < v0.12.0)"
+run_test 1 "v1.2.0" "v1.3.0" "Lower minor version (v1.2.0 < v1.3.0)"
+run_test 1 "v0.12.0-rc.1" "v0.12.0" "Pre-release after final (rc.1 < final)"
+run_test 1 "v1.9.0" "v1.10.0" "Version sort check (1.9.0 < 1.10.0)"
+
+# --- Final Report ---
+echo
+echo "--- Test Summary ---"
+if [ "$FAIL_COUNT" -eq 0 ]; then
+	echo "All $TEST_COUNT tests passed! 🎉"
+	exit 0
+else
+	echo "$FAIL_COUNT out of $TEST_COUNT tests failed. ❌"
+	exit 1
+fi

--- a/.github/workflows/scripts/release/validate_version.sh
+++ b/.github/workflows/scripts/release/validate_version.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# .github/workflows/scripts/release/validate_version.sh
+#
+# Checks if a new pushed tag is semantically greater than the
+# immediate previous tag using GNU sort -V, with a manual
+# override for SemVer pre-release vs. final release comparisons.
+#
+# This script is intended to be run from a GitHub Actions workflow.
+# It relies on the following environment variables being set:
+#
+#   PUSHED_TAG:   The new tag being validated (e.g., "v1.2.3")
+#   PREVIOUS_TAG: The immediate previous tag (e.g., "v1.2.2" or "v0.0.0")
+#
+# Exits with 0 on success (validation passed).
+# Exits with 1 on failure (validation failed).
+#
+
+# Exit on error, on unset variable, or pipe failure
+set -euo pipefail
+
+# 1. Check that environment variables are set
+if [ -z "${PUSHED_TAG:-}" ]; then
+	echo "::error::PUSHED_TAG environment variable is not set." >&2
+	exit 1
+fi
+
+if [ -z "${PREVIOUS_TAG:-}" ]; then
+	echo "::error::PREVIOUS_TAG environment variable is not set." >&2
+	exit 1
+fi
+
+# 2. Log the inputs
+echo "Validating pushed tag: ${PUSHED_TAG}"
+echo "Comparing against previous tag: ${PREVIOUS_TAG}"
+
+# 3. Check for identical tags (a definite failure)
+if [ "$PUSHED_TAG" == "$PREVIOUS_TAG" ]; then
+	echo "::error::Validation Failed: Pushed tag '${PUSHED_TAG}' is identical to the previous tag '${PREVIOUS_TAG}'."
+	exit 1
+fi
+
+# 4. Extract base versions (before any '-' pre-release suffix)
+#    Example: "v0.12.0-rc.1" -> "v0.12.0"
+#    Example: "v0.12.0"      -> "v0.12.0"
+PUSHED_BASE="${PUSHED_TAG%%-*}"
+PREVIOUS_BASE="${PREVIOUS_TAG%%-*}"
+
+# 5. Handle the special SemVer case: pre-release vs. final
+#    This is the case where 'sort -V' fails.
+if [ "$PUSHED_BASE" == "$PREVIOUS_BASE" ]; then
+
+	# CASE A: Pushed tag is a final release, previous was a pre-release.
+	# This is GOOD. (e.g., v0.12.0 > v0.12.0-rc.3)
+	# PUSHED_TAG == PUSHED_BASE (it has no '-')
+	# PREVIOUS_TAG != PREVIOUS_BASE (it has a '-')
+	if [ "$PUSHED_TAG" == "$PUSHED_BASE" ] && [ "$PREVIOUS_TAG" != "$PREVIOUS_BASE" ]; then
+		echo "✅ Version validation passed (final release after pre-release)."
+		exit 0
+	fi
+
+	# CASE B: Pushed tag is a pre-release, previous was final.
+	# This is BAD. (e.g., v0.12.0-rc.1 < v0.12.0)
+	# PUSHED_TAG != PUSHED_BASE (it has a '-')
+	# PREVIOUS_TAG == PREVIOUS_BASE (it has no '-')
+	if [ "$PUSHED_TAG" != "$PUSHED_BASE" ] && [ "$PREVIOUS_TAG" == "$PREVIOUS_BASE" ]; then
+		echo "::error::Validation Failed: Pushed tag '${PUSHED_TAG}' is a pre-release for a version that is already final ('${PREVIOUS_TAG}')."
+		exit 1
+	fi
+
+	# If both are pre-releases (rc.4 vs rc.3) or both are final (which
+	# is caught by the identical check), we fall through to the
+	# standard 'sort -V' logic, which handles rc.4 > rc.3 correctly.
+fi
+
+# 6. For all other cases (different base versions), use standard version sort.
+#    This correctly handles:
+#    - v0.12.1 > v0.12.0
+#    - v0.13.0 > v0.12.9
+#    - v0.12.0-rc.4 > v0.12.0-rc.3
+LATEST_SORTED=$(printf "%s\n%s" "$PUSHED_TAG" "$PREVIOUS_TAG" | sort -V | tail -n1)
+
+# 7. Check failure condition
+if [ "$LATEST_SORTED" != "$PUSHED_TAG" ]; then
+	echo "::error::Validation Failed: Pushed tag '${PUSHED_TAG}' is not strictly greater than the previous tag '${PREVIOUS_TAG}'."
+	echo "::error::This could be a typo. Did you mean to release a different version?"
+	exit 1
+fi
+
+echo "✅ Version validation passed."
+exit 0


### PR DESCRIPTION
<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Adds more robust checks and tests for releasing an upgrade

Closes #1363

Tested on my own fork:
1. v0.12.0: https://github.com/robert-cronin/copacetic/actions/runs/18933847787
1. v0.13.0-rc.1: https://github.com/robert-cronin/copacetic/actions/runs/18934421522
1. v1.0.0-rc.1: https://github.com/robert-cronin/copacetic/actions/runs/18934623401
1. trying v0.13.0-rc.3 after v0.13.0 has been published: https://github.com/robert-cronin/copacetic/actions/runs/18935021233/job/54059675103