### PR TITLE
ci: harden trusted-fork dispatch against fork-mutated workflow YAML and force-push races

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,17 @@ on:
       - "docs/**"
       - "demo/**"
   workflow_dispatch:
+    inputs:
+      pr_sha:
+        description: "Fork PR head SHA. Set by trusted-fork-tests orchestrator."
+        required: false
+        default: ""
+        type: string
+      pr_number:
+        description: "Fork PR number. Set by trusted-fork-tests orchestrator."
+        required: false
+        default: ""
+        type: string
 
 env:
   TRIVY_VERSION: 0.69.3
@@ -43,6 +54,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -74,6 +87,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -122,6 +137,8 @@ jobs:
       - run: docker system prune -a -f --volumes
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -173,6 +190,8 @@ jobs:
       - run: docker system prune -a -f --volumes
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -293,6 +312,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -341,6 +362,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -429,6 +452,8 @@ jobs:
       - run: docker system prune -a -f --volumes
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -491,6 +516,8 @@ jobs:
       - run: docker system prune -a -f --volumes
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -557,6 +584,8 @@ jobs:
           docker push localhost:5000/nginx:latest
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -617,6 +646,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -828,6 +859,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -862,6 +895,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - name: Configure Docker Daemon
         run: |
           echo '{"features": {"containerd-snapshotter": true}, "insecure-registries": ["127.0.0.1:37219"]}' | sudo tee /etc/docker/daemon.json
@@ -908,6 +943,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -954,6 +991,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -1002,6 +1041,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -1048,6 +1089,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,17 @@ on:
       - "docs/**"
       - "demo/**"
   workflow_dispatch:
+    inputs:
+      pr_sha:
+        description: "Fork PR head SHA. Set by trusted-fork-tests orchestrator."
+        required: false
+        default: ""
+        type: string
+      pr_number:
+        description: "Fork PR number. Set by trusted-fork-tests orchestrator."
+        required: false
+        default: ""
+        type: string
 
 env:
   TRIVY_VERSION: 0.69.3
@@ -40,6 +51,8 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -72,6 +85,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -111,6 +126,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -150,6 +167,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -189,6 +208,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -228,6 +249,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"
@@ -267,6 +290,8 @@ jobs:
           egress-policy: audit
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "1.25.9"

--- a/.github/workflows/trusted-fork-tests.yml
+++ b/.github/workflows/trusted-fork-tests.yml
@@ -6,25 +6,25 @@ name: "[Maintainer] Trusted Fork Tests"
 #   1. Review the fork PR code thoroughly.
 #   2. Add the `ok-to-test` label to the PR.
 #   3. This workflow checks that you have write/maintain/admin permission,
-#      removes the label (so it can be re-added after new commits), creates a
-#      temporary upstream branch at the PR head SHA, and dispatches the
-#      Build and Gateway Test workflows against it.
+#      removes the label (so it can be re-added after new commits), and
+#      dispatches the Build and Gateway Test workflows against the PR's base
+#      branch with the PR head SHA + number passed as inputs.
 #   4. Track progress in the Actions tab or via the link posted in the PR comment.
 #   5. Re-add `ok-to-test` after the contributor pushes new commits to re-trigger.
 #
 # SECURITY MODEL:
 #   - pull_request_target runs in the base repo context (has access to secrets).
 #   - The actor's repository permission is verified before any action is taken.
-#   - Untrusted fork code never executes in this workflow itself; it is only
-#     checked out by the dispatched Build/Gateway workflows, which run under a
-#     separate workflow_dispatch event on the temporary upstream branch.
+#   - Untrusted fork code never executes in this workflow itself.
+#   - Dispatched build/test workflows read their YAML from the PR's BASE ref
+#     (trusted) and only consume fork code as data via actions/checkout pinned
+#     to refs/pull/<n>/head.
 
 on:
   pull_request_target:
     types: [labeled]
 
 permissions:
-  contents: write      # create and delete the temporary upstream branch
   pull-requests: write # post a status comment on the PR
   actions: write       # dispatch the Build and Gateway Test workflows
 
@@ -88,57 +88,16 @@ jobs:
             "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/ok-to-test" \
             -X DELETE
 
