### PR TITLE
fix: prevent Go module flag injection via leading-dash names

### DIFF
--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -63,6 +63,11 @@ func validateGoPackageName(name string) error {
 		return fmt.Errorf("package name contains whitespace: %s", name)
 	}
 
+	// Module names must not start with '-' to prevent go tool flag injection.
+	if strings.HasPrefix(name, "-") {
+		return fmt.Errorf("package name cannot start with '-': %s", name)
+	}
+
 	return nil
 }
 
@@ -692,6 +697,9 @@ func (gm *golangManager) updateGoModule(
 			if strings.ContainsAny(u.Name, shellUnsafeChars) {
 				return state, fmt.Errorf("package name contains unsafe characters: %s", u.Name)
 			}
+			if strings.HasPrefix(u.Name, "-") {
+				return state, fmt.Errorf("package name cannot start with '-': %s", u.Name)
+			}
 			if strings.ContainsAny(u.FixedVersion, shellUnsafeChars) {
 				return state, fmt.Errorf("version contains unsafe characters: %s for package %s", u.FixedVersion, u.Name)
 			}
@@ -812,6 +820,9 @@ func (gm *golangManager) upgradePackagesWithTooling(
 			if u.FixedVersion != "" {
 				if strings.ContainsAny(u.Name, shellUnsafeChars) {
 					return currentState, nil, fmt.Errorf("package name contains unsafe characters: %s", u.Name)
+				}
+				if strings.HasPrefix(u.Name, "-") {
+					return currentState, nil, fmt.Errorf("package name cannot start with '-': %s", u.Name)
 				}
 				if strings.ContainsAny(u.FixedVersion, shellUnsafeChars) {
 					return currentState, nil, fmt.Errorf("version contains unsafe characters: %s for package %s", u.FixedVersion, u.Name)

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -207,6 +207,11 @@ func TestValidateGoPackageName(t *testing.T) {
 			packageName: "github.com/user/repo\n",
 			expectError: true,
 		},
+		{
+			name:        "package name starting with dash",
+			packageName: "-modfile=/tmp/pwn/mod",
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/provenance/rebuilder.go
+++ b/pkg/provenance/rebuilder.go
@@ -158,6 +158,16 @@ func validateShellSafeStrict(value, label string) error {
 	return nil
 }
 
+func validateGoModuleName(module string) error {
+	if strings.ContainsAny(module, ";&|`$(){}[]<>\"'\\*?!~# \t\n\r") {
+		return fmt.Errorf("module name contains unsafe characters: %s", module)
+	}
+	if strings.HasPrefix(module, "-") {
+		return fmt.Errorf("module name cannot start with '-': %s", module)
+	}
+	return nil
+}
+
 // Rebuilder orchestrates the Go binary rebuild process using heuristic detection.
 type Rebuilder struct{}
 
@@ -582,8 +592,8 @@ func (r *Rebuilder) buildBinaryWithUpdates(
 	// Apply updates with retry for each module.
 	// Validate module names and versions before constructing shell commands to prevent injection.
 	for module, version := range updates {
-		if strings.ContainsAny(module, ";&|`$(){}[]<>\"'\\*?!~# \t\n\r") {
-			return llb.State{}, fmt.Errorf("module name contains unsafe characters: %s", module)
+		if err := validateGoModuleName(module); err != nil {
+			return llb.State{}, err
 		}
 		if strings.ContainsAny(version, ";&|`$(){}[]<>\"'\\*?!~# \t\n\r") {
 			return llb.State{}, fmt.Errorf("version contains unsafe characters: %s for module %s", version, module)

--- a/pkg/provenance/rebuilder_test.go
+++ b/pkg/provenance/rebuilder_test.go
@@ -406,6 +406,45 @@ func TestStripGoMajorVersionSuffix(t *testing.T) {
 	}
 }
 
+func TestValidateGoModuleName(t *testing.T) {
+	tests := []struct {
+		name    string
+		module  string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid module name",
+			module:  "github.com/example/module",
+			wantErr: false,
+		},
+		{
+			name:    "unsafe shell characters",
+			module:  "github.com/example/module;rm -rf /",
+			wantErr: true,
+			errMsg:  "unsafe characters",
+		},
+		{
+			name:    "leading dash rejected",
+			module:  "-modfile=/tmp/pwn.mod",
+			wantErr: true,
+			errMsg:  "cannot start with '-'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGoModuleName(tt.module)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateRepoURL(t *testing.T) {
 	tests := []struct {
 		url     string


### PR DESCRIPTION
### Motivation
- The Go patching paths build `go get` shell commands from report-provided module names but only validated for shell metacharacters and whitespace, allowing module names that start with `-` to be interpreted as `go` flags and enabling argument injection. 
- The fix must block leading-dash module/package names in all update code paths while preserving existing behavior for valid module names.

### Description
- Add a leading-dash rejection to `validateGoPackageName` by returning an error if a module name `strings.HasPrefix(name, "-")`.
- Enforce the same guard in `updateGoModule` and `upgradePackagesWithTooling` by rejecting `u.Name` values that start with `-` before constructing `go get` commands.
- Introduce `validateGoModuleName(module string)` in `pkg/provenance/rebuilder.go` and use it when applying updates to centralize validation and reject leading-dash module names.
- Add regression tests: extend `TestValidateGoPackageName` with a leading-dash case and add `TestValidateGoModuleName` in rebuilder tests to cover unsafe characters and leading-dash rejection.

### Testing
- Ran unit tests with `go test ./pkg/langmgr ./pkg/provenance` and they passed successfully. 
- New/updated tests include `TestValidateGoPackageName` and `TestValidateGoModuleName`, and both passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d682c378d4832ab3c18d94c6e70a02)