### PR TITLE
fix(rpm): validate package names in dnf chroot path

### DIFF
--- a/pkg/pkgmgr/rpm.go
+++ b/pkg/pkgmgr/rpm.go
@@ -1042,6 +1042,13 @@ func (rm *rpmManager) dnfChrootInstallUpdates(ctx context.Context, updates unver
 		imageStateCurrent = rm.config.PatchedImageState
 	}
 
+	// Validate package names before interpolating them into shell commands.
+	if updates != nil {
+		if err := ValidateOSPackageNames(updates); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	// First try with the specified platform, fallback to host platform if it fails
 	toolingBase, err := tryImage(ctx, toolImage, rm.config.Client, platform)
 	if err != nil {

--- a/pkg/pkgmgr/rpm_test.go
+++ b/pkg/pkgmgr/rpm_test.go
@@ -1033,6 +1033,18 @@ func Test_dnfChrootInstallUpdates(t *testing.T) {
 			expectedError:  true,
 			expectedResult: nil,
 		},
+		{
+			name:      "dnf chroot - invalid package name is rejected",
+			mockSetup: nil,
+			updates: unversioned.UpdatePackages{
+				{Name: "curl; touch /tmp/pwned", FixedVersion: "1.0.1"},
+			},
+			toolImage:      "almalinux:9",
+			ignoreErrors:   false,
+			usePatchedCfg:  false,
+			expectedError:  true,
+			expectedResult: nil,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1045,8 +1057,10 @@ func Test_dnfChrootInstallUpdates(t *testing.T) {
 				mockResult.SetRef(mockRef)
 				mockClient.On("Solve", mock.Anything, mock.Anything).Return(mockResult, nil)
 				tt.mockSetup(mockRef)
-			} else {
+			} else if tt.name != "dnf chroot - invalid package name is rejected" {
 				mockClient.On("Solve", mock.Anything, mock.Anything).Return(nil, errors.New("solve failed"))
+			} else {
+				// Validation should fail before any Solve call.
 			}
 
 			cfg := &buildkit.Config{


### PR DESCRIPTION
### Motivation
- The chroot-based RPM update path constructed a shell script with package names interpolated directly, which skipped the existing `ValidateOSPackageNames` checks and allowed shell-metacharacter injection.
- The change ensures package names are validated before any shell command construction to prevent command injection when update manifests are attacker-controlled.

### Description
- Added an early call to `ValidateOSPackageNames(updates)` at the top of `dnfChrootInstallUpdates` so invalid package names return an error before any command is built or executed (file: `pkg/pkgmgr/rpm.go`).
- Added a unit test `dnf chroot - invalid package name is rejected` to `Test_dnfChrootInstallUpdates` which provides a payload with shell metacharacters and asserts validation fails before any BuildKit `Solve` call (file: `pkg/pkgmgr/rpm_test.go`).
- Changes are limited to `pkg/pkgmgr/rpm.go` and `pkg/pkgmgr/rpm_test.go` and preserve the existing dnf chroot functionality for valid input.

### Testing
- Ran `go test ./pkg/pkgmgr -run Test_dnfChrootInstallUpdates -count=1`, which passed successfully.
- The new test case verifies rejection of invalid package names and that no BuildKit solve is attempted for that case.
- Existing `Test_dnfChrootInstallUpdates` scenarios were run as part of the same test invocation and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6a4d17fec832abdd32cbb4575a0be)