### PR TITLE
feat: fallback source resolution for Go binary patching on stripped/distroless images

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -45,6 +45,7 @@ type patchArgs struct {
 	pkgTypes            string
 	libraryPatchLevel   string
 	toolchainPatchLevel string
+	goVCSURL            string
 	progress            string
 	ociDir              string
 	eolAPIBaseURL       string
@@ -103,6 +104,7 @@ copa patch --config copa-bulk-config.yaml --push (Bulk Image Patching)`,
 				PkgTypes:            ua.pkgTypes,
 				LibraryPatchLevel:   ua.libraryPatchLevel,
 				ToolchainPatchLevel: ua.toolchainPatchLevel,
+				GoVCSURL:            ua.goVCSURL,
 				Progress:            progressui.DisplayMode(ua.progress),
 				OCIDir:              ua.ociDir,
 				EOLAPIBaseURL:       ua.eolAPIBaseURL,
@@ -173,6 +175,8 @@ copa patch --config copa-bulk-config.yaml --push (Bulk Image Patching)`,
 				"Values: 'patch' (e.g., 1.23.0 -> 1.23.latest), 'minor' (e.g., 1.23 -> 1.25), 'major'. "+
 				"Currently supported for Go only. Requires 'library' in --pkg-types")
 		flags.Lookup("toolchain-patch-level").NoOptDefVal = utils.PatchTypePatch
+		flags.StringVar(&ua.goVCSURL, "go-vcs-url", "",
+			"[EXPERIMENTAL] Override Go source repository and ref for binary rebuilds. Format: 'https://github.com/org/repo@ref'")
 	} else {
 		// Set default values when experimental flags are not enabled
 		ua.pkgTypes = utils.PkgTypeOS

--- a/pkg/langmgr/dotnet_test.go
+++ b/pkg/langmgr/dotnet_test.go
@@ -237,7 +237,7 @@ func TestGetLanguageManagers_DotnetAndPython(t *testing.T) {
 		},
 	}
 
-	managers := GetLanguageManagers(config, testWorkingFolder, manifest, "")
+	managers := GetLanguageManagers(config, testWorkingFolder, manifest, "", "", "")
 	// Expect two managers (order not strictly guaranteed)
 	assert.Len(t, managers, 2)
 