-      # Create a short-lived upstream branch at the exact PR head SHA.
-      # workflow_dispatch requires a ref that exists in the base repository;
-      # this branch satisfies that requirement without permanently mirroring the fork branch.
-      #
-      # Note: we use git CLI rather than the REST `POST /git/refs` endpoint because
-      # fork PR head SHAs live only under `refs/pull/<n>/head` and cannot be the
-      # target of a regular branch ref via the API (returns 403/404).
-      - name: Checkout base repository
-        if: steps.check-permission.outputs.authorized == 'true'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: true
-          fetch-depth: 1
-
-      - name: Create temporary upstream branch at PR head SHA
-        if: steps.check-permission.outputs.authorized == 'true'
-        id: create-branch
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          TEMP_BRANCH="ci/trusted/pr-${PR_NUMBER}"
-          echo "temp_branch=${TEMP_BRANCH}" >> "$GITHUB_OUTPUT"
-
-          # Remove any leftover branch from a previous run on this PR.
-          git push origin --delete "${TEMP_BRANCH}" 2>/dev/null || true
-
-          # Fetch the PR head from the upstream pull-ref namespace and push it
-          # to a regular branch in the base repository.
-          git fetch origin "refs/pull/${PR_NUMBER}/head:${TEMP_BRANCH}"
-
-          # Sanity check: confirm the local branch tip matches the approved SHA
-          # before publishing it. Guards against races if new commits land between
-          # event firing and fetch.
-          LOCAL_SHA=$(git rev-parse "${TEMP_BRANCH}")
-          if [ "${LOCAL_SHA}" != "${PR_SHA}" ]; then
-            echo "::error::PR head SHA changed since label event (expected ${PR_SHA}, got ${LOCAL_SHA}). Re-add ok-to-test to re-trigger."
-            exit 1
-          fi
-
-          git push origin "${TEMP_BRANCH}"
-
       - name: Dispatch [Blocking] Build workflow
         if: steps.check-permission.outputs.authorized == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run build.yml \
-            --ref "${{ steps.create-branch.outputs.temp_branch }}" \
-            --repo "${{ github.repository }}"
+            --ref "${{ github.event.pull_request.base.ref }}" \
+            --repo "${{ github.repository }}" \
+            -f "pr_sha=${{ github.event.pull_request.head.sha }}" \
+            -f "pr_number=${{ github.event.pull_request.number }}"
 
       - name: Dispatch [Integration] Gateway Tests workflow
         if: steps.check-permission.outputs.authorized == 'true'
@@ -146,8 +105,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run test.yml \
-            --ref "${{ steps.create-branch.outputs.temp_branch }}" \
-            --repo "${{ github.repository }}"
+            --ref "${{ github.event.pull_request.base.ref }}" \
+            --repo "${{ github.repository }}" \
+            -f "pr_sha=${{ github.event.pull_request.head.sha }}" \
+            -f "pr_number=${{ github.event.pull_request.number }}"
 
       - name: Post status comment on PR
         if: steps.check-permission.outputs.authorized == 'true'
@@ -157,27 +118,12 @@ jobs:
           gh pr comment "${{ github.event.pull_request.number }}" \
             --repo "${{ github.repository }}" \
             --body "> [!NOTE]
