### PR TITLE
fix: exit successfully and fix status for up to date images

### DIFF
--- a/pkg/patch/single.go
+++ b/pkg/patch/single.go
@@ -139,16 +139,17 @@ func patchSingleArchImage(
 				updates.LangUpdates = []unversioned.UpdatePackage{}
 			}
 
-			log.Debugf("Filtered updates to apply: OS=%d, Lang=%d", len(updates.OSUpdates), len(updates.LangUpdates))
+		log.Debugf("Filtered updates to apply: OS=%d, Lang=%d", len(updates.OSUpdates), len(updates.LangUpdates))
 
-			// If after filtering there are zero OS and zero library updates, return an error
-			// only when user explicitly requested some package types (default is OS) but none are patchable.
-			if len(updates.OSUpdates) == 0 && len(updates.LangUpdates) == 0 {
-				return nil, fmt.Errorf("no patchable vulnerabilities found in provided report for selected pkg-types (%s)", pkgTypes)
-			}
+		// If after filtering there are zero OS and zero library updates, return an error
+		// only when user explicitly requested some package types (default is OS) but none are patchable.
+		if len(updates.OSUpdates) == 0 && len(updates.LangUpdates) == 0 {
+			res, _ := createOriginalImageResult(imageName, &targetPlatform, image)
+			return res, types.ErrNoUpdatesFound
 		}
+	}
 
-		log.Debugf("updates to apply: %v", updates)
+	log.Debugf("updates to apply: %v", updates)
 	}
 
 	// Create buildkit client


### PR DESCRIPTION
If there are no vulnerabilities for a multi-platform image and other platforms are preserved, Copa should exit successfully with a message. A patched manifest should not be created.

New output:

```
ashnamehrotra@Ashnas-MacBook-Pro copacetic % ./dist/darwin_arm64/release/copa patch --image quay.io/jetstack/cert-manager-controller:v1.19.1 --repor
t /Users/ashnamehrotra/reports --tag testrepo/cert-manager-controller:v1.19.1-patched-1 2>&1 | tail -30
time="2025-11-11T13:39:18-05:00" level=info msg="Platform linux/s390x marked for preservation, preserving original in manifest"
time="2025-11-11T13:39:18-05:00" level=info msg="Platform linux/ppc64le marked for preservation, preserving original in manifest"
time="2025-11-11T13:39:18-05:00" level=info msg="Platform linux/arm marked for preservation, preserving original in manifest"
time="2025-11-11T13:39:18-05:00" level=info msg="Patched image name: docker.io/testrepo/cert-manager-controller:v1.19.1-patched-1-arm64"
time="2025-11-11T13:39:18-05:00" level=warning msg="Running on macOS, assuming Docker Desktop handles emulation."
time="2025-11-11T13:39:18-05:00" level=info msg="Patched image name: docker.io/testrepo/cert-manager-controller:v1.19.1-patched-1-amd64"
Error: no images were processed, check the logs for errors
ashnamehrotra@Ashnas-MacBook-Pro copacetic % make && ./dist/darwin_arm64/release/copa patch --image quay.io/jetstack/cert-manager-controller:v1.19.1
 --report /Users/ashnamehrotra/reports --tag testrepo/cert-manager-controller:v1.19.1-patched-1
=> Building copa ...
CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 \
        go build  -ldflags "-X github.com/project-copacetic/copacetic/pkg/version.GitCommit=df8d3d6f7fb609e93550e07b75c01fd57442690d -X github.com/project-copacetic/copacetic/pkg/version.GitVersion=v0.12.0-rc.1-20-gdf8d3d6f-dirty -X github.com/project-copacetic/copacetic/pkg/version.BuildDate=2025-11-11T18:40:15Z -X main.version=edge -s -w -extldflags -static" -o ./dist/darwin_arm64/release/copa;
INFO[0000] Platform linux/s390x marked for preservation, preserving original in manifest 
INFO[0000] Platform linux/ppc64le marked for preservation, preserving original in manifest 
INFO[0000] Platform linux/arm marked for preservation, preserving original in manifest 
INFO[0000] Patched image name: docker.io/testrepo/cert-manager-controller:v1.19.1-patched-1-arm64 
WARN[0000] Running on macOS, assuming Docker Desktop handles emulation. 
INFO[0000] Patched image name: docker.io/testrepo/cert-manager-controller:v1.19.1-patched-1-amd64 
INFO[0000] 
Multi-arch patch summary:
PLATFORM       STATUS       REFERENCE                                                              MESSAGE
linux/amd64    Up-to-date   quay.io/jetstack/cert-manager-controller:v1.19.1 (original)            Image is already up-to-date
linux/arm/v7   Not Patched  quay.io/jetstack/cert-manager-controller:v1.19.1 (original reference)  Preserved original image (No Scan Report provided for platform)
linux/arm64    Up-to-date   quay.io/jetstack/cert-manager-controller:v1.19.1 (original)            Image is already up-to-date
linux/ppc64le  Not Patched  quay.io/jetstack/cert-manager-controller:v1.19.1 (original reference)  Preserved original image (No Scan Report provided for platform)
linux/s390x    Not Patched  quay.io/jetstack/cert-manager-controller:v1.19.1 (original reference)  Preserved original image (No Scan Report provided for platform) 
```

<!--
Please include the type of change in the PR title as "<type>: <summary>"
Valid <type> include: build, ci, docs, feat, fix, perf, refactor, test
See https://github.com/project-copacetic/copacetic/blob/master/CONTRIBUTING.md#pull-requests) for guidelines.
-->

Describe the changes in this pull request using active verbs such as _Add_, _Remove_, _Replace_ ...

Closes #1365 
