### PR TITLE
refactor(langmgr): replace rebuildErrors []string with structured rebuildFailure

### DIFF
--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -488,6 +488,22 @@ func (gm *golangManager) upgradePackages(
 	return &state, failedPackages, nil
 }
 
+// rebuildFailure captures a single Go binary rebuild failure with the
+// binary path and failure reason as separate fields. Using a struct
+// rather than a []string of "path: reason" strings avoids fragile
+// string parsing in downstream consumers.
+type rebuildFailure struct {
+	binaryPath string
+	reason     string
+}
+
+// String implements fmt.Stringer so that slices of rebuildFailure
+// produce the same "path: reason" format as the previous []string
+// accumulator when formatted with %v.
+func (f rebuildFailure) String() string {
+	return fmt.Sprintf("%s: %s", f.binaryPath, f.reason)
+}
+
 // attemptBinaryRebuild attempts to rebuild Go binaries using heuristic binary detection.
 // When stdlibFixedVersion is set, only binaries built with a Go version older than
 // that version are rebuilt for stdlib fixes. Binaries already on a new enough Go
@@ -559,7 +575,7 @@ func (gm *golangManager) attemptBinaryRebuild(
 	// Track overall results
 	state := currentState
 	totalRebuilt := 0
-	var rebuildErrors []string
+	var rebuildFailures []rebuildFailure
 
 	// Process each detected binary
 	for i, binaryInfo := range binaries {
@@ -570,7 +586,7 @@ func (gm *golangManager) attemptBinaryRebuild(
 		buildInfo := detector.ConvertBinaryInfoToBuildInfo(binaryInfo)
 		if buildInfo == nil {
 			log.Warnf("Could not extract build info for %s, skipping", binaryPath)
-			rebuildErrors = append(rebuildErrors, fmt.Sprintf("%s: no build info", binaryPath))
+			rebuildFailures = append(rebuildFailures, rebuildFailure{binaryPath: binaryPath, reason: "no build info"})
 			continue
 		}
 
@@ -638,13 +654,13 @@ func (gm *golangManager) attemptBinaryRebuild(
 		newState, result, err := rebuilder.RebuildBinary(rebuildCtx, filteredUpdateMap, gm.config.Platform, state, binaryPath)
 		if err != nil {
 			log.Warnf("Failed to rebuild %s (skipping): %v", binaryPath, err)
-			rebuildErrors = append(rebuildErrors, fmt.Sprintf("%s: %v", binaryPath, err))
+			rebuildFailures = append(rebuildFailures, rebuildFailure{binaryPath: binaryPath, reason: fmt.Sprintf("%v", err)})
 			continue
 		}
 
 		if !result.Success {
 			log.Warnf("Rebuild unsuccessful for %s (skipping): %v", binaryPath, result.Error)
-			rebuildErrors = append(rebuildErrors, fmt.Sprintf("%s: %v", binaryPath, result.Error))
+			rebuildFailures = append(rebuildFailures, rebuildFailure{binaryPath: binaryPath, reason: fmt.Sprintf("%v", result.Error)})
 			continue
 		}
 
@@ -659,14 +675,14 @@ func (gm *golangManager) attemptBinaryRebuild(
 		for module := range updateMap {
 			failedPackages = append(failedPackages, module)
 		}
-		if len(rebuildErrors) > 0 {
-			return currentState, failedPackages, fmt.Errorf("no binaries were successfully rebuilt: %v", rebuildErrors)
+		if len(rebuildFailures) > 0 {
+			return currentState, failedPackages, fmt.Errorf("no binaries were successfully rebuilt: %v", rebuildFailures)
 		}
 		return currentState, failedPackages, fmt.Errorf("no binaries were successfully rebuilt")
 	}
 
 	if totalRebuilt < len(binaries) {
-		log.Warnf("Partial patch: %d/%d binaries rebuilt successfully. Failed: %v", totalRebuilt, len(binaries), rebuildErrors)
+		log.Warnf("Partial patch: %d/%d binaries rebuilt successfully. Failed: %v", totalRebuilt, len(binaries), rebuildFailures)
 	} else {
 		log.Infof("Binary rebuild complete: %d/%d binaries rebuilt successfully", totalRebuilt, len(binaries))
 	}

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -1,6 +1,7 @@
 package langmgr
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
@@ -741,4 +742,46 @@ func TestGetUniqueLatestUpdates_Go(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRebuildFailureString(t *testing.T) {
+	tests := []struct {
+		name     string
+		failure  rebuildFailure
+		expected string
+	}{
+		{
+			name:     "no build info",
+			failure:  rebuildFailure{binaryPath: "/usr/bin/foo", reason: "no build info"},
+			expected: "/usr/bin/foo: no build info",
+		},
+		{
+			name:     "error reason",
+			failure:  rebuildFailure{binaryPath: "/usr/bin/bar", reason: "exit status 1"},
+			expected: "/usr/bin/bar: exit status 1",
+		},
+		{
+			name:     "empty reason",
+			failure:  rebuildFailure{binaryPath: "/usr/bin/baz", reason: ""},
+			expected: "/usr/bin/baz: ",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.failure.String())
+		})
+	}
+}
+
+func TestRebuildFailureSliceFormat(t *testing.T) {
+	failures := []rebuildFailure{
+		{binaryPath: "/usr/bin/foo", reason: "no build info"},
+		{binaryPath: "/usr/bin/bar", reason: "exit status 1"},
+	}
+	oldStyle := []string{
+		"/usr/bin/foo: no build info",
+		"/usr/bin/bar: exit status 1",
+	}
+	assert.Equal(t, fmt.Sprintf("%v", oldStyle), fmt.Sprintf("%v", failures),
+		"rebuildFailure slice must format identically to the old []string representation")
 }


### PR DESCRIPTION
Closes #1559

## What

Replaces `rebuildErrors []string` with `rebuildFailures []rebuildFailure` in the Go binary rebuild path (`pkg/langmgr/golang.go`):

- New `rebuildFailure` struct with typed `binaryPath` and `reason` fields.
- `String()` method preserves the existing `"path: reason"` format so `%v` on a slice of `rebuildFailure` produces byte-identical output to the old `[]string` representation.
- Three append sites (no-build-info, rebuild error, unsuccessful rebuild) and three consumer sites (len check, final error, partial-patch warning) all updated.

## Why

Review feedback on #1516 flagged that formatting errors into strings and then reparsing them with `strings.SplitN` to recover the binary path is fragile - a format-string refactor silently breaks the consumer. A typed struct makes the data directly accessible without parsing.

Acceptance criteria from #1559:

- [x] `rebuildErrors []string` replaced with `rebuildFailures []rebuildFailure`
- [x] No `strings.SplitN` on formatted error strings in this file
- [x] Existing partial-patch log output preserved (`fmt.Stringer` keeps format byte-identical)
- [x] `go test ./pkg/langmgr/...` passes

## Testing

Two regression tests added to `pkg/langmgr/golang_test.go`:

- `TestRebuildFailureString` - table-driven, covers no-build-info, error-reason, and empty-reason cases
- `TestRebuildFailureSliceFormat` - asserts `fmt.Sprintf("%v", []rebuildFailure{...})` equals `fmt.Sprintf("%v", []string{...})` for the same logical content

Local verification: `go build ./...`, `go test ./pkg/langmgr/...`, `go vet ./pkg/langmgr/...`, and `golangci-lint run --new-from-rev=upstream/main` all pass.