-          > 🚀 **Trusted fork tests triggered** by @${{ github.actor }} for commit \`${{ github.event.pull_request.head.sha }}\`.
+          > 🚀 **Trusted fork tests triggered** by @${{ github.actor }} for commit \`${{ github.event.pull_request.head.sha }}\` against base branch \`${{ github.event.pull_request.base.ref }}\`.
           >
-          > The following workflows have been dispatched on a temporary upstream branch:
+          > The following workflows have been dispatched:
           > - **[\[Blocking\] Build](https://github.com/${{ github.repository }}/actions/workflows/build.yml)**
           > - **[\[Integration\] Gateway Tests](https://github.com/${{ github.repository }}/actions/workflows/test.yml)**
           >
           > Track progress in the [Actions tab](https://github.com/${{ github.repository }}/actions).
           >
           > ℹ️ The \`ok-to-test\` label has been removed. Re-add it after new commits to trigger a fresh run."
-
-      # Delete the temporary branch. The dispatched workflow runs already have the
-      # commit SHA recorded (github.sha is set at dispatch time), so actions/checkout
-      # will succeed by SHA even after this branch reference is removed.
-      - name: Delete temporary upstream branch
-        if: steps.check-permission.outputs.authorized == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Brief pause to allow GitHub Actions to register the dispatched runs
-          # before the ref is removed.
-          sleep 10
-          gh api \
-            "repos/${{ github.repository }}/git/refs/heads/${{ steps.create-branch.outputs.temp_branch }}" \
-            -X DELETE || true


### PR DESCRIPTION
Follow-up to #1572 / #1573.

While testing the new fork-PR CI flow on a real fork PR (#1574), two latent issues with the temp-branch approach surfaced:

1. **Workflow YAML was being read from the fork's temp branch.** `gh workflow run --ref ci/trusted/pr-N` evaluates the workflow YAML on the temp branch, which is just the fork's HEAD. A malicious PR could rewrite `build.yml`/`test.yml` itself and have those changes execute on self-hosted runners with secrets.
2. **GITHUB_TOKEN can't push fork-modified workflow files.** `refusing to allow a GitHub App to create or update workflow .github/workflows/trusted-fork-tests.yml without workflows permission` — the orchestrator failed entirely whenever the PR touched any `.github/workflows/` file.

Both stem from the same root cause: pushing fork code as a real branch and dispatching against that branch.

## What this PR does

Switches to a Prow-style pattern: orchestrator dispatches `build.yml`/`test.yml` against the **PR's base branch** (so the workflow YAML always comes from a trusted ref) and passes the fork PR's head SHA + number as inputs. The dispatched workflows then check out fork code by `refs/pull/<n>/head` as data, with `persist-credentials: false`, and re-validate the SHA before any heavy job runs.

### `trusted-fork-tests.yml`
- Drops temp-branch creation, the 10s sleep, the temp-branch deletion, and `contents: write` permission.
- Re-queries PR head SHA + base ref + state via the API at orchestration time (narrows the force-push race window vs. trusting the label-event payload).
- Dispatches `build.yml`/`test.yml` with `--ref <PR base ref>` and `pr_sha`/`pr_number` inputs.
- Idempotent label removal (single step, doesn't fail if already absent).
- Concurrency group per PR with `cancel-in-progress: false`.

### `build.yml` and `test.yml`
- Add `workflow_dispatch.inputs` (`pr_sha`, `pr_number`).
- Add `run-name` showing PR number + SHA on trusted-fork dispatches.
- New `validate-dispatch` job (GitHub-hosted, ~30s) that:
  - validates input shape (`pr_sha` is 40-char hex, `pr_number` is digits),
  - rejects mismatched-pair inputs,
  - re-queries PR via API and asserts `state == open`, `head.sha == pr_sha`, `base.ref == github.ref_name` — closes the dispatch-to-runner-pickup window where a force-push could otherwise substitute unreviewed code.
- All self-hosted jobs gain `needs: validate-dispatch` (transitively via `build`).
- Every `actions/checkout` switches to a single-step ternary: `ref: ${{ inputs.pr_number && format('refs/pull/{0}/head', inputs.pr_number) || '' }}`, `persist-credentials: false`, `fetch-depth: 1`. Empty `ref` falls back to `github.ref`/`github.sha` for normal push/PR runs.
- Every `actions/setup-go` gains `cache: ${{ inputs.pr_number == '' }}` to prevent fork code from poisoning the GHA Go module/build cache used by mainline runs.
- Codecov upload step in `unit-test` is gated on `inputs.pr_number == ''` so `CODECOV_TOKEN` is never exposed to fork code.
- Drops unused `packages: write` on the `build` job (no GHCR publish in this workflow).
- Concurrency group keyed on `inputs.pr_number` with `cancel-in-progress` only for trusted-fork runs.

### `CONTRIBUTING.md`
Adds a 'Trust model' subsection documenting both protected behaviors and explicitly accepted risks (self-hosted runner persistence, matrix-fanout DoS, manual `workflow_dispatch` UI bypass for write users).

## Verification

- `actionlint` clean on all three workflow files (only the unrelated pre-existing self-hosted runner label warning remains).
- YAML parse-clean for all three.
- Job graph preserved: `unit-test` and `build` now `needs: validate-dispatch`; downstream test jobs unchanged (`needs: build` already transitively depends on validate-dispatch).
- Will need a manual trusted-fork dispatch on a fork PR to confirm end-to-end.

## Why not a composite checkout action?

Considered and rejected: a local composite action can't run before the repository is checked out, so it can't be the wrapper for the first checkout step. The single-step ternary pattern accomplishes the same thing without bootstrapping issues.
