### PR TITLE
docs(adopters): add Verity to Copa CLI adopters

### DIFF
--- a/website/docs/adopters.md
+++ b/website/docs/adopters.md
@@ -16,3 +16,4 @@ Check out some adopters of Copa in the community:
 - [Helmper](https://github.com/ChristofferNissen/helmper)
 - [Kubescape](https://github.com/kubescape/kubescape)
 - [Devtron](https://docs.devtron.ai/usage/plugins/plugin-list/copacetic)
+- [Verity](https://www.verity.supply)


### PR DESCRIPTION
Adds [Verity](https://www.verity.supply) to the Copa CLI Adopters section