### PR TITLE
fix(langmgr): suppress NU1605 in generated patch.csproj for .NET

### DIFF
--- a/pkg/langmgr/dotnet.go
+++ b/pkg/langmgr/dotnet.go
@@ -79,6 +79,31 @@ func escapeXMLAttribute(s string) string {
 	return replacer.Replace(s)
 }
 
+// buildPatchCsproj renders the minimal csproj used to download patched
+// NuGet packages inside the SDK container.
+//
+// NU1605 is suppressed because Trivy reports a minimum fixed version per
+// package, but different fixed packages can have transitive dependencies on
+// each other with higher minimum versions (e.g. NuGet.Packaging 7.3.1 depends
+// transitively on Newtonsoft.Json >= 13.0.3 while Trivy also pins
+// Newtonsoft.Json to 13.0.1 as its direct fix). Without NoWarn NuGet flags
+// that as a "downgrade" and dotnet restore fails with NU1605.
+// Letting NuGet's highest-wins resolution pick the transitive minimum is
+// strictly safer than the Trivy-suggested fix - the resolved version is
+// always >= the Trivy fix, never below a known good version.
+func buildPatchCsproj(targetFramework, packageRefs string) string {
+	return fmt.Sprintf(`<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>%s</TargetFramework>
+    <OutputType>Library</OutputType>
+    <NoWarn>NU1605</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+%s  </ItemGroup>
+</Project>
+`, targetFramework, packageRefs)
+}
+
 // isValidDotnetVersion checks if a version string is a valid NuGet version.
 // NuGet supports Major.Minor.Patch[.Revision][-prerelease][+buildmetadata].
 func isValidDotnetVersion(v string) bool {
@@ -359,18 +384,10 @@ func (dnm *dotnetManager) patchRuntimeImage(
 	}
 	targetFramework := fmt.Sprintf("net%s", tfmVersion)
 
-	// Create complete project file in one command
+	patchCsproj := buildPatchCsproj(targetFramework, packageRefs.String())
 	createProjectCmd := fmt.Sprintf(`sh -c 'mkdir -p /patch && cat > /patch/patch.csproj << "EOF"
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>%s</TargetFramework>
-    <OutputType>Library</OutputType>
-  </PropertyGroup>
-  <ItemGroup>
-%s  </ItemGroup>
-</Project>
-EOF
-cat /patch/patch.csproj'`, targetFramework, packageRefs.String())
+%sEOF
+cat /patch/patch.csproj'`, patchCsproj)
 
 	projectCreated := sdkState.Run(
 		llb.Shlex(createProjectCmd),

--- a/pkg/langmgr/dotnet.go
+++ b/pkg/langmgr/dotnet.go
@@ -595,13 +595,13 @@ echo "Updating %s: %s -> (resolve from generated deps.json, Trivy pin %s)"
 # Find the actual resolved package key in the generated deps.json. NU1605 is
 # suppressed during restore so NuGet may have resolved to a version newer than
 # the Trivy pin if a transitive dep required it.
-RESOLVED_KEY=$(jq -r --arg name "%s" '.targets[$GEN_TARGET_KEY] | keys[] | select(startswith($name + "/"))' /output/patch.deps.json 2>/dev/null | head -1)
+RESOLVED_KEY=$(jq -r --arg name "%s" --arg targetKey "$GEN_TARGET_KEY" '.targets[$targetKey] | keys[] | select(startswith($name + "/"))' /output/patch.deps.json 2>/dev/null | head -1)
 RESOLVED_LIB_KEY=$(jq -r --arg name "%s" '.libraries | keys[] | select(startswith($name + "/"))' /output/patch.deps.json 2>/dev/null | head -1)
 
 if [ -n "$RESOLVED_KEY" ] && [ "$RESOLVED_KEY" != "null" ] && [ -n "$RESOLVED_LIB_KEY" ] && [ "$RESOLVED_LIB_KEY" != "null" ]; then
 	RESOLVED_VERSION="${RESOLVED_KEY#%s/}"
 	echo "  Resolved version: $RESOLVED_VERSION"
-	NEW_TARGET=$(jq -r --arg key "$RESOLVED_KEY" '.targets[$GEN_TARGET_KEY][$key]' /output/patch.deps.json 2>/dev/null)
+	NEW_TARGET=$(jq -r --arg key "$RESOLVED_KEY" --arg targetKey "$GEN_TARGET_KEY" '.targets[$targetKey][$key]' /output/patch.deps.json 2>/dev/null)
 	NEW_LIBRARY=$(jq -r --arg key "$RESOLVED_LIB_KEY" '.libraries[$key]' /output/patch.deps.json 2>/dev/null)
 	echo "  Extracted package metadata from generated deps.json"
 

--- a/pkg/langmgr/dotnet.go
+++ b/pkg/langmgr/dotnet.go
@@ -578,51 +578,75 @@ echo "Generated target framework: $GEN_TARGET_KEY"
 	for _, update := range safeUpdates {
 		packageName := update.Name
 		oldVersion := update.InstalledVersion
-		newVersion := update.FixedVersion
+		trivyPin := update.FixedVersion
 
+		// Resolve the actual package key from the generated deps.json rather than
+		// assuming it is "Name/TrivyPin". NU1605 is suppressed in the generated
+		// patch.csproj (see buildPatchCsproj), so NuGet's highest-wins resolution
+		// can legitimately produce a higher version than Trivy requested when a
+		// transitive dependency requires it. Looking up by "Name/TrivyPin"
+		// in that case returns empty and the deps.json merge is skipped, leaving
+		// stale hashPath/sha512 referencing the old version while the DLL on
+		// disk has been upgraded - an inconsistent manifest.
 		fmt.Fprintf(&script, `
-# Update %s from %s to %s
-echo "Updating %s: %s -> %s"
+# Update %s (Trivy requested >= %s, actual resolved version looked up from generated deps.json)
+echo "Updating %s: %s -> (resolve from generated deps.json, Trivy pin %s)"
 
-# Extract just the package entries from generated deps.json
-NEW_TARGET=$(jq -r ".targets[\"$GEN_TARGET_KEY\"][\"%s/%s\"] // empty" /output/patch.deps.json 2>/dev/null)
-NEW_LIBRARY=$(jq -r '.libraries["%s/%s"] // empty' /output/patch.deps.json 2>/dev/null)
+# Find the actual resolved package key in the generated deps.json. NU1605 is
+# suppressed during restore so NuGet may have resolved to a version newer than
+# the Trivy pin if a transitive dep required it.
+RESOLVED_KEY=$(jq -r --arg name "%s" '.targets[$GEN_TARGET_KEY] | keys[] | select(startswith($name + "/"))' /output/patch.deps.json 2>/dev/null | head -1)
+RESOLVED_LIB_KEY=$(jq -r --arg name "%s" '.libraries | keys[] | select(startswith($name + "/"))' /output/patch.deps.json 2>/dev/null | head -1)
 
-if [ -n "$NEW_TARGET" ] && [ "$NEW_TARGET" != "null" ] && [ -n "$NEW_LIBRARY" ] && [ "$NEW_LIBRARY" != "null" ]; then
+if [ -n "$RESOLVED_KEY" ] && [ "$RESOLVED_KEY" != "null" ] && [ -n "$RESOLVED_LIB_KEY" ] && [ "$RESOLVED_LIB_KEY" != "null" ]; then
+	RESOLVED_VERSION="${RESOLVED_KEY#%s/}"
+	echo "  Resolved version: $RESOLVED_VERSION"
+	NEW_TARGET=$(jq -r --arg key "$RESOLVED_KEY" '.targets[$GEN_TARGET_KEY][$key]' /output/patch.deps.json 2>/dev/null)
+	NEW_LIBRARY=$(jq -r --arg key "$RESOLVED_LIB_KEY" '.libraries[$key]' /output/patch.deps.json 2>/dev/null)
 	echo "  Extracted package metadata from generated deps.json"
 
-	# Update targets section: remove old package entry, add new one with correct metadata
-	jq --argjson newTarget "$NEW_TARGET" --arg targetKey "$ORIG_TARGET_KEY" '
+	# Update targets section: remove old package entry, add resolved one with correct metadata
+	jq --argjson newTarget "$NEW_TARGET" \
+	   --arg targetKey "$ORIG_TARGET_KEY" \
+	   --arg oldKey "%s/%s" \
+	   --arg newKey "$RESOLVED_KEY" '
 		.targets[$targetKey] |= (
-			del(.["%s/%s"]) |
-			. + {"%s/%s": $newTarget}
+			del(.[$oldKey]) |
+			. + {($newKey): $newTarget}
 		)
 	' "$UPDATED_DEPS" > "${UPDATED_DEPS}.tmp" && mv "${UPDATED_DEPS}.tmp" "$UPDATED_DEPS"
 
-	# Update libraries section: remove old entry, add new one with correct sha512, hashPath, etc.
-	jq --argjson newLib "$NEW_LIBRARY" '
+	# Update libraries section: remove old entry, add resolved one with correct sha512, hashPath, etc.
+	jq --argjson newLib "$NEW_LIBRARY" \
+	   --arg oldKey "%s/%s" \
+	   --arg newKey "$RESOLVED_LIB_KEY" '
 		.libraries |= (
-			del(.["%s/%s"]) |
-			. + {"%s/%s": $newLib}
+			del(.[$oldKey]) |
+			. + {($newKey): $newLib}
 		)
 	' "$UPDATED_DEPS" > "${UPDATED_DEPS}.tmp" && mv "${UPDATED_DEPS}.tmp" "$UPDATED_DEPS"
 
 	# Update dependency version references throughout all targets
-	jq '(.targets[][].dependencies // {}) |= with_entries(if .key == "%s" then .value = "%s" else . end)' \
-		"$UPDATED_DEPS" > "${UPDATED_DEPS}.tmp" && mv "${UPDATED_DEPS}.tmp" "$UPDATED_DEPS"
+	jq --arg name "%s" --arg ver "$RESOLVED_VERSION" '
+		(.targets[][].dependencies // {}) |= with_entries(if .key == $name then .value = $ver else . end)
+	' "$UPDATED_DEPS" > "${UPDATED_DEPS}.tmp" && mv "${UPDATED_DEPS}.tmp" "$UPDATED_DEPS"
 
-	echo "  Updated %s to %s with correct metadata (sha512, hashPath, assemblyVersion, fileVersion)"
+	echo "  Updated %s to $RESOLVED_VERSION with correct metadata (sha512, hashPath, assemblyVersion, fileVersion)"
 else
-	echo "  ERROR: Could not extract package metadata for %s/%s from generated deps.json"
+	echo "  ERROR: Could not find %s in generated deps.json (Trivy pin was %s)"
 fi
-`, packageName, oldVersion, newVersion, packageName, oldVersion, newVersion,
-			packageName, newVersion, // NEW_TARGET extraction
-			packageName, newVersion, // NEW_LIBRARY extraction
-			packageName, oldVersion, packageName, newVersion, // targets update
-			packageName, oldVersion, packageName, newVersion, // libraries update
-			packageName, newVersion, // dependency update
-			packageName, newVersion, // success message
-			packageName, newVersion) // error message
+`,
+			packageName, trivyPin, // comment
+			packageName, oldVersion, trivyPin, // echo
+			packageName,             // RESOLVED_KEY --arg name
+			packageName,             // RESOLVED_LIB_KEY --arg name
+			packageName,             // RESOLVED_VERSION prefix strip
+			packageName, oldVersion, // --arg oldKey (targets)
+			packageName, oldVersion, // --arg oldKey (libraries)
+			packageName,           // --arg name (dependencies update)
+			packageName,           // success echo
+			packageName, trivyPin, // error echo
+		)
 	}
 
 	script.WriteString(`

--- a/pkg/langmgr/dotnet_test.go
+++ b/pkg/langmgr/dotnet_test.go
@@ -345,3 +345,61 @@ func TestBuildPatchCsproj_EmptyPackageRefs(t *testing.T) {
 	assert.Contains(t, got, "<ItemGroup>\n  </ItemGroup>",
 		"empty ItemGroup should still be well-formed")
 }
+
+func TestBuildUpdateDepsJsonScript_ResolvesActualVersion(t *testing.T) {
+	dnm := &dotnetManager{}
+	updates := unversioned.LangUpdatePackages{
+		{
+			Name:             "Newtonsoft.Json",
+			InstalledVersion: "12.0.1",
+			FixedVersion:     "13.0.1",
+			Type:             "dotnet-core",
+		},
+	}
+
+	got := dnm.buildUpdateDepsJsonScript(updates)
+
+	assert.Contains(t, got, `RESOLVED_KEY=`,
+		"script must resolve the actual package key from the generated deps.json")
+	assert.Contains(t, got, `select(startswith($name + "/"))`,
+		"script must look up by Name prefix, not Name/TrivyPin")
+	assert.Contains(t, got, `RESOLVED_VERSION="${RESOLVED_KEY#Newtonsoft.Json/}"`,
+		"script must strip the package name prefix to extract the resolved version")
+	assert.Contains(t, got, `--arg newKey "$RESOLVED_KEY"`,
+		"targets insertion must use the resolved key, not Name/TrivyPin")
+	assert.Contains(t, got, `--arg newKey "$RESOLVED_LIB_KEY"`,
+		"libraries insertion must use the resolved key, not Name/TrivyPin")
+	assert.Contains(t, got, `--arg ver "$RESOLVED_VERSION"`,
+		"dependency version updates must use the resolved version, not Trivy's pin")
+	assert.Contains(t, got, `"Newtonsoft.Json/12.0.1"`,
+		"old entry must still be deleted using the installed version from Trivy")
+}
+
+func TestBuildUpdateDepsJsonScript_HardcodedTrivyPinRemoved(t *testing.T) {
+	dnm := &dotnetManager{}
+	updates := unversioned.LangUpdatePackages{
+		{
+			Name:             "NuGet.Packaging",
+			InstalledVersion: "6.11.1",
+			FixedVersion:     "7.3.1",
+			Type:             "dotnet-core",
+		},
+	}
+
+	got := dnm.buildUpdateDepsJsonScript(updates)
+
+	assert.NotContains(t, got, `"NuGet.Packaging/7.3.1": $newTarget`,
+		"new target entry must not hardcode Trivy's requested version - transitive deps can force a higher one")
+	assert.NotContains(t, got, `"NuGet.Packaging/7.3.1": $newLib`,
+		"new library entry must not hardcode Trivy's requested version")
+	assert.NotContains(t, got,
+		`jq '(.targets[][].dependencies // {}) |= with_entries(if .key == "NuGet.Packaging" then .value = "7.3.1"`,
+		"dependency version rewrite must not hardcode Trivy's requested version")
+}
+
+func TestBuildUpdateDepsJsonScript_EmptyUpdates(t *testing.T) {
+	dnm := &dotnetManager{}
+	got := dnm.buildUpdateDepsJsonScript(unversioned.LangUpdatePackages{})
+	assert.Equal(t, `echo "No updates to apply to deps.json"`, got,
+		"empty updates should produce a no-op script")
+}

--- a/pkg/langmgr/dotnet_test.go
+++ b/pkg/langmgr/dotnet_test.go
@@ -1,6 +1,7 @@
 package langmgr
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
@@ -308,4 +309,39 @@ func TestBuildUpdateDepsJsonScript_NoValidUpdates(t *testing.T) {
 
 	script := dnm.buildUpdateDepsJsonScript(updates)
 	assert.Equal(t, `echo "No valid updates to apply to deps.json"`, script)
+}
+
+func TestBuildPatchCsproj(t *testing.T) {
+	refs := `    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />` + "\n" +
+		`    <PackageReference Include="NuGet.Packaging" Version="7.3.1" />` + "\n"
+
+	got := buildPatchCsproj("net8.0", refs)
+
+	assert.Contains(t, got, `<TargetFramework>net8.0</TargetFramework>`,
+		"target framework should be included")
+	assert.Contains(t, got, `<OutputType>Library</OutputType>`,
+		"output type should be Library")
+	assert.Contains(t, got, `<NoWarn>NU1605</NoWarn>`,
+		"NU1605 must be suppressed so transitive-dependency minimums do not fail restore")
+	assert.Contains(t, got,
+		`<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />`,
+		"Newtonsoft.Json reference should be present")
+	assert.Contains(t, got,
+		`<PackageReference Include="NuGet.Packaging" Version="7.3.1" />`,
+		"NuGet.Packaging reference should be present")
+
+	assert.True(t, strings.Contains(got, "</Project>"), "project should be closed")
+	propStart := strings.Index(got, "<PropertyGroup>")
+	propEnd := strings.Index(got, "</PropertyGroup>")
+	noWarn := strings.Index(got, "<NoWarn>NU1605</NoWarn>")
+	assert.True(t, propStart >= 0 && propEnd > propStart && noWarn > propStart && noWarn < propEnd,
+		"<NoWarn> must live inside <PropertyGroup>")
+}
+
+func TestBuildPatchCsproj_EmptyPackageRefs(t *testing.T) {
+	got := buildPatchCsproj("net9.0", "")
+	assert.Contains(t, got, `<TargetFramework>net9.0</TargetFramework>`)
+	assert.Contains(t, got, `<NoWarn>NU1605</NoWarn>`)
+	assert.Contains(t, got, "<ItemGroup>\n  </ItemGroup>",
+		"empty ItemGroup should still be well-formed")
 }


### PR DESCRIPTION
Fixes #1556

## What

The `.NET` patch pipeline in `pkg/langmgr/dotnet.go` generates a minimal `patch.csproj` with one `<PackageReference>` per Trivy-reported fixed version, then runs `dotnet restore + publish` inside an SDK container to extract the patched DLLs. When two of the reported fixes have transitive relationships in NuGet's dependency graph, the direct pin on one package conflicts with the transitive minimum required by another. NuGet raises `NU1605` "package downgrade", the rule is treated as error by default, and `dotnet restore` fails. This breaks the entire patch.

Observed failure from `Test .NET patching` on `main` (commit `928892c1`):

```
<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
<PackageReference Include="NuGet.Packaging" Version="7.3.1" />

/patch/patch.csproj : error NU1605: Warning As Error: Detected package downgrade: Newtonsoft.Json from 13.0.3 to 13.0.1.
  patch -> NuGet.Packaging 7.3.1 -> Newtonsoft.Json (>= 13.0.3)
  patch -> Newtonsoft.Json (>= 13.0.1)
```

## Fix

Add `<NoWarn>NU1605</NoWarn>` to the generated csproj so NuGet's natural highest-wins resolution picks the transitive minimum automatically. This is strictly safer than the Trivy-suggested fix:

- The resolved version is always `>=` the reported fixed version, never below a known good version.
- `GetUniqueLatestUpdates` already selects the newest fix per package, so there is no risk of silently downgrading past a known fix.

Also extracted the csproj rendering into a `buildPatchCsproj` helper so the logic can be unit tested without spinning up BuildKit.

## Test plan

- `go test ./pkg/langmgr/...` passes locally, including two new unit tests for `buildPatchCsproj` asserting that `<NoWarn>NU1605</NoWarn>` lives inside `<PropertyGroup>` and that the ItemGroup is well-formed even when empty.
- `golangci-lint run --new-from-rev=upstream/main` reports 0 issues.
- Once CI runs against `docker.io/ashnam/dotnet-sdk-vuln:v1` and `docker.io/ashnam/dotnet-runtime-vuln:v2`, the `Test .NET patching` job that has been failing on every recent PR should pass again.

Signed-off-by: Omer &lt;omer@descope.com&gt;
