### PR TITLE
fix: close progress channel when no platforms need patching

### DIFF
--- a/pkg/patch/multi.go
+++ b/pkg/patch/multi.go
@@ -112,6 +112,9 @@ func patchMultiPlatformImage(
 	// Start the unified progress display
 	displayEg, displayCtx := errgroup.WithContext(ctx)
 	common.DisplayProgress(displayCtx, displayEg, sharedProgressCh, opts.Progress)
+	if patchingPlatformCount == 0 {
+		closeProgressOnce.Do(func() { close(sharedProgressCh) })
+	}
 
 	var mu sync.Mutex
 	patchResults := []types.PatchResult{}


### PR DESCRIPTION
### Motivation
- When all discovered platforms are marked `ShouldPreserve`, the shared TUI progress channel was never closed which caused `displayEg.Wait()` in `patchMultiPlatformImage` to block forever and hang the multi-platform patch flow.

### Description
- Close the shared progress channel immediately when `patchingPlatformCount == 0` after starting the display by invoking `closeProgressOnce.Do(func() { close(sharedProgressCh) })` in `pkg/patch/multi.go` to ensure the display goroutine can exit.

### Testing
- Attempted `go test ./pkg/patch` and `timeout 60s go test ./pkg/patch -run TestPatchMultiPlatformImage -count=1`, but the test runs timed out in this environment and did not complete successfully; no further automated test failures were observed in the limited run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d69a6bd7e4832ab3e4a4ce5266332d)