### PR TITLE
fix: validate rpm package names before distroless shell execution

### DIFF
--- a/pkg/pkgmgr/rpm.go
+++ b/pkg/pkgmgr/rpm.go
@@ -673,6 +673,12 @@ func (rm *rpmManager) checkForUpgrades(ctx context.Context, toolPath, checkUpdat
 }
 
 func (rm *rpmManager) unpackAndMergeUpdates(ctx context.Context, updates unversioned.UpdatePackages, toolImage string, platform *ocispecs.Platform, ignoreErrors bool) (*llb.State, []byte, error) {
+	if updates != nil {
+		if err := ValidateOSPackageNames(updates); err != nil {
+			return nil, nil, fmt.Errorf("package name validation failed: %w", err)
+		}
+	}
+
 	// Spin up a build tooling container to fetch and unpack packages to create patch layer.
 	// Pull family:version -> need to create version to base image map
 


### PR DESCRIPTION
### Motivation
- Prevent command injection from untrusted update manifest package names because `unpackAndMergeUpdates` builds a shell command and runs it via `buildkit.Sh` (which executes `/bin/sh -c`).

### Description
- Add a call to `ValidateOSPackageNames(updates)` at the start of `rpmManager.unpackAndMergeUpdates` in `pkg/pkgmgr/rpm.go` and return an error on invalid names to stop unsafe package names before any shell command construction or execution.

### Testing
- Ran `go test ./pkg/pkgmgr`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7f68ccb34832ab3eb92be80200aeb)