### PR TITLE
fix(frontend): bump frontend.Dockerfile Go base to 1.25.9-alpine3.23

### DIFF
--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -1,6 +1,6 @@
 
 # syntax=docker/dockerfile:1
-FROM golang:1.25.5-alpine3.23 AS builder
+FROM golang:1.25.9-alpine3.23 AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates


### PR DESCRIPTION
Refs #1570.

## Problem

`frontend.Dockerfile` pins `golang:1.25.5-alpine3.23` as its builder base. `go.mod` requires `go >= 1.25.9`, so `go build` inside the builder fails with:

```
go: go.mod requires go >= 1.25.9 (running go 1.25.5; GOTOOLCHAIN=local)
```

This blocks the `copacetic-frontend` image build on every tag push. Discovered by @robert-cronin while cutting `v0.14.0-rc.1`.

## Fix

Bump the base image to `golang:1.25.9-alpine3.23`. One-line change in `frontend.Dockerfile`.

## Verification

```sh
docker buildx build --platform linux/amd64 -f frontend.Dockerfile -t copa-frontend-test:1570 .
# build succeeds; final image size 27.8MB (consistent with prior builds)
```

## Scope

Addresses the build-blocker portion of #1570 only. The other acceptance items in that issue (drift-prevention guard, release.md post-tag verification doc, `.goreleaser.yml` `prerelease: auto`) are intentionally left for follow-up PRs to keep this one minimal and reviewable.