### PR TITLE
fix(ci): pin BuildKit version and set explicit DNS for podman/container env

### DIFF
--- a/.github/workflows/scripts/buildkitenvs/podman/container
+++ b/.github/workflows/scripts/buildkitenvs/podman/container
@@ -2,15 +2,27 @@
 
 set -eu -o pipefail
 
+# Pin BuildKit to match BUILDKIT_VERSION (set in .github/workflows/build.yml,
+# test.yml, and private-registry-test.yml). Every other buildkit env script
+# respects this var; using :latest here caused version drift between the
+# podman/container matrix cell and the rest of the CI.
+: "${BUILDKIT_VERSION:=0.19.0}"
+
 # Start Podman buildkit container
 CONTAINER_NAME="copa-buildkitd-$(date +%s)"
-echo "Starting Podman buildkit container: ${CONTAINER_NAME}" >&2
+echo "Starting Podman buildkit container: ${CONTAINER_NAME} (buildkit v${BUILDKIT_VERSION})" >&2
 
-# Start buildkit
+# Start buildkit.
+# --dns forces explicit resolvers in the container's /etc/resolv.conf. With
+# --network=host podman still writes a custom resolv.conf in the container,
+# which BuildKit reads at startup for its sandbox DNS. This hardens the job
+# against flaky resolver config on the self-hosted runners.
 podman run -d --rm --name "${CONTAINER_NAME}" \
     --privileged \
     --network=host \
-    docker.io/moby/buildkit:latest >/dev/null
+    --dns=8.8.8.8 \
+    --dns=1.1.1.1 \
+    "docker.io/moby/buildkit:v${BUILDKIT_VERSION}" >/dev/null
 
 # Wait for container to be ready
 echo "Waiting for buildkit container to be ready..." >&2


### PR DESCRIPTION
Fixes #1562.

## Problem

The `podman/container` BuildKit env script uses `moby/buildkit:latest`, while every other env respects `BUILDKIT_VERSION=0.19.0` (set in `.github/workflows/build.yml`, `test.yml`, and `private-registry-test.yml`). Today `moby/buildkit:latest` resolves to `v0.29.0` (pushed 2026-03-31), so the podman matrix cell runs 10 minor versions ahead of the rest of the CI.

This causes flaky failures in `Test patch with trivy podman/container` and `Test patch no report podman/container`. Sample failure signature:

```
#5 705.3 Error(1207) : Could not resolve hostname
#5 705.3 Error: Failed to synchronize cache for repo 'Azure Linux Official Cloud Native 3.0 aarch64'
#5 ERROR: process "tdnf install busybox dnf-utils cpio -y" did not complete successfully: exit code: 243

FAIL: integration/singlearch TestPatch/Custom_rpmmanifest_files,_no_yum/tdnf/dnf/microdnf/rpm#01
```

Three PRs run on 2026-04-23 against the same main base:

| PR | podman/container result |
| --- | --- |
| #1552 | `Test patch with trivy` and `Test patch no report` FAILED |
| #1555 | `Test patch no report` FAILED |
| #1560 | all passed |

Between v0.19.0 and v0.29.0 BuildKit bumped CNI plugins (v1.7.x to v1.9.1 across multiple releases), go-cni (v1.1.12 to v1.1.13), and embedded QEMU (to v10.2.1 in v0.29) - all relevant to DNS resolution inside emulated aarch64 build sandboxes.

## Fix

Two small changes to `.github/workflows/scripts/buildkitenvs/podman/container`:

1. Respect `BUILDKIT_VERSION` the same way `direct/tcp` does. The image tag becomes `moby/buildkit:v${BUILDKIT_VERSION}` instead of `:latest`. Script default is `0.19.0` to match `direct/tcp`; the workflow env passes the canonical value.

2. Add `--dns=8.8.8.8 --dns=1.1.1.1` to the podman run. Per the podman-run docs `--dns` is compatible with `--network=host` (only blocked for `--network=none` or `--network=container:id`) and writes a custom `/etc/resolv.conf` in the container, which BuildKit reads at startup for sandbox DNS.

No other files change. Other buildkit envs are unaffected.

## Risk

- Low. v0.19.0 is already known-compatible with the copa test suite through the `direct/tcp` path which passes consistently on all recent runs.
- If v0.19.0 itself has the DNS bug the pin does not fix it, but it removes version drift as a variable and makes the flake reproducible.
- `--dns` with `--network=host` is a documented, supported combination.

## Testing

CI on this PR exercises the podman/container matrix. If version drift is the primary cause of the flake, the podman jobs should run green here and on subsequent PRs. If flakes persist we will have narrowed the cause to something other than BuildKit version and can follow up.