@@ -257,14 +257,14 @@ func TestGetLanguageManagers_DotnetAndPython(t *testing.T) {
 func TestGetLanguageManagers_None(t *testing.T) {
 	config := &buildkit.Config{}
 	manifest := &unversioned.UpdateManifest{LangUpdates: unversioned.LangUpdatePackages{}}
-	managers := GetLanguageManagers(config, testWorkingFolder, manifest, "")
+	managers := GetLanguageManagers(config, testWorkingFolder, manifest, "", "", "")
 	assert.Len(t, managers, 0)
 }
 
 func TestGetLanguageManagers_DotnetOnly(t *testing.T) {
 	config := &buildkit.Config{}
 	manifest := &unversioned.UpdateManifest{LangUpdates: unversioned.LangUpdatePackages{{Name: "Newtonsoft.Json", FixedVersion: "13.0.3", Type: utils.DotNetPackages}}}
-	managers := GetLanguageManagers(config, testWorkingFolder, manifest, "")
+	managers := GetLanguageManagers(config, testWorkingFolder, manifest, "", "", "")
 	assert.Len(t, managers, 1)
 	_, ok := managers[0].(*dotnetManager)
 	assert.True(t, ok, "expected first manager to be dotnetManager")

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -713,15 +713,16 @@ func (gm *golangManager) attemptBinaryRebuild(
 		binaryNeedsStdlib := false
 		if stdlibFixedVersion != "" {
 			binaryGoVersion := strings.TrimPrefix(binaryInfo.GoVersion, "go")
-			if binaryGoVersion == "" {
+			switch {
+			case binaryGoVersion == "":
 				// Synthetic binaries from distroless fallback have no Go version info.
 				// Assume they need stdlib rebuild since we can't prove otherwise.
 				binaryNeedsStdlib = true
 				log.Infof("  Binary %s has unknown Go version (synthetic), assuming stdlib rebuild needed", binaryPath)
-			} else if isValidGoVersion(binaryGoVersion) && isLessThanGoVersion(binaryGoVersion, stdlibFixedVersion) {
+			case isValidGoVersion(binaryGoVersion) && isLessThanGoVersion(binaryGoVersion, stdlibFixedVersion):
 				binaryNeedsStdlib = true
-				log.Debugf("  Binary %s (Go %s) needs stdlib upgrade to >= %s", binaryPath, binaryGoVersion, stdlibFixedVersion)
-			} else {
+				log.Infof("  Binary %s (Go %s) needs stdlib upgrade to >= %s", binaryPath, binaryGoVersion, stdlibFixedVersion)
+			default:
 				log.Debugf("  Binary %s (Go %s) already has stdlib >= %s, no stdlib rebuild needed", binaryPath, binaryGoVersion, stdlibFixedVersion)
 			}
 		}

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/moby/buildkit/client/llb"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
 	"github.com/project-copacetic/copacetic/pkg/provenance"
 	"github.com/project-copacetic/copacetic/pkg/types/unversioned"
@@ -168,6 +169,7 @@ func filterGoPackages(langUpdates unversioned.LangUpdatePackages) (unversioned.L
 				continue
 			}
 			goPackages = append(goPackages, pkg)
+			log.Debugf("filterGoPackages: keeping %s@%s → %s (type=%s, path=%s)", pkg.Name, pkg.InstalledVersion, pkg.FixedVersion, pkg.Type, pkg.PkgPath)
 		}
 	}
 	return goPackages, stdlibFixedVersion
@@ -650,6 +652,7 @@ func (gm *golangManager) attemptBinaryRebuild(
 
 	// Build update map from updates (shared across all binaries)
 	updateMap := make(map[string]string)
+	log.Debugf("[updateMap] building from %d updates", len(updates))
 	for _, update := range updates {
 		if update.FixedVersion == "" {
 			log.Debugf("Skipping %s: no fixed version available", update.Name)
@@ -799,7 +802,25 @@ func (gm *golangManager) attemptBinaryRebuild(
 			continue
 		}
 
-		// Success - update state for next iteration
+		// Verify the rebuild actually works by doing an intermediate Solve.
+		// RebuildBinary only constructs the LLB graph — it doesn't execute it.
+		// Without this check, Copa logs success but the build may fail later.
+		verifyDef, verifyErr := newState.Marshal(ctx)
+		if verifyErr != nil {
+			log.Warnf("Failed to marshal rebuild state for %s (skipping): %v", binaryPath, verifyErr)
+			rebuildFailures = append(rebuildFailures, rebuildFailure{binaryPath: binaryPath, reason: fmt.Sprintf("marshal error: %v", verifyErr)})
+			continue
+		}
+		_, solveErr := gm.config.Client.Solve(ctx, gwclient.SolveRequest{
+			Definition: verifyDef.ToPB(),
+		})
+		if solveErr != nil {
+			log.Warnf("Binary rebuild for %s built LLB successfully but execution failed (skipping): %v", binaryPath, solveErr)
+			rebuildFailures = append(rebuildFailures, rebuildFailure{binaryPath: binaryPath, reason: fmt.Sprintf("build execution failed: %v", solveErr)})
+			continue
+		}
+
+		// Verified — update state for next iteration
 		state = &newState
 		totalRebuilt++
 		log.Debugf("Prepared rebuild for binary: %s", binaryPath)

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -545,10 +545,12 @@ func (f rebuildFailure) String() string {
 func collectGoBinaryInfo(langUpdates unversioned.LangUpdatePackages) (paths []string, goVersion string) {
 	seen := make(map[string]bool)
 	for _, u := range langUpdates {
-		if u.Type != utils.GoBinary && u.Type != utils.GoModules {
+		// Only gobinary entries carry binary paths via PkgPath. GoModules entries' PkgPath
+		// points at go.mod/go.sum locations which are not useful for synthetic BinaryInfo.
+		if u.Type != utils.GoBinary {
 			continue
 		}
-		// Extract Go version from stdlib entries (e.g., "v1.26.0" → "1.26.0")
+		// Extract Go version from stdlib entries (e.g., "v1.26.0" -> "1.26.0").
 		if u.Name == "stdlib" && goVersion == "" && u.InstalledVersion != "" {
 			goVersion = strings.TrimPrefix(u.InstalledVersion, "v")
 		}
@@ -683,6 +685,10 @@ func (gm *golangManager) attemptBinaryRebuild(
 	totalAttempted := 0
 	var rebuildFailures []rebuildFailure
 
+	// Image-level metadata reused across every binary in this image. Parse once to avoid
+	// re-unmarshalling the OCI config for every binary.
+	imageSourceLabel := extractOCISourceLabel(gm.config)
+
 	// Process each detected binary
 	for i, binaryInfo := range binaries {
 		binaryPath := binaryInfo.Path
@@ -758,26 +764,34 @@ func (gm *golangManager) attemptBinaryRebuild(
 			}
 		}
 
+		// Resolution paths cloneSourceCode supports: VCS metadata (sourceCommit + sourceRepo),
+		// --go-vcs-url override, OCI source label + image tag, or image-tag heuristic. Only
+		// fail-fast here when none of these can fire; otherwise let cloneSourceCode try and
+		// produce its specific error if every fallback ultimately fails.
+		hasFallback := gm.goVCSURL != "" || imageSourceLabel != "" || gm.imageRef != ""
 		switch {
-		case sourceCommit == "":
-			log.Warnf("  Binary %s has no VCS commit info and no OCI revision label. "+
-				"Cannot rebuild without source.", binaryPath)
-			rebuildFailures = append(rebuildFailures, rebuildFailure{binaryPath: binaryPath, reason: "no source commit available"})
+		case sourceCommit == "" && sourceRepo == "" && !hasFallback:
+			log.Warnf("  Binary %s has no VCS info, no --go-vcs-url, no OCI source label, "+
+				"and no image tag. Cannot rebuild without source.", binaryPath)
+			rebuildFailures = append(rebuildFailures, rebuildFailure{binaryPath: binaryPath, reason: "no source resolution path"})
 			continue
-		case sourceRepo == "":
-			log.Warnf("  Binary %s has commit %s but no source repo could be derived. "+
+		case sourceCommit != "" && sourceRepo == "" && !hasFallback:
+			log.Warnf("  Binary %s has commit %s but no source repo and no fallback. "+
 				"Cannot rebuild without source.", binaryPath, sourceCommit)
 			rebuildFailures = append(rebuildFailures, rebuildFailure{binaryPath: binaryPath, reason: "no source repo"})
 			continue
 		default:
-			log.Debugf("  Source: %s @ %s", sourceRepo, sourceCommit)
+			if sourceCommit != "" && sourceRepo != "" {
+				log.Debugf("  Source: %s @ %s", sourceRepo, sourceCommit)
+			} else {
+				log.Debugf("  Source: deferring resolution to cloneSourceCode (fallback path)")
+			}
 		}
 
 		for module, version := range filteredUpdateMap {
 			log.Debugf("  Will update %s to %s", module, version)
 		}
 
-		// Create rebuild context for this binary
 		rebuildCtx := &provenance.RebuildContext{
 			Strategy:         provenance.RebuildStrategyHeuristic,
 			BuildInfo:        buildInfo,
@@ -785,7 +799,7 @@ func (gm *golangManager) attemptBinaryRebuild(
 			ImageLabels:      gm.config.ImageLabels,
 			ImageRef:         gm.imageRef,
 			GoVCSURL:         gm.goVCSURL,
-			ImageSourceLabel: extractOCISourceLabel(gm.config),
+			ImageSourceLabel: imageSourceLabel,
 		}
 
 		// Attempt to rebuild this binary and merge into current state

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -42,6 +42,7 @@ type golangManager struct {
 	toolchainPatchLevel string
 	goVCSURL            string
 	imageRef            string
+	goBinaryPaths       []string // binary paths from all gobinary updates (including stdlib)
 }
 
 // validateGoPackageName validates a Go module name for safety and correctness.
@@ -184,6 +185,10 @@ func (gm *golangManager) InstallUpdates(
 	// Filter for Go packages only
 	goUpdates, stdlibFixedVersion := filterGoPackages(manifest.LangUpdates)
 	hasStdlib := stdlibFixedVersion != ""
+
+	// Collect binary paths from ALL gobinary updates (including stdlib) for
+	// the synthetic binary fallback on distroless images where detection fails.
+	gm.goBinaryPaths = collectGoBinaryPaths(manifest.LangUpdates)
 
 	// Only act on stdlib vulns if user explicitly opted in via --toolchain-patch-level
 	if hasStdlib && gm.toolchainPatchLevel == "" {
@@ -532,21 +537,30 @@ func (f rebuildFailure) String() string {
 	return fmt.Sprintf("%s: %s", f.binaryPath, f.reason)
 }
 
-// buildSyntheticBinaryInfo constructs BinaryInfo entries from Trivy report data
-// when go version -m detection fails (e.g., distroless/scratch images without a shell).
-// Binary paths come from UpdatePackage.PkgPath, which Trivy sets from the gobinary
-// scan result's Target field.
-func buildSyntheticBinaryInfo(updates unversioned.LangUpdatePackages, goVCSURL string) []*provenance.BinaryInfo {
+// collectGoBinaryPaths extracts unique binary paths from all gobinary updates,
+// including stdlib entries that filterGoPackages strips out. These paths are needed
+// for the synthetic binary fallback when go version -m detection fails.
+func collectGoBinaryPaths(langUpdates unversioned.LangUpdatePackages) []string {
 	seen := make(map[string]bool)
+	var paths []string
+	for _, u := range langUpdates {
+		if (u.Type == utils.GoBinary || u.Type == utils.GoModules) && u.PkgPath != "" && !seen[u.PkgPath] {
+			seen[u.PkgPath] = true
+			paths = append(paths, u.PkgPath)
+		}
+	}
+	return paths
+}
+
+// buildSyntheticBinaryInfo constructs BinaryInfo entries from collected binary paths
+// when go version -m detection fails (e.g., distroless/scratch images without a shell).
+// binaryPaths comes from collectGoBinaryPaths which includes paths from ALL gobinary
+// updates (including stdlib entries stripped by filterGoPackages).
+func buildSyntheticBinaryInfo(binaryPaths []string, goVCSURL string) []*provenance.BinaryInfo {
 	var binaries []*provenance.BinaryInfo
 
-	for _, u := range updates {
-		if u.PkgPath == "" || seen[u.PkgPath] {
-			continue
-		}
-		seen[u.PkgPath] = true
-
-		path := u.PkgPath
+	for _, p := range binaryPaths {
+		path := p
 		if !strings.HasPrefix(path, "/") {
 			path = "/" + path
 		}
@@ -601,7 +615,7 @@ func (gm *golangManager) attemptBinaryRebuild(
 	// `go version -m` cannot run due to missing shell.
 	if (detectErr != nil || len(binaries) == 0) && gm.goVCSURL != "" {
 		log.Info("Binary detection unavailable (distroless/scratch image?), falling back to Trivy report + --go-vcs-url")
-		binaries = buildSyntheticBinaryInfo(updates, gm.goVCSURL)
+		binaries = buildSyntheticBinaryInfo(gm.goBinaryPaths, gm.goVCSURL)
 		if len(binaries) > 0 {
 			log.Infof("Constructed %d synthetic binary entries from Trivy report", len(binaries))
 		}

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -43,6 +43,7 @@ type golangManager struct {
 	goVCSURL            string
 	imageRef            string
 	goBinaryPaths       []string // binary paths from all gobinary updates (including stdlib)
+	goBinaryGoVersion   string   // Go version from stdlib entries (e.g., "1.26.0")
 }
 
 // validateGoPackageName validates a Go module name for safety and correctness.
@@ -188,7 +189,7 @@ func (gm *golangManager) InstallUpdates(
 
 	// Collect binary paths from ALL gobinary updates (including stdlib) for
 	// the synthetic binary fallback on distroless images where detection fails.
-	gm.goBinaryPaths = collectGoBinaryPaths(manifest.LangUpdates)
+	gm.goBinaryPaths, gm.goBinaryGoVersion = collectGoBinaryInfo(manifest.LangUpdates)
 
 	// Only act on stdlib vulns if user explicitly opted in via --toolchain-patch-level
 	if hasStdlib && gm.toolchainPatchLevel == "" {
@@ -537,26 +538,31 @@ func (f rebuildFailure) String() string {
 	return fmt.Sprintf("%s: %s", f.binaryPath, f.reason)
 }
 
-// collectGoBinaryPaths extracts unique binary paths from all gobinary updates,
-// including stdlib entries that filterGoPackages strips out. These paths are needed
-// for the synthetic binary fallback when go version -m detection fails.
-func collectGoBinaryPaths(langUpdates unversioned.LangUpdatePackages) []string {
+// collectGoBinaryInfo extracts unique binary paths and the installed Go version
+// from all gobinary updates, including stdlib entries that filterGoPackages strips.
+func collectGoBinaryInfo(langUpdates unversioned.LangUpdatePackages) (paths []string, goVersion string) {
 	seen := make(map[string]bool)
-	var paths []string
 	for _, u := range langUpdates {
-		if (u.Type == utils.GoBinary || u.Type == utils.GoModules) && u.PkgPath != "" && !seen[u.PkgPath] {
+		if u.Type != utils.GoBinary && u.Type != utils.GoModules {
+			continue
+		}
+		// Extract Go version from stdlib entries (e.g., "v1.26.0" → "1.26.0")
+		if u.Name == "stdlib" && goVersion == "" && u.InstalledVersion != "" {
+			goVersion = strings.TrimPrefix(u.InstalledVersion, "v")
+		}
+		if u.PkgPath != "" && !seen[u.PkgPath] {
 			seen[u.PkgPath] = true
 			paths = append(paths, u.PkgPath)
 		}
 	}
-	return paths
+	return
 }
 
 // buildSyntheticBinaryInfo constructs BinaryInfo entries from collected binary paths
 // when go version -m detection fails (e.g., distroless/scratch images without a shell).
 // binaryPaths comes from collectGoBinaryPaths which includes paths from ALL gobinary
 // updates (including stdlib entries stripped by filterGoPackages).
-func buildSyntheticBinaryInfo(binaryPaths []string, goVCSURL string) []*provenance.BinaryInfo {
+func buildSyntheticBinaryInfo(binaryPaths []string, goVCSURL string, goVersion string) []*provenance.BinaryInfo {
 	var binaries []*provenance.BinaryInfo
 
 	for _, p := range binaryPaths {
@@ -574,6 +580,7 @@ func buildSyntheticBinaryInfo(binaryPaths []string, goVCSURL string) []*provenan
 		log.Infof("  Synthetic binary: %s (module: %s)", path, modulePath)
 		binaries = append(binaries, &provenance.BinaryInfo{
 			Path:          path,
+			GoVersion:     goVersion, // from stdlib InstalledVersion or empty
 			ModulePath:    modulePath,
 			Dependencies:  make(map[string]string),
 			BuildSettings: map[string]string{"CGO_ENABLED": "0"},
@@ -615,7 +622,7 @@ func (gm *golangManager) attemptBinaryRebuild(
 	// `go version -m` cannot run due to missing shell.
 	if (detectErr != nil || len(binaries) == 0) && gm.goVCSURL != "" {
 		log.Info("Binary detection unavailable (distroless/scratch image?), falling back to Trivy report + --go-vcs-url")
-		binaries = buildSyntheticBinaryInfo(gm.goBinaryPaths, gm.goVCSURL)
+		binaries = buildSyntheticBinaryInfo(gm.goBinaryPaths, gm.goVCSURL, gm.goBinaryGoVersion)
 		if len(binaries) > 0 {
 			log.Infof("Constructed %d synthetic binary entries from Trivy report", len(binaries))
 		}
@@ -703,7 +710,12 @@ func (gm *golangManager) attemptBinaryRebuild(
 		binaryNeedsStdlib := false
 		if stdlibFixedVersion != "" {
 			binaryGoVersion := strings.TrimPrefix(binaryInfo.GoVersion, "go")
-			if isValidGoVersion(binaryGoVersion) && isLessThanGoVersion(binaryGoVersion, stdlibFixedVersion) {
+			if binaryGoVersion == "" {
+				// Synthetic binaries from distroless fallback have no Go version info.
+				// Assume they need stdlib rebuild since we can't prove otherwise.
+				binaryNeedsStdlib = true
+				log.Infof("  Binary %s has unknown Go version (synthetic), assuming stdlib rebuild needed", binaryPath)
+			} else if isValidGoVersion(binaryGoVersion) && isLessThanGoVersion(binaryGoVersion, stdlibFixedVersion) {
 				binaryNeedsStdlib = true
 				log.Debugf("  Binary %s (Go %s) needs stdlib upgrade to >= %s", binaryPath, binaryGoVersion, stdlibFixedVersion)
 			} else {

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -39,6 +39,8 @@ type golangManager struct {
 	config              *buildkit.Config
 	workingFolder       string
 	toolchainPatchLevel string
+	goVCSURL            string
+	imageRef            string
 }
 
 // validateGoPackageName validates a Go module name for safety and correctness.
@@ -697,6 +699,8 @@ func (gm *golangManager) attemptBinaryRebuild(
 			BuildInfo:   buildInfo,
 			BinaryInfo:  []*provenance.BinaryInfo{binaryInfo},
 			ImageLabels: gm.config.ImageLabels,
+			ImageRef:    gm.imageRef,
+			GoVCSURL:    gm.goVCSURL,
 		}
 
 		// Attempt to rebuild this binary and merge into current state

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -2,6 +2,7 @@ package langmgr
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -695,12 +696,13 @@ func (gm *golangManager) attemptBinaryRebuild(
 
 		// Create rebuild context for this binary
 		rebuildCtx := &provenance.RebuildContext{
-			Strategy:    provenance.RebuildStrategyHeuristic,
-			BuildInfo:   buildInfo,
-			BinaryInfo:  []*provenance.BinaryInfo{binaryInfo},
-			ImageLabels: gm.config.ImageLabels,
-			ImageRef:    gm.imageRef,
-			GoVCSURL:    gm.goVCSURL,
+			Strategy:         provenance.RebuildStrategyHeuristic,
+			BuildInfo:        buildInfo,
+			BinaryInfo:       []*provenance.BinaryInfo{binaryInfo},
+			ImageLabels:      gm.config.ImageLabels,
+			ImageRef:         gm.imageRef,
+			GoVCSURL:         gm.goVCSURL,
+			ImageSourceLabel: extractOCISourceLabel(gm.config),
 		}
 
 		// Attempt to rebuild this binary and merge into current state
@@ -956,4 +958,28 @@ func (gm *golangManager) upgradePackagesWithTooling(
 	log.Warn("Note: Go binaries are not automatically rebuilt in tooling container strategy. Updated go.mod/go.sum only.")
 
 	return &state, failedPackages, nil
+}
+
+// extractOCISourceLabel reads org.opencontainers.image.source from the image's OCI config labels.
+// Returns empty string if the label is not present or the config can't be parsed.
+func extractOCISourceLabel(config *buildkit.Config) string {
+	if config == nil || len(config.ConfigData) == 0 {
+		return ""
+	}
+
+	var imageConfig struct {
+		Config struct {
+			Labels map[string]string `json:"labels"`
+		} `json:"config"`
+	}
+	if err := json.Unmarshal(config.ConfigData, &imageConfig); err != nil {
+		log.Debugf("Could not parse image config for OCI labels: %v", err)
+		return ""
+	}
+
+	source := imageConfig.Config.Labels["org.opencontainers.image.source"]
+	if source != "" {
+		log.Debugf("Found OCI label org.opencontainers.image.source: %s", source)
+	}
+	return source
 }

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -532,6 +532,45 @@ func (f rebuildFailure) String() string {
 	return fmt.Sprintf("%s: %s", f.binaryPath, f.reason)
 }
 
+// buildSyntheticBinaryInfo constructs BinaryInfo entries from Trivy report data
+// when go version -m detection fails (e.g., distroless/scratch images without a shell).
+// Binary paths come from UpdatePackage.PkgPath, which Trivy sets from the gobinary
+// scan result's Target field.
+func buildSyntheticBinaryInfo(updates unversioned.LangUpdatePackages, goVCSURL string) []*provenance.BinaryInfo {
+	seen := make(map[string]bool)
+	var binaries []*provenance.BinaryInfo
+
+	for _, u := range updates {
+		if u.PkgPath == "" || seen[u.PkgPath] {
+			continue
+		}
+		seen[u.PkgPath] = true
+
+		path := u.PkgPath
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+
+		// Derive module path from VCS URL (e.g., "https://github.com/org/repo@ref" -> "github.com/org/repo")
+		modulePath := ""
+		if i := strings.LastIndex(goVCSURL, "@"); i > 0 {
+			modulePath = strings.TrimPrefix(goVCSURL[:i], "https://")
+		}
+
+		log.Infof("  Synthetic binary: %s (module: %s)", path, modulePath)
+		binaries = append(binaries, &provenance.BinaryInfo{
+			Path:          path,
+			ModulePath:    modulePath,
+			Dependencies:  make(map[string]string),
+			BuildSettings: map[string]string{"CGO_ENABLED": "0"},
+			VCS:           make(map[string]string),
+			FileMode:      "0755",
+			FileOwner:     "0:0",
+		})
+	}
+	return binaries
+}
+
 // attemptBinaryRebuild attempts to rebuild Go binaries using heuristic binary detection.
 // When stdlibFixedVersion is set, only binaries built with a Go version older than
 // that version are rebuilt for stdlib fixes. Binaries already on a new enough Go
@@ -554,14 +593,28 @@ func (gm *golangManager) attemptBinaryRebuild(
 	binaries, detectErr := detector.DetectGoBinaries(ctx, gm.config.Client, currentState, gm.config.Platform)
 	if detectErr != nil {
 		log.Debugf("Binary detection failed: %v", detectErr)
-		return currentState, failedPackages, fmt.Errorf("binary detection failed: %w", detectErr)
+	}
+
+	// Fallback: when detection fails but --go-vcs-url is provided,
+	// construct synthetic BinaryInfo from Trivy report data (PkgPath field).
+	// This enables Go binary patching on distroless/scratch images where
+	// `go version -m` cannot run due to missing shell.
+	if (detectErr != nil || len(binaries) == 0) && gm.goVCSURL != "" {
+		log.Info("Binary detection unavailable (distroless/scratch image?), falling back to Trivy report + --go-vcs-url")
+		binaries = buildSyntheticBinaryInfo(updates, gm.goVCSURL)
+		if len(binaries) > 0 {
+			log.Infof("Constructed %d synthetic binary entries from Trivy report", len(binaries))
+		}
 	}
 
 	if len(binaries) == 0 {
+		if detectErr != nil {
+			return currentState, failedPackages, fmt.Errorf("binary detection failed: %w", detectErr)
+		}
 		return currentState, failedPackages, fmt.Errorf("no Go binaries detected in image")
 	}
 
-	log.Infof("Detected %d Go binaries via go version -m", len(binaries))
+	log.Infof("Processing %d Go binaries for rebuild", len(binaries))
 
 	// Log what we found
 	for _, bi := range binaries {

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -786,56 +786,84 @@ func TestRebuildFailureSliceFormat(t *testing.T) {
 		"rebuildFailure slice must format identically to the old []string representation")
 }
 
+func TestCollectGoBinaryPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		updates unversioned.LangUpdatePackages
+		want    []string
+	}{
+		{
+			name: "extracts paths from gobinary including stdlib",
+			updates: unversioned.LangUpdatePackages{
+				{Name: "stdlib", PkgPath: "manager", Type: utils.GoBinary},
+				{Name: "golang.org/x/crypto", PkgPath: "manager", Type: utils.GoBinary},
+			},
+			want: []string{"manager"},
+		},
+		{
+			name: "multiple binary paths",
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/crypto", PkgPath: "bin/consul", Type: utils.GoBinary},
+				{Name: "golang.org/x/net", PkgPath: "bin/consul-agent", Type: utils.GoBinary},
+			},
+			want: []string{"bin/consul", "bin/consul-agent"},
+		},
+		{
+			name:    "skips non-gobinary types",
+			updates: unversioned.LangUpdatePackages{{Name: "flask", PkgPath: "app/requirements.txt", Type: "pip"}},
+			want:    nil,
+		},
+		{
+			name:    "empty updates",
+			updates: unversioned.LangUpdatePackages{},
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := collectGoBinaryPaths(tt.updates)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
 func TestBuildSyntheticBinaryInfo(t *testing.T) {
 	tests := []struct {
 		name      string
-		updates   unversioned.LangUpdatePackages
+		paths     []string
 		goVCSURL  string
 		wantCount int
 		wantPaths []string
 		wantMod   string
 	}{
 		{
-			name: "single binary from Trivy report",
-			updates: unversioned.LangUpdatePackages{
-				{Name: "golang.org/x/crypto", PkgPath: "manager", Type: "gobinary"},
-				{Name: "golang.org/x/net", PkgPath: "manager", Type: "gobinary"},
-			},
+			name:      "single binary path",
+			paths:     []string{"manager"},
 			goVCSURL:  "https://github.com/grafana/grafana-operator@v5.22.0",
 			wantCount: 1,
 			wantPaths: []string{"/manager"},
 			wantMod:   "github.com/grafana/grafana-operator",
 		},
 		{
-			name: "multiple binaries with different paths",
-			updates: unversioned.LangUpdatePackages{
-				{Name: "golang.org/x/crypto", PkgPath: "bin/consul", Type: "gobinary"},
-				{Name: "golang.org/x/net", PkgPath: "bin/consul-agent", Type: "gobinary"},
-			},
+			name:      "multiple paths",
+			paths:     []string{"bin/consul", "bin/consul-agent"},
 			goVCSURL:  "https://github.com/hashicorp/consul@v1.22.4",
 			wantCount: 2,
 			wantPaths: []string{"/bin/consul", "/bin/consul-agent"},
 			wantMod:   "github.com/hashicorp/consul",
 		},
 		{
-			name: "path already has leading slash",
-			updates: unversioned.LangUpdatePackages{
-				{Name: "golang.org/x/crypto", PkgPath: "/usr/local/bin/app", Type: "gobinary"},
-			},
+			name:      "path already has leading slash",
+			paths:     []string{"/usr/local/bin/app"},
 			goVCSURL:  "https://github.com/example/app@v1.0.0",
 			wantCount: 1,
 			wantPaths: []string{"/usr/local/bin/app"},
 			wantMod:   "github.com/example/app",
 		},
 		{
-			name:      "no PkgPath in updates",
-			updates:   unversioned.LangUpdatePackages{{Name: "golang.org/x/crypto", Type: "gobinary"}},
-			goVCSURL:  "https://github.com/example/app@v1.0.0",
-			wantCount: 0,
-		},
-		{
-			name:      "empty updates",
-			updates:   unversioned.LangUpdatePackages{},
+			name:      "empty paths",
+			paths:     []string{},
 			goVCSURL:  "https://github.com/example/app@v1.0.0",
 			wantCount: 0,
 		},
@@ -843,7 +871,7 @@ func TestBuildSyntheticBinaryInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildSyntheticBinaryInfo(tt.updates, tt.goVCSURL)
+			result := buildSyntheticBinaryInfo(tt.paths, tt.goVCSURL)
 			assert.Len(t, result, tt.wantCount)
 
 			for i, wantPath := range tt.wantPaths {

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -563,7 +563,7 @@ func TestGetLanguageManagers_Go(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			managers := GetLanguageManagers(config, workingFolder, tt.manifest, "")
+			managers := GetLanguageManagers(config, workingFolder, tt.manifest, "", "", "")
 			assert.Len(t, managers, tt.expectedCount, "Expected %d managers, got %d", tt.expectedCount, len(managers))
 
 			var hasGoMgr, hasPythonMgr, hasNodeMgr bool
@@ -591,7 +591,7 @@ func TestGetLanguageManagers_Go(t *testing.T) {
 				{Name: "github.com/user/repo", Type: utils.GoModules, FixedVersion: "v1.2.3"},
 			},
 		}
-		managers := GetLanguageManagers(config, workingFolder, manifest, "minor")
+		managers := GetLanguageManagers(config, workingFolder, manifest, "minor", "", "")
 		require.Len(t, managers, 1)
 		goMgr, ok := managers[0].(*golangManager)
 		require.True(t, ok, "Expected golangManager")
@@ -604,7 +604,7 @@ func TestGetLanguageManagers_Go(t *testing.T) {
 				{Name: "github.com/user/repo", Type: utils.GoModules, FixedVersion: "v1.2.3"},
 			},
 		}
-		managers := GetLanguageManagers(config, workingFolder, manifest, "")
+		managers := GetLanguageManagers(config, workingFolder, manifest, "", "", "")
 		require.Len(t, managers, 1)
 		goMgr, ok := managers[0].(*golangManager)
 		require.True(t, ok, "Expected golangManager")

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -816,6 +816,24 @@ func TestCollectGoBinaryInfo(t *testing.T) {
 			updates:   unversioned.LangUpdatePackages{{Name: "flask", PkgPath: "app/requirements.txt", Type: "pip"}},
 			wantPaths: nil,
 		},
+		{
+			name: "skips gomod entries even if PkgPath set",
+			updates: unversioned.LangUpdatePackages{
+				{Name: "github.com/foo/bar", PkgPath: "src/go.mod", Type: utils.GoModules},
+				{Name: "stdlib", PkgPath: "manager", Type: utils.GoBinary, InstalledVersion: "v1.26.0"},
+			},
+			wantPaths:   []string{"manager"},
+			wantVersion: "1.26.0",
+		},
+		{
+			name: "all gomod, no binary paths returned",
+			updates: unversioned.LangUpdatePackages{
+				{Name: "github.com/foo/bar", PkgPath: "src/go.mod", Type: utils.GoModules},
+				{Name: "github.com/baz/qux", PkgPath: "src/go.sum", Type: utils.GoModules},
+			},
+			wantPaths:   nil,
+			wantVersion: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -785,3 +785,76 @@ func TestRebuildFailureSliceFormat(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%v", oldStyle), fmt.Sprintf("%v", failures),
 		"rebuildFailure slice must format identically to the old []string representation")
 }
+
+func TestBuildSyntheticBinaryInfo(t *testing.T) {
+	tests := []struct {
+		name      string
+		updates   unversioned.LangUpdatePackages
+		goVCSURL  string
+		wantCount int
+		wantPaths []string
+		wantMod   string
+	}{
+		{
+			name: "single binary from Trivy report",
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/crypto", PkgPath: "manager", Type: "gobinary"},
+				{Name: "golang.org/x/net", PkgPath: "manager", Type: "gobinary"},
+			},
+			goVCSURL:  "https://github.com/grafana/grafana-operator@v5.22.0",
+			wantCount: 1,
+			wantPaths: []string{"/manager"},
+			wantMod:   "github.com/grafana/grafana-operator",
+		},
+		{
+			name: "multiple binaries with different paths",
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/crypto", PkgPath: "bin/consul", Type: "gobinary"},
+				{Name: "golang.org/x/net", PkgPath: "bin/consul-agent", Type: "gobinary"},
+			},
+			goVCSURL:  "https://github.com/hashicorp/consul@v1.22.4",
+			wantCount: 2,
+			wantPaths: []string{"/bin/consul", "/bin/consul-agent"},
+			wantMod:   "github.com/hashicorp/consul",
+		},
+		{
+			name: "path already has leading slash",
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/crypto", PkgPath: "/usr/local/bin/app", Type: "gobinary"},
+			},
+			goVCSURL:  "https://github.com/example/app@v1.0.0",
+			wantCount: 1,
+			wantPaths: []string{"/usr/local/bin/app"},
+			wantMod:   "github.com/example/app",
+		},
+		{
+			name:      "no PkgPath in updates",
+			updates:   unversioned.LangUpdatePackages{{Name: "golang.org/x/crypto", Type: "gobinary"}},
+			goVCSURL:  "https://github.com/example/app@v1.0.0",
+			wantCount: 0,
+		},
+		{
+			name:      "empty updates",
+			updates:   unversioned.LangUpdatePackages{},
+			goVCSURL:  "https://github.com/example/app@v1.0.0",
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := buildSyntheticBinaryInfo(tt.updates, tt.goVCSURL)
+			assert.Len(t, result, tt.wantCount)
+
+			for i, wantPath := range tt.wantPaths {
+				if i < len(result) {
+					assert.Equal(t, wantPath, result[i].Path)
+					assert.Equal(t, tt.wantMod, result[i].ModulePath)
+					assert.Equal(t, "0", result[i].BuildSettings["CGO_ENABLED"])
+					assert.Equal(t, "0755", result[i].FileMode)
+					assert.Equal(t, "0:0", result[i].FileOwner)
+				}
+			}
+		})
+	}
+}

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -786,44 +786,43 @@ func TestRebuildFailureSliceFormat(t *testing.T) {
 		"rebuildFailure slice must format identically to the old []string representation")
 }
 
-func TestCollectGoBinaryPaths(t *testing.T) {
+func TestCollectGoBinaryInfo(t *testing.T) {
 	tests := []struct {
-		name    string
-		updates unversioned.LangUpdatePackages
-		want    []string
+		name        string
+		updates     unversioned.LangUpdatePackages
+		wantPaths   []string
+		wantVersion string
 	}{
 		{
-			name: "extracts paths from gobinary including stdlib",
+			name: "extracts paths and Go version from stdlib",
 			updates: unversioned.LangUpdatePackages{
-				{Name: "stdlib", PkgPath: "manager", Type: utils.GoBinary},
+				{Name: "stdlib", PkgPath: "manager", Type: utils.GoBinary, InstalledVersion: "v1.26.0"},
 				{Name: "golang.org/x/crypto", PkgPath: "manager", Type: utils.GoBinary},
 			},
-			want: []string{"manager"},
+			wantPaths:   []string{"manager"},
+			wantVersion: "1.26.0",
 		},
 		{
-			name: "multiple binary paths",
+			name: "multiple paths no stdlib",
 			updates: unversioned.LangUpdatePackages{
 				{Name: "golang.org/x/crypto", PkgPath: "bin/consul", Type: utils.GoBinary},
 				{Name: "golang.org/x/net", PkgPath: "bin/consul-agent", Type: utils.GoBinary},
 			},
-			want: []string{"bin/consul", "bin/consul-agent"},
+			wantPaths:   []string{"bin/consul", "bin/consul-agent"},
+			wantVersion: "",
 		},
 		{
-			name:    "skips non-gobinary types",
-			updates: unversioned.LangUpdatePackages{{Name: "flask", PkgPath: "app/requirements.txt", Type: "pip"}},
-			want:    nil,
-		},
-		{
-			name:    "empty updates",
-			updates: unversioned.LangUpdatePackages{},
-			want:    nil,
+			name:      "skips non-gobinary",
+			updates:   unversioned.LangUpdatePackages{{Name: "flask", PkgPath: "app/requirements.txt", Type: "pip"}},
+			wantPaths: nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := collectGoBinaryPaths(tt.updates)
-			assert.Equal(t, tt.want, result)
+			paths, goVersion := collectGoBinaryInfo(tt.updates)
+			assert.Equal(t, tt.wantPaths, paths)
+			assert.Equal(t, tt.wantVersion, goVersion)
 		})
 	}
 }
@@ -871,7 +870,7 @@ func TestBuildSyntheticBinaryInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := buildSyntheticBinaryInfo(tt.paths, tt.goVCSURL)
+			result := buildSyntheticBinaryInfo(tt.paths, tt.goVCSURL, "1.26.0")
 			assert.Len(t, result, tt.wantCount)
 
 			for i, wantPath := range tt.wantPaths {

--- a/pkg/langmgr/langmgr.go
+++ b/pkg/langmgr/langmgr.go
@@ -28,7 +28,7 @@ type LangManager interface {
 
 // GetLanguageManagers returns a list of language managers that have relevant packages to process.
 // Uses a switch-based approach to determine which managers to include based on package types.
-func GetLanguageManagers(config *buildkit.Config, workingFolder string, manifest *unversioned.UpdateManifest, toolchainPatchLevel string) []LangManager {
+func GetLanguageManagers(config *buildkit.Config, workingFolder string, manifest *unversioned.UpdateManifest, toolchainPatchLevel, goVCSURL, imageRef string) []LangManager {
 	var managers []LangManager
 
 	if manifest == nil || len(manifest.LangUpdates) == 0 {
@@ -49,7 +49,7 @@ func GetLanguageManagers(config *buildkit.Config, workingFolder string, manifest
 			managers = append(managers, &nodejsManager{config: config, workingFolder: workingFolder})
 		case utils.GoModules, utils.GoBinary:
 			if !goAdded {
-				managers = append(managers, &golangManager{config: config, workingFolder: workingFolder, toolchainPatchLevel: toolchainPatchLevel})
+				managers = append(managers, &golangManager{config: config, workingFolder: workingFolder, toolchainPatchLevel: toolchainPatchLevel, goVCSURL: goVCSURL, imageRef: imageRef})
 				goAdded = true
 			}
 		case utils.DotNetPackages:

--- a/pkg/langmgr/langmgr_test.go
+++ b/pkg/langmgr/langmgr_test.go
@@ -21,7 +21,7 @@ func TestGetLanguageManagers(t *testing.T) {
 
 	// Test with empty manifest
 	emptyManifest := &unversioned.UpdateManifest{}
-	managers := GetLanguageManagers(config, workingFolder, emptyManifest, "")
+	managers := GetLanguageManagers(config, workingFolder, emptyManifest, "", "", "")
 	assert.Empty(t, managers, "Should return no managers for empty manifest")
 
 	// Test with invalid package type
@@ -33,7 +33,7 @@ func TestGetLanguageManagers(t *testing.T) {
 			},
 		},
 	}
-	managers = GetLanguageManagers(config, workingFolder, invalidManifest, "")
+	managers = GetLanguageManagers(config, workingFolder, invalidManifest, "", "", "")
 	assert.Empty(t, managers, "Should return no managers for invalid manifest")
 
 	// Test with Python packages
@@ -45,7 +45,7 @@ func TestGetLanguageManagers(t *testing.T) {
 			},
 		},
 	}
-	managers = GetLanguageManagers(config, workingFolder, manifestWithPython, "")
+	managers = GetLanguageManagers(config, workingFolder, manifestWithPython, "", "", "")
 
 	assert.NotEmpty(t, managers, "Should return at least one language manager")
 	assert.Len(t, managers, 1, "Should return only Python manager when only python packages present")

--- a/pkg/langmgr/python_test.go
+++ b/pkg/langmgr/python_test.go
@@ -584,7 +584,7 @@ func TestPythonManagerType(t *testing.T) {
 			},
 		},
 	}
-	managers := GetLanguageManagers(config, workingFolder, manifest, "")
+	managers := GetLanguageManagers(config, workingFolder, manifest, "", "", "")
 	require.Len(t, managers, 1)
 
 	pythonMgr, ok := managers[0].(*pythonManager)

--- a/pkg/patch/core.go
+++ b/pkg/patch/core.go
@@ -41,6 +41,7 @@ type Options struct {
 
 	// Toolchain patch level (e.g., "patch", "minor", "major"; empty = disabled)
 	ToolchainPatchLevel string
+	GoVCSURL            string
 
 	// EOL configuration
 	ExitOnEOL bool
@@ -133,7 +134,7 @@ func ExecutePatchCore(patchCtx *Context, opts *Options) (*Result, error) {
 	// For normal Docker export, continue with solving but preserve states
 	// Handle Language Specific Updates
 	if updates != nil && len(updates.LangUpdates) > 0 {
-		languageManagers := langmgr.GetLanguageManagers(config, workingFolder, updates, opts.ToolchainPatchLevel)
+		languageManagers := langmgr.GetLanguageManagers(config, workingFolder, updates, opts.ToolchainPatchLevel, opts.GoVCSURL, opts.ImageName)
 		var langErrPkgsFromAllManagers []string
 		var combinedLangError error
 

--- a/pkg/patch/single.go
+++ b/pkg/patch/single.go
@@ -78,6 +78,7 @@ func patchSingleArchImage(
 	pkgTypes := opts.PkgTypes
 	libraryPatchLevel := opts.LibraryPatchLevel
 	toolchainPatchLevel := opts.ToolchainPatchLevel
+	goVCSURL := opts.GoVCSURL
 
 	if reportFile == "" && output != "" {
 		log.Warn("No vulnerability report was provided, so no VEX output will be generated.")
@@ -209,7 +210,7 @@ func patchSingleArchImage(
 	eg.Go(func() error {
 		defer pipeW.Close()
 		result, err := executePatchBuild(ctx, bkClient, buildConfig, buildkitImageRef, &targetPlatform,
-			workingFolder, updates, ignoreError, reportFile, format, output, patchedImageName, buildChannel, opts.ExitOnEOL, toolchainPatchLevel)
+			workingFolder, updates, ignoreError, reportFile, format, output, patchedImageName, buildChannel, opts.ExitOnEOL, toolchainPatchLevel, goVCSURL)
 		if err != nil {
 			return err
 		}
@@ -471,6 +472,7 @@ func executePatchBuild(
 	buildChannel chan *client.SolveStatus,
 	exitOnEOL bool,
 	toolchainPatchLevel string,
+	goVCSURL string,
 ) (*Result, error) {
 	var pkgType string
 	var validatedManifest *unversioned.UpdateManifest
@@ -510,6 +512,7 @@ func executePatchBuild(
 			ReturnState:         false, // Always solve for Docker export
 			ExitOnEOL:           exitOnEOL,
 			ToolchainPatchLevel: toolchainPatchLevel,
+			GoVCSURL:            goVCSURL,
 		}
 
 		// Execute the core patching logic

--- a/pkg/provenance/rebuilder.go
+++ b/pkg/provenance/rebuilder.go
@@ -648,6 +648,22 @@ func extractImageTag(imageRef string) string {
 	return imageRef[lastColon+1:]
 }
 
+// looksLikeSemverTag returns true if the tag looks like a version string
+// (e.g., "v1.2.3", "1.45.0", "v3.9.1-rc1"). This prevents the image tag
+// heuristic from trying non-version tags like "latest", "stable", or "alpine"
+// as git refs.
+func looksLikeSemverTag(tag string) bool {
+	t := strings.TrimPrefix(tag, "v")
+	if t == "" {
+		return false
+	}
+	// Must start with a digit and contain at least one dot (e.g., "1.2")
+	if t[0] < '0' || t[0] > '9' {
+		return false
+	}
+	return strings.Contains(t, ".")
+}
+
 func parseGoVCSURL(goVCSURL string) (string, string, error) {
 	if goVCSURL == "" {
 		return "", "", fmt.Errorf("go-vcs-url is empty")
@@ -661,7 +677,7 @@ func parseGoVCSURL(goVCSURL string) (string, string, error) {
 	if err := validateRepoURL(repoURL); err != nil {
 		return "", "", err
 	}
-	if err := validateShellSafe(ref, "go-vcs-url ref"); err != nil {
+	if err := validateShellSafeStrict(ref, "go-vcs-url ref"); err != nil {
 		return "", "", err
 	}
 	return repoURL, ref, nil
@@ -695,14 +711,15 @@ func (r *Rebuilder) cloneSourceCode(buildInfo *BuildInfo, rebuildCtx *RebuildCon
 		}
 	}
 
-	if overrideRepoURL != "" {
+	switch {
+	case overrideRepoURL != "":
 		repoURL = overrideRepoURL
 		ref = overrideRef
 		if err := validateRepoURL(repoURL); err != nil {
 			return llb.State{}, "", err
 		}
 		log.Infof("Using --go-vcs-url override: %s @ %s", repoURL, ref)
-	} else if commit != "" {
+	case commit != "":
 		if err := validateCommitHash(commit); err != nil {
 			return llb.State{}, "", fmt.Errorf("invalid source commit: %w", err)
 		}
@@ -717,18 +734,18 @@ func (r *Rebuilder) cloneSourceCode(buildInfo *BuildInfo, rebuildCtx *RebuildCon
 		}
 		ref = commit
 		log.Infof("Cloning source from binary VCS metadata %s @ %s", repoURL, ref)
-	} else {
+	default:
 		tag := ""
 		if rebuildCtx != nil {
 			tag = extractImageTag(rebuildCtx.ImageRef)
 		}
-		if tag == "" {
+		if tag == "" || !looksLikeSemverTag(tag) {
 			if repoURL != "" {
 				log.Warnf("No commit/tag specified for %s - skipping clone", repoURL)
 			}
 			return llb.State{}, "", fmt.Errorf("no commit/tag specified for source clone")
 		}
-		if err := validateShellSafe(tag, "image tag"); err != nil {
+		if err := validateShellSafeStrict(tag, "image tag"); err != nil {
 			return llb.State{}, "", fmt.Errorf("invalid image tag for source clone: %w", err)
 		}
 		if repoURL == "" {

--- a/pkg/provenance/rebuilder.go
+++ b/pkg/provenance/rebuilder.go
@@ -734,7 +734,31 @@ func (r *Rebuilder) cloneSourceCode(buildInfo *BuildInfo, rebuildCtx *RebuildCon
 		}
 		ref = commit
 		log.Infof("Cloning source from binary VCS metadata %s @ %s", repoURL, ref)
+	case rebuildCtx != nil && rebuildCtx.ImageSourceLabel != "":
+		// Step 3: OCI label org.opencontainers.image.source provides the source repo.
+		// Combine with image tag as the git ref.
+		labelURL := rebuildCtx.ImageSourceLabel
+		if !strings.HasPrefix(labelURL, "https://github.com/") {
+			return llb.State{}, "", fmt.Errorf("OCI source label URL not on github.com: %s", labelURL)
+		}
+		if err := validateRepoURL(labelURL); err != nil {
+			return llb.State{}, "", fmt.Errorf("invalid OCI source label URL: %w", err)
+		}
+		tag := ""
+		if rebuildCtx.ImageRef != "" {
+			tag = extractImageTag(rebuildCtx.ImageRef)
+		}
+		if tag == "" || !looksLikeSemverTag(tag) {
+			return llb.State{}, "", fmt.Errorf("OCI source label found (%s) but image has no semver tag for git ref", labelURL)
+		}
+		if err := validateShellSafeStrict(tag, "image tag"); err != nil {
+			return llb.State{}, "", fmt.Errorf("invalid image tag: %w", err)
+		}
+		repoURL = labelURL
+		ref = tag
+		log.Infof("Using OCI source label %s @ %s (from org.opencontainers.image.source)", repoURL, ref)
 	default:
+		// Step 4: Image tag heuristic — derive repo from module path, use image tag as ref.
 		tag := ""
 		if rebuildCtx != nil {
 			tag = extractImageTag(rebuildCtx.ImageRef)
@@ -771,7 +795,6 @@ func (r *Rebuilder) cloneSourceCode(buildInfo *BuildInfo, rebuildCtx *RebuildCon
 	}
 
 	log.Debugf("Cloning source from %s @ %s", repoURL, commit)
-
 
 	gitRef := repoURL
 	if !strings.HasSuffix(gitRef, ".git") {

--- a/pkg/provenance/rebuilder.go
+++ b/pkg/provenance/rebuilder.go
@@ -367,7 +367,7 @@ func (r *Rebuilder) RebuildBinary(
 	log.Debugf("Using base image: %s", baseImage)
 
 	// Build the new binary with updated dependencies (outputs to /output/<name>)
-	buildState, err := r.buildBinaryWithUpdates(baseImage, rebuildCtx, buildInfo, updates, platform, outputPath)
+	buildState, err := r.buildBinaryWithUpdates(baseImage, rebuildCtx, buildInfo, updates, platform, outputPath, rebuildCtx.ImageLabels)
 	if err != nil {
 		result.Error = fmt.Errorf("failed to rebuild binary %s (module: %s, Go: %s): %w",
 			binaryPath, buildInfo.ModulePath, buildInfo.GoVersion, err)
@@ -734,16 +734,12 @@ func (r *Rebuilder) cloneSourceCode(buildInfo *BuildInfo, rebuildCtx *RebuildCon
 		}
 		ref = commit
 		log.Infof("Cloning source from binary VCS metadata %s @ %s", repoURL, ref)
-	case rebuildCtx != nil && rebuildCtx.ImageSourceLabel != "":
+	case rebuildCtx != nil && rebuildCtx.ImageSourceLabel != "" && validateRepoURL(rebuildCtx.ImageSourceLabel) == nil:
 		// Step 3: OCI label org.opencontainers.image.source provides the source repo.
 		// Combine with image tag as the git ref.
+		// Only fires when the label URL is on a trusted host; otherwise falls through
+		// to the tag heuristic so users on GitLab/Gitea/self-hosted forges are not blocked.
 		labelURL := rebuildCtx.ImageSourceLabel
-		if !strings.HasPrefix(labelURL, "https://github.com/") {
-			return llb.State{}, "", fmt.Errorf("OCI source label URL not on github.com: %s", labelURL)
-		}
-		if err := validateRepoURL(labelURL); err != nil {
-			return llb.State{}, "", fmt.Errorf("invalid OCI source label URL: %w", err)
-		}
 		tag := ""
 		if rebuildCtx.ImageRef != "" {
 			tag = extractImageTag(rebuildCtx.ImageRef)

--- a/pkg/provenance/rebuilder.go
+++ b/pkg/provenance/rebuilder.go
@@ -801,7 +801,7 @@ func (r *Rebuilder) cloneSourceCode(buildInfo *BuildInfo, rebuildCtx *RebuildCon
 		return llb.State{}, "", err
 	}
 
-	log.Debugf("Cloning source from %s @ %s", repoURL, commit)
+	log.Debugf("Cloning source from %s @ %s", repoURL, ref)
 
 	gitRef := repoURL
 	if !strings.HasSuffix(gitRef, ".git") {

--- a/pkg/provenance/rebuilder.go
+++ b/pkg/provenance/rebuilder.go
@@ -1005,12 +1005,19 @@ fi
 		).Root()
 	}
 
-	// Verify the rebuilt binary is a valid Go binary and is executable.
-	verifyCmd := fmt.Sprintf("test -s %s && %s version -m %s > /dev/null 2>&1",
-		outputPath, goBin, outputPath)
+	// Verify the rebuilt binary is a valid Go binary.
+	verifyScript := fmt.Sprintf(`
+if ! %s version -m %s > /dev/null 2>&1; then
+  echo "ERROR: rebuilt binary %s is not a valid Go binary"
+  exit 1
+fi
+`, goBin, outputPath, outputPath)
 	log.Debug("Verifying rebuilt binary...")
+	state = state.File(
+		llb.Mkfile("/tmp/copa_verify.sh", 0o755, []byte(verifyScript)),
+	)
 	state = state.Run(
-		llb.Shlex(fmt.Sprintf("sh -c '%s'", verifyCmd)),
+		llb.Shlex("sh /tmp/copa_verify.sh"),
 	).Root()
 
 	return state, nil

--- a/pkg/provenance/rebuilder.go
+++ b/pkg/provenance/rebuilder.go
@@ -552,13 +552,24 @@ func deriveRepoFromModulePath(modulePath string) (repoURL string, subpath string
 	}
 
 	if strings.HasPrefix(modulePath, "go.opentelemetry.io/") {
+		// OpenTelemetry does not follow the github.com/open-telemetry/<name>
+		// naming convention. Map known top-level modules to their actual repos.
+		otelRepos := map[string]string{
+			"otel":          "https://github.com/open-telemetry/opentelemetry-go",
+			"contrib":       "https://github.com/open-telemetry/opentelemetry-go-contrib",
+			"collector":     "https://github.com/open-telemetry/opentelemetry-collector",
+			"ebpf-profiler": "https://github.com/open-telemetry/opentelemetry-ebpf-profiler",
+		}
 		parts := strings.SplitN(modulePath, "/", 3)
 		if len(parts) >= 2 {
-			repoURL = fmt.Sprintf("https://github.com/open-telemetry/%s", parts[1])
-			if len(parts) >= 3 {
-				subpath = parts[2]
+			if mapped, ok := otelRepos[parts[1]]; ok {
+				repoURL = mapped
+				if len(parts) >= 3 {
+					subpath = parts[2]
+				}
+				return repoURL, subpath
 			}
-			return repoURL, subpath
+			// Unknown top-level module, fall through to generic derivation.
 		}
 	}
 

--- a/pkg/provenance/rebuilder.go
+++ b/pkg/provenance/rebuilder.go
@@ -367,7 +367,7 @@ func (r *Rebuilder) RebuildBinary(
 	log.Debugf("Using base image: %s", baseImage)
 
 	// Build the new binary with updated dependencies (outputs to /output/<name>)
-	buildState, err := r.buildBinaryWithUpdates(baseImage, buildInfo, updates, platform, outputPath, rebuildCtx.ImageLabels)
+	buildState, err := r.buildBinaryWithUpdates(baseImage, rebuildCtx, buildInfo, updates, platform, outputPath)
 	if err != nil {
 		result.Error = fmt.Errorf("failed to rebuild binary %s (module: %s, Go: %s): %w",
 			binaryPath, buildInfo.ModulePath, buildInfo.GoVersion, err)
@@ -520,6 +520,64 @@ func deriveRepoFromModulePath(modulePath string) (repoURL string, subpath string
 		}
 	}
 
+	if strings.HasPrefix(modulePath, "cloud.google.com/go/") || modulePath == "cloud.google.com/go" {
+		parts := strings.Split(modulePath, "/")
+		repoURL = "https://github.com/googleapis/google-cloud-go"
+		if len(parts) > 2 {
+			subpath = strings.Join(parts[2:], "/")
+		}
+		return repoURL, subpath
+	}
+
+	if strings.HasPrefix(modulePath, "go.uber.org/") {
+		parts := strings.SplitN(modulePath, "/", 3)
+		if len(parts) >= 2 {
+			repoURL = fmt.Sprintf("https://github.com/uber-go/%s", parts[1])
+			if len(parts) >= 3 {
+				subpath = parts[2]
+			}
+			return repoURL, subpath
+		}
+	}
+
+	if strings.HasPrefix(modulePath, "go.etcd.io/") {
+		parts := strings.SplitN(modulePath, "/", 3)
+		if len(parts) >= 2 {
+			repoURL = fmt.Sprintf("https://github.com/etcd-io/%s", parts[1])
+			if len(parts) >= 3 {
+				subpath = parts[2]
+			}
+			return repoURL, subpath
+		}
+	}
+
+	if strings.HasPrefix(modulePath, "go.opentelemetry.io/") {
+		parts := strings.SplitN(modulePath, "/", 3)
+		if len(parts) >= 2 {
+			repoURL = fmt.Sprintf("https://github.com/open-telemetry/%s", parts[1])
+			if len(parts) >= 3 {
+				subpath = parts[2]
+			}
+			return repoURL, subpath
+		}
+	}
+
+	if modulePath == "google.golang.org/grpc" || strings.HasPrefix(modulePath, "google.golang.org/grpc/") {
+		repoURL = "https://github.com/grpc/grpc-go"
+		if modulePath != "google.golang.org/grpc" {
+			subpath = strings.TrimPrefix(modulePath, "google.golang.org/grpc/")
+		}
+		return repoURL, subpath
+	}
+
+	if modulePath == "google.golang.org/protobuf" || strings.HasPrefix(modulePath, "google.golang.org/protobuf/") {
+		repoURL = "https://github.com/protocolbuffers/protobuf-go"
+		if modulePath != "google.golang.org/protobuf" {
+			subpath = strings.TrimPrefix(modulePath, "google.golang.org/protobuf/")
+		}
+		return repoURL, subpath
+	}
+
 	return "", ""
 }
 
@@ -574,38 +632,116 @@ func validateCommitHash(commit string) error {
 	return nil
 }
 
+func extractImageTag(imageRef string) string {
+	imageRef = strings.TrimSpace(imageRef)
+	if imageRef == "" {
+		return ""
+	}
+	if i := strings.Index(imageRef, "@"); i >= 0 {
+		imageRef = imageRef[:i]
+	}
+	lastSlash := strings.LastIndex(imageRef, "/")
+	lastColon := strings.LastIndex(imageRef, ":")
+	if lastColon <= lastSlash {
+		return ""
+	}
+	return imageRef[lastColon+1:]
+}
+
+func parseGoVCSURL(goVCSURL string) (string, string, error) {
+	if goVCSURL == "" {
+		return "", "", fmt.Errorf("go-vcs-url is empty")
+	}
+	i := strings.LastIndex(goVCSURL, "@")
+	if i <= 0 || i >= len(goVCSURL)-1 {
+		return "", "", fmt.Errorf("invalid go-vcs-url format, expected repo@ref")
+	}
+	repoURL := goVCSURL[:i]
+	ref := goVCSURL[i+1:]
+	if err := validateRepoURL(repoURL); err != nil {
+		return "", "", err
+	}
+	if err := validateShellSafe(ref, "go-vcs-url ref"); err != nil {
+		return "", "", err
+	}
+	return repoURL, ref, nil
+}
+
 // cloneSourceCode clones the source repository using BuildKit Git LLB.
-func (r *Rebuilder) cloneSourceCode(buildInfo *BuildInfo) (llb.State, string, error) {
+func (r *Rebuilder) cloneSourceCode(buildInfo *BuildInfo, rebuildCtx *RebuildContext) (llb.State, string, error) {
 	repoURL := buildInfo.BuildArgs["_sourceRepo"]
 	commit := buildInfo.BuildArgs["_sourceCommit"]
 	subpath := ""
+	ref := ""
 
-	// Without a specific commit/tag, don't attempt to clone
-	if commit == "" {
-		if repoURL != "" {
-			log.Warnf("No commit/tag specified for %s - skipping clone", repoURL)
+	var overrideRepoURL, overrideRef string
+	if rebuildCtx != nil && rebuildCtx.GoVCSURL != "" {
+		var err error
+		overrideRepoURL, overrideRef, err = parseGoVCSURL(rebuildCtx.GoVCSURL)
+		if err != nil {
+			return llb.State{}, "", fmt.Errorf("invalid go-vcs-url override: %w", err)
 		}
-		return llb.State{}, "", fmt.Errorf("no commit/tag specified for source clone")
 	}
 
-	// Validate commit hash format to prevent injection via crafted binary metadata
-	if err := validateCommitHash(commit); err != nil {
-		return llb.State{}, "", fmt.Errorf("invalid source commit: %w", err)
-	}
-
-	// Always derive subpath from module path. For monorepo modules (e.g., k8s.io/autoscaler/cluster-autoscaler),
-	// the module root lives in a subdirectory of the repository and we need subpath to set the correct workdir.
+	derivedURL := ""
+	derivedSubpath := ""
 	if buildInfo.ModulePath != "" {
-		derivedURL, derivedSubpath := deriveRepoFromModulePath(buildInfo.ModulePath)
-		if repoURL == "" {
-			repoURL = derivedURL
-		}
+		derivedURL, derivedSubpath = deriveRepoFromModulePath(buildInfo.ModulePath)
 		// Strip Go major version suffixes (v2, v3, ...) since these are module path
 		// conventions, not actual subdirectories in most repositories.
 		subpath = stripGoMajorVersionSuffix(derivedSubpath)
 		if derivedURL != "" {
 			log.Debugf("Derived source repository from module path: %s (subpath: %q)", derivedURL, subpath)
 		}
+	}
+
+	if overrideRepoURL != "" {
+		repoURL = overrideRepoURL
+		ref = overrideRef
+		if err := validateRepoURL(repoURL); err != nil {
+			return llb.State{}, "", err
+		}
+		log.Infof("Using --go-vcs-url override: %s @ %s", repoURL, ref)
+	} else if commit != "" {
+		if err := validateCommitHash(commit); err != nil {
+			return llb.State{}, "", fmt.Errorf("invalid source commit: %w", err)
+		}
+		if repoURL == "" {
+			repoURL = derivedURL
+		}
+		if repoURL == "" {
+			return llb.State{}, "", fmt.Errorf("no source repository URL in build info")
+		}
+		if err := validateRepoURL(repoURL); err != nil {
+			return llb.State{}, "", err
+		}
+		ref = commit
+		log.Infof("Cloning source from binary VCS metadata %s @ %s", repoURL, ref)
+	} else {
+		tag := ""
+		if rebuildCtx != nil {
+			tag = extractImageTag(rebuildCtx.ImageRef)
+		}
+		if tag == "" {
+			if repoURL != "" {
+				log.Warnf("No commit/tag specified for %s - skipping clone", repoURL)
+			}
+			return llb.State{}, "", fmt.Errorf("no commit/tag specified for source clone")
+		}
+		if err := validateShellSafe(tag, "image tag"); err != nil {
+			return llb.State{}, "", fmt.Errorf("invalid image tag for source clone: %w", err)
+		}
+		if repoURL == "" {
+			repoURL = derivedURL
+		}
+		if repoURL == "" {
+			return llb.State{}, "", fmt.Errorf("no source repository URL in build info")
+		}
+		if err := validateRepoURL(repoURL); err != nil {
+			return llb.State{}, "", err
+		}
+		ref = tag
+		log.Infof("Cloning source using image tag fallback %s @ %s", repoURL, ref)
 	}
 
 	if repoURL == "" {
@@ -619,15 +755,16 @@ func (r *Rebuilder) cloneSourceCode(buildInfo *BuildInfo) (llb.State, string, er
 
 	log.Debugf("Cloning source from %s @ %s", repoURL, commit)
 
+
 	gitRef := repoURL
 	if !strings.HasSuffix(gitRef, ".git") {
 		gitRef += ".git"
 	}
-	if commit != "" {
-		gitRef += "#" + commit
+	if ref != "" {
+		gitRef += "#" + ref
 	}
 
-	gitState := llb.Git(gitRef, commit, llb.KeepGitDir())
+	gitState := llb.Git(gitRef, ref, llb.KeepGitDir())
 	log.Debugf("Created Git LLB state for %s", gitRef)
 	return gitState, subpath, nil
 }
@@ -654,6 +791,7 @@ done
 // buildBinaryWithUpdates creates a BuildKit LLB state that rebuilds the binary.
 func (r *Rebuilder) buildBinaryWithUpdates(
 	baseImage string,
+	rebuildCtx *RebuildContext,
 	buildInfo *BuildInfo,
 	updates map[string]string,
 	platform *specs.Platform,
@@ -678,7 +816,7 @@ func (r *Rebuilder) buildBinaryWithUpdates(
 
 	// Try to clone source code from Git
 	sourceCloned := false
-	sourceState, subpath, err := r.cloneSourceCode(buildInfo)
+	sourceState, subpath, err := r.cloneSourceCode(buildInfo, rebuildCtx)
 	if err == nil {
 		state = state.File(
 			llb.Copy(sourceState, "/", workdir, &llb.CopyInfo{

--- a/pkg/provenance/rebuilder_test.go
+++ b/pkg/provenance/rebuilder_test.go
@@ -862,6 +862,43 @@ func TestCloneSourceCodeFallbackChain(t *testing.T) {
 			rebuildCtx: &RebuildContext{ImageRef: "prometheus:latest"},
 			wantError:  true,
 		},
+		{
+			name: "uses OCI source label when no VCS commit",
+			buildInfo: &BuildInfo{
+				BuildArgs:  map[string]string{},
+				ModulePath: "github.com/VictoriaMetrics/VictoriaLogs",
+			},
+			rebuildCtx: &RebuildContext{
+				ImageRef:         "victoriametrics/victoria-logs:v1.45.0",
+				ImageSourceLabel: "https://github.com/VictoriaMetrics/VictoriaMetrics",
+			},
+			wantRepo: "github.com/VictoriaMetrics/VictoriaMetrics",
+			wantRef:  "v1.45.0",
+		},
+		{
+			name: "OCI label without semver tag fails",
+			buildInfo: &BuildInfo{
+				BuildArgs:  map[string]string{},
+				ModulePath: "github.com/example/repo",
+			},
+			rebuildCtx: &RebuildContext{
+				ImageRef:         "example/repo:latest",
+				ImageSourceLabel: "https://github.com/example/repo",
+			},
+			wantError: true,
+		},
+		{
+			name: "OCI label with non-github URL rejected",
+			buildInfo: &BuildInfo{
+				BuildArgs:  map[string]string{},
+				ModulePath: "gitlab.com/example/repo",
+			},
+			rebuildCtx: &RebuildContext{
+				ImageRef:         "example/repo:v1.0.0",
+				ImageSourceLabel: "https://gitlab.com/example/repo",
+			},
+			wantError: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/provenance/rebuilder_test.go
+++ b/pkg/provenance/rebuilder_test.go
@@ -1,6 +1,8 @@
 package provenance
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -559,6 +561,36 @@ func TestDeriveRepoFromModulePath(t *testing.T) {
 			wantSubpath: "",
 		},
 		{
+			modulePath:  "cloud.google.com/go/storage",
+			wantRepoURL: "https://github.com/googleapis/google-cloud-go",
+			wantSubpath: "storage",
+		},
+		{
+			modulePath:  "go.uber.org/zap",
+			wantRepoURL: "https://github.com/uber-go/zap",
+			wantSubpath: "",
+		},
+		{
+			modulePath:  "go.etcd.io/etcd/client/v3",
+			wantRepoURL: "https://github.com/etcd-io/etcd",
+			wantSubpath: "client/v3",
+		},
+		{
+			modulePath:  "go.opentelemetry.io/otel/exporters/otlp",
+			wantRepoURL: "https://github.com/open-telemetry/otel",
+			wantSubpath: "exporters/otlp",
+		},
+		{
+			modulePath:  "google.golang.org/grpc",
+			wantRepoURL: "https://github.com/grpc/grpc-go",
+			wantSubpath: "",
+		},
+		{
+			modulePath:  "google.golang.org/protobuf/encoding/protojson",
+			wantRepoURL: "https://github.com/protocolbuffers/protobuf-go",
+			wantSubpath: "encoding/protojson",
+		},
+		{
 			modulePath:  "",
 			wantRepoURL: "",
 			wantSubpath: "",
@@ -707,5 +739,141 @@ func TestIsSafeOCISource(t *testing.T) {
 	for input, want := range cases {
 		got := isSafeOCISource(input)
 		assert.Equal(t, want, got, "input=%q", input)
+	}
+}
+
+func TestExtractImageTag(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageRef string
+		want     string
+	}{
+		{name: "tagged image", imageRef: "prometheus:v3.9.1", want: "v3.9.1"},
+		{name: "registry with port", imageRef: "localhost:5000/prometheus:v3.9.1", want: "v3.9.1"},
+		{name: "digest only", imageRef: "ghcr.io/org/repo@sha256:abc", want: ""},
+		{name: "tag and digest", imageRef: "ghcr.io/org/repo:v1.2.3@sha256:abc", want: "v1.2.3"},
+		{name: "no tag", imageRef: "ghcr.io/org/repo", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractImageTag(tt.imageRef))
+		})
+	}
+}
+
+func TestParseGoVCSURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantRepo  string
+		wantRef   string
+		wantError bool
+	}{
+		{name: "tag ref", input: "https://github.com/org/repo@v1.2.3", wantRepo: "https://github.com/org/repo", wantRef: "v1.2.3"},
+		{name: "commit ref", input: "https://github.com/org/repo@d7b4f0c7322e7151d6e3b1e31cbc15361e295d8d", wantRepo: "https://github.com/org/repo", wantRef: "d7b4f0c7322e7151d6e3b1e31cbc15361e295d8d"},
+		{name: "missing ref", input: "https://github.com/org/repo@", wantError: true},
+		{name: "missing separator", input: "https://github.com/org/repo", wantError: true},
+		{name: "untrusted host", input: "https://gitlab.com/org/repo@v1.0.0", wantError: true},
+		{name: "unsafe ref", input: "https://github.com/org/repo@v1.0.0;rm", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, ref, err := parseGoVCSURL(tt.input)
+			if tt.wantError {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRepo, repo)
+			assert.Equal(t, tt.wantRef, ref)
+		})
+	}
+}
+
+func TestCloneSourceCodeFallbackChain(t *testing.T) {
+	rebuilder := NewRebuilder()
+
+	tests := []struct {
+		name        string
+		buildInfo   *BuildInfo
+		rebuildCtx  *RebuildContext
+		wantRef     string
+		wantRepo    string
+		wantSubpath string
+		wantError   bool
+	}{
+		{
+			name: "go-vcs-url override has highest priority",
+			buildInfo: &BuildInfo{
+				BuildArgs: map[string]string{
+					"_sourceRepo":   "https://github.com/source/repo",
+					"_sourceCommit": "d7b4f0c7322e7151d6e3b1e31cbc15361e295d8d",
+				},
+				ModulePath: "github.com/source/repo/cmd/app",
+			},
+			rebuildCtx:  &RebuildContext{GoVCSURL: "https://github.com/override/repo@v1.2.3"},
+			wantRepo:    "https://github.com/override/repo",
+			wantRef:     "v1.2.3",
+			wantSubpath: "cmd/app",
+		},
+		{
+			name: "binary vcs commit is used when override absent",
+			buildInfo: &BuildInfo{
+				BuildArgs: map[string]string{
+					"_sourceRepo":   "https://github.com/source/repo",
+					"_sourceCommit": "d7b4f0c7322e7151d6e3b1e31cbc15361e295d8d",
+				},
+				ModulePath: "github.com/source/repo/cmd/app",
+			},
+			rebuildCtx:  &RebuildContext{ImageRef: "repo:v9.9.9"},
+			wantRepo:    "https://github.com/source/repo",
+			wantRef:     "d7b4f0c7322e7151d6e3b1e31cbc15361e295d8d",
+			wantSubpath: "cmd/app",
+		},
+		{
+			name: "image tag fallback when commit missing",
+			buildInfo: &BuildInfo{
+				BuildArgs:  map[string]string{},
+				ModulePath: "github.com/prometheus/prometheus/cmd/prometheus",
+				GoVersion:  "1.22",
+			},
+			rebuildCtx:  &RebuildContext{ImageRef: "prometheus:v3.9.1"},
+			wantRepo:    "https://github.com/prometheus/prometheus",
+			wantRef:     "v3.9.1",
+			wantSubpath: "cmd/prometheus",
+		},
+		{
+			name: "fails when no ref sources available",
+			buildInfo: &BuildInfo{
+				BuildArgs:  map[string]string{},
+				ModulePath: "github.com/prometheus/prometheus",
+			},
+			rebuildCtx: &RebuildContext{ImageRef: "prometheus"},
+			wantError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, subpath, err := rebuilder.cloneSourceCode(tt.buildInfo, tt.rebuildCtx)
+			if tt.wantError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSubpath, subpath)
+
+			def, marshalErr := state.Marshal(context.Background())
+			require.NoError(t, marshalErr)
+			blob := strings.Builder{}
+			for _, dt := range def.Def {
+				blob.Write(dt)
+			}
+			assert.Contains(t, blob.String(), tt.wantRepo)
+			assert.Contains(t, blob.String(), tt.wantRef)
+		})
 	}
 }

--- a/pkg/provenance/rebuilder_test.go
+++ b/pkg/provenance/rebuilder_test.go
@@ -853,6 +853,15 @@ func TestCloneSourceCodeFallbackChain(t *testing.T) {
 			rebuildCtx: &RebuildContext{ImageRef: "prometheus"},
 			wantError:  true,
 		},
+		{
+			name: "rejects non-semver tag like latest",
+			buildInfo: &BuildInfo{
+				BuildArgs:  map[string]string{},
+				ModulePath: "github.com/prometheus/prometheus",
+			},
+			rebuildCtx: &RebuildContext{ImageRef: "prometheus:latest"},
+			wantError:  true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -874,6 +883,31 @@ func TestCloneSourceCodeFallbackChain(t *testing.T) {
 			}
 			assert.Contains(t, blob.String(), tt.wantRepo)
 			assert.Contains(t, blob.String(), tt.wantRef)
+		})
+	}
+}
+
+func TestLooksLikeSemverTag(t *testing.T) {
+	tests := []struct {
+		tag  string
+		want bool
+	}{
+		{"v1.2.3", true},
+		{"1.45.0", true},
+		{"v3.9.1-rc1", true},
+		{"v0.1.0", true},
+		{"latest", false},
+		{"stable", false},
+		{"alpine", false},
+		{"v", false},
+		{"", false},
+		{"3", false},
+		{"sha-abc123", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			assert.Equal(t, tt.want, looksLikeSemverTag(tt.tag))
 		})
 	}
 }

--- a/pkg/provenance/rebuilder_test.go
+++ b/pkg/provenance/rebuilder_test.go
@@ -577,8 +577,18 @@ func TestDeriveRepoFromModulePath(t *testing.T) {
 		},
 		{
 			modulePath:  "go.opentelemetry.io/otel/exporters/otlp",
-			wantRepoURL: "https://github.com/open-telemetry/otel",
+			wantRepoURL: "https://github.com/open-telemetry/opentelemetry-go",
 			wantSubpath: "exporters/otlp",
+		},
+		{
+			modulePath:  "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+			wantRepoURL: "https://github.com/open-telemetry/opentelemetry-go-contrib",
+			wantSubpath: "instrumentation/net/http/otelhttp",
+		},
+		{
+			modulePath:  "go.opentelemetry.io/collector/component",
+			wantRepoURL: "https://github.com/open-telemetry/opentelemetry-collector",
+			wantSubpath: "component",
 		},
 		{
 			modulePath:  "google.golang.org/grpc",

--- a/pkg/provenance/types.go
+++ b/pkg/provenance/types.go
@@ -66,6 +66,8 @@ type RebuildContext struct {
 	BinaryInfo []*BinaryInfo
 	// ImageLabels contains OCI image labels for version metadata fallback.
 	ImageLabels map[string]string
+	ImageRef    string
+	GoVCSURL    string
 }
 
 // RebuildResult contains the outcome of a rebuild attempt.

--- a/pkg/provenance/types.go
+++ b/pkg/provenance/types.go
@@ -65,9 +65,10 @@ type RebuildContext struct {
 	// BinaryInfo contains information from detected Go binaries.
 	BinaryInfo []*BinaryInfo
 	// ImageLabels contains OCI image labels for version metadata fallback.
-	ImageLabels map[string]string
-	ImageRef    string
-	GoVCSURL    string
+	ImageLabels      map[string]string
+	ImageRef         string
+	GoVCSURL         string
+	ImageSourceLabel string // org.opencontainers.image.source OCI label
 }
 
 // RebuildResult contains the outcome of a rebuild attempt.

--- a/pkg/report/trivy.go
+++ b/pkg/report/trivy.go
@@ -432,9 +432,16 @@ func (t *TrivyParser) ParseWithLibraryPatchLevel(file, libraryPatchLevel string)
 			if r.Type == utils.PythonPackages || r.Type == utils.NodePackages || r.Type == utils.GoModules || r.Type == utils.GoBinary {
 				for v := range r.Vulnerabilities {
 					vuln := &r.Vulnerabilities[v]
+					// For gobinary results, Trivy puts the binary path in the Result's Target
+					// field but may leave PkgPath empty (especially for stdlib vulns).
+					// Fall back to Target so Copa can locate the binary for rebuilding.
+					pkgPath := vuln.PkgPath
+					if pkgPath == "" && r.Type == utils.GoBinary {
+						pkgPath = string(r.Target)
+					}
 					if vuln.FixedVersion != "" {
 						// Composite key: same package at different paths is a separate upgrade target.
-						key := vuln.PkgName + "\x00" + vuln.PkgPath
+						key := vuln.PkgName + "\x00" + pkgPath
 						if _, exists := langPackageVulns[key]; !exists {
 							langPackageVulns[key] = []trivyTypes.DetectedVulnerability{}
 							langPackageInfo[key] = unversioned.UpdatePackage{
@@ -442,7 +449,7 @@ func (t *TrivyParser) ParseWithLibraryPatchLevel(file, libraryPatchLevel string)
 								Type:             string(r.Type),
 								Class:            string(r.Class),
 								InstalledVersion: vuln.InstalledVersion,
-								PkgPath:          vuln.PkgPath,
+							PkgPath:          pkgPath,
 							}
 							langPackageVulnIDs[key] = make(map[string]struct{})
 						}

--- a/pkg/report/trivy.go
+++ b/pkg/report/trivy.go
@@ -449,7 +449,7 @@ func (t *TrivyParser) ParseWithLibraryPatchLevel(file, libraryPatchLevel string)
 								Type:             string(r.Type),
 								Class:            string(r.Class),
 								InstalledVersion: vuln.InstalledVersion,
-							PkgPath:          pkgPath,
+								PkgPath:          pkgPath,
 							}
 							langPackageVulnIDs[key] = make(map[string]struct{})
 						}

--- a/pkg/types/options.go
+++ b/pkg/types/options.go
@@ -48,6 +48,7 @@ type Options struct {
 
 	// Toolchain patch level (e.g., Go stdlib upgrade)
 	ToolchainPatchLevel string
+	GoVCSURL            string
 
 	// Generate specific
 	OutputContext string

--- a/website/docs/app-level-patching.md
+++ b/website/docs/app-level-patching.md
@@ -371,6 +371,13 @@ copa patch \
     -r scan.json \
     --pkg-types library \
     --toolchain-patch-level
+
+# Provide source repo for stripped binaries (no embedded VCS info)
+copa patch \
+    -i $IMAGE \
+    -r scan.json \
+    --pkg-types library \
+    --go-vcs-url https://github.com/org/repo@v1.2.3
 ```
 
 ##### The `--toolchain-patch-level` Flag
@@ -402,22 +409,42 @@ copa patch \
 Copa analyzes Go binaries in the image and rebuilds them using embedded build metadata:
 
 1. **Binary detection**: Runs `go version -m` on each binary in the image to extract embedded build metadata (module path, dependency versions, build flags, VCS info)
-2. **Source derivation**: Derives the source repository URL from the module path (e.g., `github.com/example/repo`)
-3. **Source cloning**: Uses the embedded VCS commit hash (`vcs.revision`) to clone the exact source at the correct commit
+2. **Source derivation**: Derives the source repository URL from the module path (e.g., `github.com/example/repo`), with built-in mappings for vanity imports (`k8s.io`, `golang.org/x`, `cloud.google.com/go`, `go.uber.org`, `go.etcd.io`, `go.opentelemetry.io`, `google.golang.org/grpc`, `google.golang.org/protobuf`)
+3. **Source resolution**: Resolves the git ref to clone using a 3-step fallback chain (see [Source Resolution Chain](#source-resolution-chain) below)
 4. **Build reconstruction**: Reconstructs build flags from the embedded build settings (`-ldflags`, `-tags`, `CGO_ENABLED`, etc.)
 5. **Dependency update**: Applies `go get module@version` for each vulnerable dependency, runs `go mod tidy`
 6. **Main package discovery**: Locates the main package in the cloned source using multiple strategies (explicit path, `cmd/` directory, binary name matching)
 7. **Rebuild and replace**: Rebuilds the binary with updated dependencies and copies it back to its original location in the image
 
-##### Key Requirement: VCS Commit Hash
+##### Source Resolution Chain
 
-:::danger Critical Requirement
-Go binaries **must have a VCS commit hash embedded** for Copa to clone the source and rebuild. This is the most important requirement for binary rebuilding to work.
-:::
+Copa resolves where to clone source code using a 3-step fallback chain. Each step is tried in order; the first success wins:
 
-The Go toolchain automatically embeds VCS metadata (commit hash, timestamp, dirty flag) when building inside a git repository (default since Go 1.18). However, many Dockerfiles exclude the `.git` directory via `.dockerignore` or by not copying it, which prevents VCS embedding.
+| Priority | Method | When it fires |
+|---|---|---|
+| 1 | `--go-vcs-url` override | User explicitly provides `repo@ref` |
+| 2 | VCS commit from binary | Binary has embedded `vcs.revision` |
+| 3 | Image tag heuristic | No VCS info, but image has a semver-like tag (e.g., `v1.2.3`) |
 
-**Recommended: Use a multi-stage build with `.git` in the builder stage.** The `.git` directory is only needed during compilation and never ends up in the final image, so there is no size penalty:
+**Step 1: `--go-vcs-url` override** — Highest priority. The user provides the source repository and git ref directly. Useful for stripped binaries where neither VCS metadata nor tag heuristic works (e.g., the Docker Hub image name doesn't match the GitHub org).
+
+```bash
+# Format: repo@ref
+copa patch -i calico/node:v3.31.4 --pkg-types library \
+    --go-vcs-url https://github.com/projectcalico/calico@v3.31.4
+```
+
+**Step 2: VCS commit from binary** — If the binary has `vcs.revision` embedded (the default since Go 1.18 when `.git` is present at build time), Copa clones the source at the exact commit. This is the most precise method.
+
+**Step 3: Image tag heuristic** — When VCS info is missing, Copa extracts the tag from the image reference (e.g., `prometheus:v3.9.1` → `v3.9.1`) and tries it as a git ref. This works for the common convention where image tags match git tags.
+
+If all three steps fail, Copa falls back to generating a synthetic `go.mod` from the binary's embedded dependency list, which may produce a partial rebuild.
+
+##### Recommended: Embed VCS Metadata
+
+While Copa now has fallbacks for stripped binaries, embedding VCS metadata remains the recommended approach for the most reliable rebuilds. The Go toolchain automatically embeds VCS metadata when building inside a git repository (default since Go 1.18).
+
+**Use a multi-stage build with `.git` in the builder stage.** The `.git` directory is only needed during compilation and never ends up in the final image:
 
 ```dockerfile
 # GOOD: Multi-stage build preserves VCS metadata at zero cost
@@ -432,17 +459,6 @@ COPY --from=builder /app /app
 # Final image has no .git, but the binary has VCS info embedded
 ```
 
-If your `.dockerignore` excludes `.git`, remove that line -- in a multi-stage build it only affects the builder stage and won't bloat your final image.
-
-```dockerfile
-# BAD: No .git means no VCS metadata in the binary
-FROM golang:1.23 AS builder
-COPY . /src
-# .git excluded by .dockerignore or never copied
-RUN go build -o /app ./cmd/myapp
-# Binary has no vcs.revision -- Copa cannot rebuild it
-```
-
 You can verify whether a binary has VCS info embedded:
 
 ```bash
@@ -453,17 +469,15 @@ go version -m /path/to/binary | grep vcs
 #   build   vcs.time=2024-01-01T00:00:00Z
 ```
 
-If `vcs.revision` is missing, the binary was built without git context and Copa cannot rebuild it.
-
 ##### Binary Rebuild Requirements
 
-- **VCS commit hash**: The Go binary must have `vcs.revision` embedded (requires `.git` directory present at build time)
-- **Public source repository**: Source code must be accessible on GitHub at the embedded commit
+- **Source resolution**: At least one of: `--go-vcs-url` override, embedded `vcs.revision`, or a semver-like image tag that matches a git tag
+- **Public source repository**: Source code must be accessible on GitHub at the resolved commit/tag
 - **Standard Go build**: The binary must be buildable with the standard Go toolchain
 
 ##### Binary Rebuild Limitations
 
-1. **VCS metadata required**: Binaries built without `.git` present (or with `-buildvcs=false`) cannot be rebuilt. This is the most common cause of failure, as many production Go container images lack embedded VCS metadata.
+1. **Source resolution failure**: If the binary has no VCS metadata, the image has no usable tag, and no `--go-vcs-url` is provided, Copa falls back to a synthetic `go.mod` which may produce incomplete rebuilds.
 
 2. **Private repositories**: Currently only public GitHub repositories are supported for source cloning.
 
@@ -471,7 +485,7 @@ If `vcs.revision` is missing, the binary was built without git context and Copa 
 
 4. **Monorepo builds**: Images containing multiple binaries from the same repository may have binaries at non-standard source locations. Copa uses a multi-strategy discovery approach but may not find all main packages.
 
-5. **Module download failures**: Some projects use private modules, vanity import paths, or vendored dependencies that cannot be resolved in the rebuild environment.
+5. **Vanity import resolution**: While Copa handles common vanity imports (`k8s.io`, `golang.org/x`, `cloud.google.com/go`, `go.uber.org`, `go.etcd.io`, `go.opentelemetry.io`, `google.golang.org/grpc`, `google.golang.org/protobuf`), other custom vanity import paths may not resolve correctly. Use `--go-vcs-url` as a workaround.
 
 6. **Build reproducibility**: Rebuilt binaries may differ from originals due to timestamps, Go version differences, or non-deterministic build steps.
 
@@ -509,7 +523,19 @@ INFO   Source: github.com/example/repo @ abc123
 INFO   Will update golang.org/x/net to v0.33.0
 ```
 
-When a binary lacks VCS metadata:
+When using the image tag heuristic (no VCS metadata):
+
+```text
+INFO Cloning source using image tag fallback https://github.com/example/repo @ v1.2.3
+```
+
+When using `--go-vcs-url`:
+
+```text
+INFO Using --go-vcs-url override: https://github.com/org/repo @ v1.2.3
+```
+
+When all resolution methods fail:
 
 ```text
 WARN   Binary /usr/bin/mybinary has no VCS commit info (likely built without .git directory).

--- a/website/docs/app-level-patching.md
+++ b/website/docs/app-level-patching.md
@@ -373,6 +373,7 @@ copa patch \
     --toolchain-patch-level
 
 # Provide source repo for stripped binaries (no embedded VCS info)
+# Note: --go-vcs-url is experimental and requires COPA_EXPERIMENTAL=1
 copa patch \
     -i $IMAGE \
     -r scan.json \
@@ -410,7 +411,7 @@ Copa analyzes Go binaries in the image and rebuilds them using embedded build me
 
 1. **Binary detection**: Runs `go version -m` on each binary in the image to extract embedded build metadata (module path, dependency versions, build flags, VCS info)
 2. **Source derivation**: Derives the source repository URL from the module path (e.g., `github.com/example/repo`), with built-in mappings for vanity imports (`k8s.io`, `golang.org/x`, `cloud.google.com/go`, `go.uber.org`, `go.etcd.io`, `go.opentelemetry.io`, `google.golang.org/grpc`, `google.golang.org/protobuf`)
-3. **Source resolution**: Resolves the git ref to clone using a 3-step fallback chain (see [Source Resolution Chain](#source-resolution-chain) below)
+3. **Source resolution**: Resolves the git ref to clone using a 4-step fallback chain (see [Source Resolution Chain](#source-resolution-chain) below)
 4. **Build reconstruction**: Reconstructs build flags from the embedded build settings (`-ldflags`, `-tags`, `CGO_ENABLED`, etc.)
 5. **Dependency update**: Applies `go get module@version` for each vulnerable dependency, runs `go mod tidy`
 6. **Main package discovery**: Locates the main package in the cloned source using multiple strategies (explicit path, `cmd/` directory, binary name matching)
@@ -418,15 +419,16 @@ Copa analyzes Go binaries in the image and rebuilds them using embedded build me
 
 ##### Source Resolution Chain
 
-Copa resolves where to clone source code using a 3-step fallback chain. Each step is tried in order; the first success wins:
+Copa resolves where to clone source code using a 4-step fallback chain. Each step is tried in order; the first success wins:
 
 | Priority | Method | When it fires |
 |---|---|---|
-| 1 | `--go-vcs-url` override | User explicitly provides `repo@ref` |
+| 1 | `--go-vcs-url` override | User explicitly provides `repo@ref` (requires `COPA_EXPERIMENTAL=1`) |
 | 2 | VCS commit from binary | Binary has embedded `vcs.revision` |
-| 3 | Image tag heuristic | No VCS info, but image has a semver-like tag (e.g., `v1.2.3`) |
+| 3 | OCI source label | Image has `org.opencontainers.image.source` label pointing at a trusted host, combined with a semver-like image tag |
+| 4 | Image tag heuristic | No VCS info and no usable label, but image has a semver-like tag (e.g., `v1.2.3`) |
 
-**Step 1: `--go-vcs-url` override** — Highest priority. The user provides the source repository and git ref directly. Useful for stripped binaries where neither VCS metadata nor tag heuristic works (e.g., the Docker Hub image name doesn't match the GitHub org).
+**Step 1: `--go-vcs-url` override** — Highest priority. The user provides the source repository and git ref directly. Useful for stripped binaries where neither VCS metadata nor tag heuristic works (e.g., the Docker Hub image name doesn't match the GitHub org). This flag is gated behind `COPA_EXPERIMENTAL=1` along with the rest of the library/application patching workflow.
 
 ```bash
 # Format: repo@ref
@@ -436,9 +438,11 @@ copa patch -i calico/node:v3.31.4 --pkg-types library \
 
 **Step 2: VCS commit from binary** — If the binary has `vcs.revision` embedded (the default since Go 1.18 when `.git` is present at build time), Copa clones the source at the exact commit. This is the most precise method.
 
-**Step 3: Image tag heuristic** — When VCS info is missing, Copa extracts the tag from the image reference (e.g., `prometheus:v3.9.1` → `v3.9.1`) and tries it as a git ref. This works for the common convention where image tags match git tags.
+**Step 3: OCI source label** — If the image carries an `org.opencontainers.image.source` annotation pointing at a trusted source host, Copa uses the label URL as the repository and the image's semver-like tag as the git ref. Images without a semver-like tag, or with a label URL on an untrusted host, fall through to step 4.
 
-If all three steps fail, Copa falls back to generating a synthetic `go.mod` from the binary's embedded dependency list, which may produce a partial rebuild.
+**Step 4: Image tag heuristic** — When VCS info is missing, Copa extracts the tag from the image reference (e.g., `prometheus:v3.9.1` → `v3.9.1`) and tries it as a git ref. This works for the common convention where image tags match git tags.
+
+If all four steps fail, Copa falls back to generating a synthetic `go.mod` from the binary's embedded dependency list, which may produce a partial rebuild.
 
 ##### Recommended: Embed VCS Metadata
 


### PR DESCRIPTION
## Summary

Resolves #1545

Enhances Go binary patching to work on distroless/scratch images where VCS metadata is stripped (`-trimpath` or `-buildvcs=false`). Adds a 4-step source resolution fallback chain, OCI source label handling, an OpenTelemetry lookup table, and better vanity import coverage.

## What changed

### 4-step source resolution fallback (`pkg/provenance/rebuilder.go`)

`cloneSourceCode()` now tries four methods in priority order:

| Priority | Method | When it fires |
|---|---|---|
| 1 | `--go-vcs-url` override | User provides `repo@ref` explicitly (requires `COPA_EXPERIMENTAL=1`) |
| 2 | VCS commit from binary | Binary has embedded `vcs.revision` (existing behavior) |
| 3 | OCI source label | Image has `org.opencontainers.image.source` label on a trusted host, combined with a semver-like image tag |
| 4 | Image tag heuristic | No VCS info, no usable label, but image has a semver-like tag (e.g., `prometheus:v3.9.1` -> try `v3.9.1` as git ref) |

The OCI label step only fires when `validateRepoURL` passes; otherwise it falls through to the tag heuristic so users on GitLab/Gitea/self-hosted forges are not blocked.

New helpers:
- `parseGoVCSURL()` - parses `repo@ref` with `validateRepoURL` + `validateShellSafeStrict` for the ref
- `extractImageTag()` - strips digest suffix and registry-port prefix
- `looksLikeSemverTag()` - gates the tag heuristic so `latest`, `stable`, `alpine`, `sha-<hex>`, etc. do not trigger fallback
- `formatOCILabelsForScript()` + `isSafeOCIVersion` / `isSafeOCIRevision` / `isSafeOCISource` - safely propagate OCI labels into the rebuild script

### Extended vanity import mappings (`deriveRepoFromModulePath`)

Added resolution for vanity import paths that previously returned empty:
- `cloud.google.com/go/*` -> `github.com/googleapis/google-cloud-go`
- `go.uber.org/*` -> `github.com/uber-go/*`
- `go.etcd.io/*` -> `github.com/etcd-io/*`
- `go.opentelemetry.io/*` -> looked up via `otelRepos` map (`otel` -> `opentelemetry-go`, `contrib` -> `opentelemetry-go-contrib`, `collector` -> `opentelemetry-collector`, `ebpf-profiler` -> `opentelemetry-ebpf-profiler`); unknown top-level modules fall through to generic derivation
- `google.golang.org/grpc` -> `github.com/grpc/grpc-go`
- `google.golang.org/protobuf` -> `github.com/protocolbuffers/protobuf-go`

### `--go-vcs-url` experimental flag (`pkg/cmd/cmd.go`)

New flag behind `COPA_EXPERIMENTAL=1`:
```bash
copa patch -i calico/node:v3.31.4 --pkg-types library \
    --go-vcs-url https://github.com/projectcalico/calico@v3.31.4
```

### Synthetic binary info for detection failures

`collectGoBinaryInfo()` pulls binary paths and Go version from Trivy report `PkgPath` when `go version -m` detection fails (distroless/scratch). `buildSyntheticBinaryInfo()` constructs `BinaryInfo` entries from the collected paths so the rebuild flow can still fire.

### Rebuild verification

After constructing the LLB graph, `RebuildBinary` does an intermediate `Solve` and checks the rebuilt binary with `go version -m` before claiming success. Prevents the "LLB graph built, actual build fails later" class of bugs.

### Pipeline threading

`ImageRef`, `GoVCSURL`, and `ImageSourceLabel` threaded through: `cmd.go` -> `Options` -> `patch/core.go` -> `patch/single.go` -> `langmgr.go` -> `golangManager` -> `RebuildContext` -> `cloneSourceCode()`. `ImageLabels` (added by #1516) is also carried on `RebuildContext` and reused for OCI label propagation.

### Documentation (`website/docs/app-level-patching.md`)

- "How Binary Rebuilding Works" updated for the 4-step resolution chain
- "Source Resolution Chain" section describes each step with its preconditions and logs
- `--go-vcs-url` examples carry explicit `COPA_EXPERIMENTAL=1` callouts
- Limitations updated to reflect the new fallbacks

## Tests

- `TestExtractImageTag` - registry with port, digest-only, tag+digest, no tag
- `TestParseGoVCSURL` - tag ref, commit ref, missing ref, missing separator, untrusted host, unsafe ref
- `TestDeriveRepoFromModulePath` - extended with vanity import cases including OpenTelemetry lookup
- `TestCloneSourceCodeFallbackChain` - priority order (override > VCS > OCI label > tag > fail)
- `TestFormatOCILabelsForScript` - safe propagation of OCI labels into shell script
- `TestIsSafeOCIVersion` / `TestIsSafeOCIRevision` / `TestIsSafeOCISource` - injection-safe validators for OCI label values
- Updated `GetLanguageManagers` call sites in `dotnet_test.go`, `golang_test.go`, `langmgr_test.go`, `python_test.go`

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `gofmt -l` clean
- `golangci-lint run --new-from-rev=origin/main` zero new issues
- `go test ./pkg/langmgr/... ./pkg/provenance/... ./pkg/report/...` pass
