### PR TITLE
fix(nodejs): prevent shell injection via untrusted package paths

### DIFF
--- a/pkg/langmgr/nodejs.go
+++ b/pkg/langmgr/nodejs.go
@@ -506,6 +506,12 @@ func (nm *nodejsManager) upgradePackages(
 	return &updatedState, nil
 }
 
+// shellQuote wraps s in single quotes and escapes embedded single quotes so it can be
+// safely passed as a shell argument.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'"'"'`) + "'"
+}
+
 // installNodePackages updates both direct and transitive dependencies.
 // It uses npm install for direct dependencies and npm overrides for transitive dependencies.
 func (nm *nodejsManager) installNodePackages(
@@ -530,10 +536,10 @@ func (nm *nodejsManager) installNodePackages(
 	// This ensures production images don't include development dependencies
 	log.Debugf("Removing devDependencies from package.json in %s", workDir)
 	removeDevDepsCmd := fmt.Sprintf(
-		`sh -c 'cd %s && `+
+		`sh -c 'cd -- "$1" && `+
 			`node -e "const fs=require('\''fs'\''); const pkg=JSON.parse(fs.readFileSync('\''package.json'\'')); `+
-			`delete pkg.devDependencies; fs.writeFileSync('\''package.json'\'', JSON.stringify(pkg, null, 2));"'`,
-		workDir,
+			`delete pkg.devDependencies; fs.writeFileSync('\''package.json'\'', JSON.stringify(pkg, null, 2));"' -- %s`,
+		shellQuote(workDir),
 	)
 	state = state.Run(llb.Shlex(removeDevDepsCmd), llb.WithProxy(utils.GetProxy())).Root()
 
@@ -554,7 +560,7 @@ func (nm *nodejsManager) installNodePackages(
 			downloadScript := nodeDownloadScript(tarballURL, tarballFile)
 
 			replaceCmd := fmt.Sprintf(
-				`sh -c 'cd %s && `+
+				`sh -c 'cd -- "$1" && `+
 					`PKG_DIR="node_modules/%s" && `+
 					`if [ -d "$PKG_DIR" ]; then `+
 					`  echo "INFO: Replacing direct dependency %s with version %s" && `+
@@ -568,8 +574,7 @@ func (nm *nodejsManager) installNodePackages(
 					`  fi; `+
 					`else `+
 					`  echo "WARN: %s not found in node_modules, skipping"; `+
-					`fi'`,
-				workDir,
+					`fi' -- %s`,
 				u.Name,
 				u.Name, u.FixedVersion,
 				downloadScript,
@@ -578,6 +583,7 @@ func (nm *nodejsManager) installNodePackages(
 				u.Name,
 				u.Name, u.FixedVersion,
 				u.Name,
+				shellQuote(workDir),
 			)
 
 			log.Infof("Replacing direct dependency %s@%s in %s", u.Name, u.FixedVersion, workDir)
@@ -610,7 +616,7 @@ func (nm *nodejsManager) installNodePackages(
 			downloadScript := nodeDownloadScript(tarballURL, tarballFile)
 
 			replaceCmd := fmt.Sprintf(
-				`sh -c 'cd %s && `+
+				`sh -c 'cd -- "$1" && `+
 					`if %s; then `+
 					`  PKG_NAME="%s" && `+
 					`  FOUND=0 && `+
@@ -627,8 +633,7 @@ func (nm *nodejsManager) installNodePackages(
 					`  if [ "$FOUND" -eq 0 ]; then echo "WARN: %s not found in node_modules"; fi; `+
 					`else `+
 					`  echo "WARN: failed to download %s@%s, skipping"; `+
-					`fi'`,
-				workDir,
+					`fi' -- %s`,
 				downloadScript,
 				u.Name,
 				u.FixedVersion,
@@ -636,6 +641,7 @@ func (nm *nodejsManager) installNodePackages(
 				tarballFile,
 				u.Name,
 				u.Name, u.FixedVersion,
+				shellQuote(workDir),
 			)
 
 			log.Infof("Replacing transitive dependency %s@%s in %s", u.Name, u.FixedVersion, workDir)
@@ -649,11 +655,11 @@ func (nm *nodejsManager) installNodePackages(
 	// == Step 3: Final Cleanup ==
 	log.Infof("Running final cleanup for %s...", workDir)
 	cleanupCmd := fmt.Sprintf(
-		`sh -c 'cd %s && `+
+		`sh -c 'cd -- "$1" && `+
 			`npm prune --omit=dev --legacy-peer-deps 2>&1 | grep -v "^npm warn" || true && `+
 			`npm dedupe --omit=dev --legacy-peer-deps 2>&1 | grep -v "^npm warn" || true && `+
-			`(rm -rf /root/.npm ~/.npm /home/*/.npm /tmp/npm-* 2>&1 || echo "WARN: Cache cleanup failed")'`,
-		workDir,
+			`(rm -rf /root/.npm ~/.npm /home/*/.npm /tmp/npm-* 2>&1 || echo "WARN: Cache cleanup failed")' -- %s`,
+		shellQuote(workDir),
 	)
 	state = state.Run(
 		llb.Shlex(cleanupCmd),
@@ -977,10 +983,10 @@ func (nm *nodejsManager) upgradeGlobalPackages(
 		// This ensures global packages don't include development dependencies
 		log.Debugf("Removing devDependencies from package.json for global package %s", pkgName)
 		removeDevDepsCmd := fmt.Sprintf(
-			`sh -c 'cd %s && `+
+			`sh -c 'cd -- "$1" && `+
 				`node -e "const fs=require('\''fs'\''); const pkg=JSON.parse(fs.readFileSync('\''package.json'\'')); `+
-				`delete pkg.devDependencies; fs.writeFileSync('\''package.json'\'', JSON.stringify(pkg, null, 2));"'`,
-			pkgPath,
+				`delete pkg.devDependencies; fs.writeFileSync('\''package.json'\'', JSON.stringify(pkg, null, 2));"' -- %s`,
+			shellQuote(pkgPath),
 		)
 		state = state.Run(llb.Shlex(removeDevDepsCmd), llb.WithProxy(utils.GetProxy())).Root()
 
@@ -1010,7 +1016,7 @@ func (nm *nodejsManager) upgradeGlobalPackages(
 				downloadScript := nodeDownloadScript(tarballURL, tarballFile)
 
 				replaceCmd := fmt.Sprintf(
-					`sh -c 'cd %s && `+
+					`sh -c 'cd -- "$1" && `+
 						`PKG_DIR="node_modules/%s" && `+
 						`if [ -d "$PKG_DIR" ]; then `+
 						`  echo "INFO: Replacing direct dependency %s with version %s" && `+
@@ -1024,8 +1030,7 @@ func (nm *nodejsManager) upgradeGlobalPackages(
 						`  fi; `+
 						`else `+
 						`  echo "WARN: %s not found in node_modules, skipping"; `+
-						`fi'`,
-					pkgPath,
+						`fi' -- %s`,
 					u.Name,
 					u.Name, u.FixedVersion,
 					downloadScript,
@@ -1034,6 +1039,7 @@ func (nm *nodejsManager) upgradeGlobalPackages(
 					u.Name,
 					u.Name, u.FixedVersion,
 					u.Name,
+					shellQuote(pkgPath),
 				)
 
 				log.Infof("Replacing direct dependency %s@%s in global package %s", u.Name, u.FixedVersion, pkgName)
@@ -1059,7 +1065,7 @@ func (nm *nodejsManager) upgradeGlobalPackages(
 				downloadScript := nodeDownloadScript(tarballURL, tarballFile)
 
 				replaceCmd := fmt.Sprintf(
-					`sh -c 'cd %s && `+
+					`sh -c 'cd -- "$1" && `+
 						`if %s; then `+
 						`  PKG_NAME="%s" && `+
 						`  FOUND=0 && `+
@@ -1076,8 +1082,7 @@ func (nm *nodejsManager) upgradeGlobalPackages(
 						`  if [ "$FOUND" -eq 0 ]; then echo "WARN: %s not found in node_modules"; fi; `+
 						`else `+
 						`  echo "WARN: failed to download %s@%s, skipping"; `+
-						`fi'`,
-					pkgPath,
+						`fi' -- %s`,
 					downloadScript,
 					u.Name,
 					u.FixedVersion,
@@ -1085,6 +1090,7 @@ func (nm *nodejsManager) upgradeGlobalPackages(
 					tarballFile,
 					u.Name,
 					u.Name, u.FixedVersion,
+					shellQuote(pkgPath),
 				)
 
 				log.Infof("Replacing transitive dependency %s@%s in global package %s", u.Name, u.FixedVersion, pkgName)

--- a/pkg/langmgr/nodejs_test.go
+++ b/pkg/langmgr/nodejs_test.go
@@ -346,3 +346,28 @@ func TestGetNpmTarballURL(t *testing.T) {
 		})
 	}
 }
+
+func TestShellQuote(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "simple path",
+			in:   "/app",
+			want: "'/app'",
+		},
+		{
+			name: "path with single quote",
+			in:   "/tmp/o'hare/app",
+			want: "'/tmp/o'\"'\"'hare/app'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shellQuote(tt.in))
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
- The Node.js patching flow derived application directories from untrusted `PkgPath` values and interpolated them directly into `sh -c 'cd %s && ...'` commands, creating a command-injection vector. 
- The fix must be minimal and preserve existing patching behavior while preventing shell metacharacters from breaking out of the scripted shell context.

### Description
- Add `shellQuote(s string) string` to escape embedded single quotes and produce a safely quoted shell argument. 
- Change vulnerable `sh -c` usages to pass the directory as a positional parameter (`$1`) via `sh -c 'cd -- "$1" && ...' -- %s` and supply the quoted directory using `shellQuote(...)` to avoid direct interpolation. 
- Apply the safer pattern across app-level flows and global-package flows where `workDir`/`pkgPath` was previously interpolated (devDependency removal, direct and transitive replacement commands, and cleanup steps). 
- Add `TestShellQuote` unit tests to validate quoting behavior for typical and single-quote-containing paths.

### Testing
- Ran unit tests for the modified package with `go test ./pkg/langmgr`, which passed (`ok github.com/project-copacetic/copacetic/pkg/langmgr`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d78bd22850832a9b40f359eabe161b)