### PR TITLE
fix: prevent EnsurePath panic on non-ENOENT stat errors

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -96,16 +96,20 @@ func DeduplicateStringSlice(input []string) []string {
 func EnsurePath(path string, perm fs.FileMode) (bool, error) {
 	createdPath := false
 	st, err := os.Stat(path)
-	if err != nil && os.IsNotExist(err) {
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, err
+		}
 		err = os.MkdirAll(path, perm)
 		createdPath = (err == nil)
-	} else {
-		if !st.IsDir() {
-			return false, fs.ErrExist
-		}
-		if st.Mode().Perm() != perm {
-			return false, fs.ErrPermission
-		}
+		return createdPath, err
+	}
+
+	if !st.IsDir() {
+		return false, fs.ErrExist
+	}
+	if st.Mode().Perm() != perm {
+		return false, fs.ErrPermission
 	}
 	return createdPath, err
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -96,6 +96,7 @@ func TestEnsurePath(t *testing.T) {
 		{"PathExists", args{existingDir, testPerms}, false, false},
 		{"PathExistsWithDiffPerms", args{diffPermsDir, testPerms}, false, true},
 		{"PathIsFile", args{emptyFile, testPerms}, false, true},
+		{"StatErrorNotExist", args{path.Join(emptyFile, "child"), testPerms}, false, true},
 		{"EmptyPath", args{"", testPerms}, false, true},
 		{"EmptyPerms", args{existingDir, 0o000}, false, true},
 	}


### PR DESCRIPTION
### Motivation

- `EnsurePath` could dereference a nil `FileInfo` when `os.Stat` returned an error that was not `ENOENT`, which caused a panic for callers (e.g., `ENOTDIR` or permission errors). 
- The intent is to treat non-`ENOENT` `os.Stat` errors as immediate failures while preserving the existing behavior of creating missing directories.

### Description

- In `pkg/utils/utils.go` updated `EnsurePath` to immediately return non-`ENOENT` errors from `os.Stat` instead of dereferencing `st`, and to only call `os.MkdirAll` when the error is `ENOENT`. 
- Kept the existing checks for `st.IsDir()` and permission bits when `os.Stat` succeeds. 
- Added a regression test case `StatErrorNotExist` in `pkg/utils/utils_test.go` that exercises a non-`ENOENT` stat error path (e.g., `path.Join(emptyFile, "child")`) to ensure the function returns an error instead of panicking.

### Testing

- Added unit test `StatErrorNotExist` in `pkg/utils` alongside existing `TestEnsurePath` tests and validated locally that the test exercises the non-`ENOENT` path (regression coverage added). 
- Ran `go test ./pkg/utils` in this environment but the run failed due to module downloads from `proxy.golang.org` being forbidden, so tests could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8594dea74832a8e9e99ea175ea9ed)