### PR TITLE
fix(frontend): restore /tmp on scratch image, switch to distroless, build real Dockerfile in e2e

### DIFF
--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -36,9 +36,6 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
 # adding those back.
 FROM gcr.io/distroless/static-debian12:nonroot AS frontend
 
-# Copy CA certificates for HTTPS connections
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-
 # Copy the frontend binary
 COPY --from=builder /copa-frontend /copa-frontend
 

--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -28,7 +28,13 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /copa-frontend ./cmd/frontend
 
 # Final image
-FROM scratch AS frontend
+#
+# Distroless static gives us a minimal rootfs (no shell, no package
+# manager) while still providing /tmp, CA certs, /etc/passwd, and
+# tzdata -- which the frontend needs at runtime (e.g. os.MkdirTemp
+# requires /tmp to exist). Do not switch to `FROM scratch` without
+# adding those back.
+FROM gcr.io/distroless/static-debian12:nonroot AS frontend
 
 # Copy CA certificates for HTTPS connections
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/pkg/frontend/build.go
+++ b/pkg/frontend/build.go
@@ -24,10 +24,8 @@ const (
 )
 
 // ensureTempDir makes sure the directory returned by os.TempDir() exists
-// before callers invoke os.MkdirTemp("", ...). The published frontend image
-// is built FROM scratch (see frontend.Dockerfile), so /tmp is not present
-// at runtime and MkdirTemp would otherwise fail with
-// "stat /tmp: no such file or directory".
+// before callers invoke os.MkdirTemp("", ...). Minimal frontend images must
+// provide a writable temp base directory for report extraction.
 func ensureTempDir() error {
 	return os.MkdirAll(os.TempDir(), 0o1777)
 }

--- a/pkg/frontend/build.go
+++ b/pkg/frontend/build.go
@@ -23,6 +23,15 @@ const (
 	jsonExt = ".json"
 )
 
+// ensureTempDir makes sure the directory returned by os.TempDir() exists
+// before callers invoke os.MkdirTemp("", ...). The published frontend image
+// is built FROM scratch (see frontend.Dockerfile), so /tmp is not present
+// at runtime and MkdirTemp would otherwise fail with
+// "stat /tmp: no such file or directory".
+func ensureTempDir() error {
+	return os.MkdirAll(os.TempDir(), 0o1777)
+}
+
 // BuildPatchedImage builds a patched image using the Copa patching logic.
 // This reuses the same components as the CLI to ensure consistency.
 func (f *Frontend) buildPatchedImage(ctx context.Context, opts *types.Options, platform *ocispecs.Platform) (llb.State, error) {
@@ -145,6 +154,10 @@ func extractReportFromContext(ctx context.Context, client gwclient.Client, repor
 func extractReportFile(ctx context.Context, ref gwclient.Reference, reportPath string, fileSize int64) (string, error) {
 	const chunkSize = 8 * 1024 * 1024 // 8MB chunks to stay well under 16MB gRPC limit
 
+	if err := ensureTempDir(); err != nil {
+		return "", errors.Wrap(err, "failed to ensure temp dir exists")
+	}
+
 	tmpDir, err := os.MkdirTemp("", "copa-frontend-report-")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create temp dir for report file")
@@ -237,6 +250,10 @@ func extractReportDirectory(ctx context.Context, ref gwclient.Reference, reportP
 
 	if len(entries) == 0 {
 		return "", errors.Errorf("no JSON files found in report directory: %s", reportPath)
+	}
+
+	if err := ensureTempDir(); err != nil {
+		return "", errors.Wrap(err, "failed to ensure temp dir exists")
 	}
 
 	tmpDir, err := os.MkdirTemp("", "copa-frontend-reports-")

--- a/pkg/frontend/build_test.go
+++ b/pkg/frontend/build_test.go
@@ -3,6 +3,7 @@ package frontend
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,6 +17,32 @@ const (
 // Note: buildPatchedImage tests are covered by e2e tests in test/e2e/frontend/
 // since they require a real BuildKit gateway client and complex setup.
 // This file tests helper functions that can be unit tested.
+
+func TestEnsureTempDirCreatesMissingDir(t *testing.T) {
+	// Simulate the FROM scratch frontend image where /tmp does not exist.
+	// Point TMPDIR at a not-yet-created path under a real temp dir, then
+	// verify ensureTempDir() materializes it so os.MkdirTemp("", ...) works.
+	parent := t.TempDir()
+	missing := filepath.Join(parent, "does-not-exist-yet")
+
+	t.Setenv("TMPDIR", missing)
+
+	// Sanity: the directory really is missing before we call ensureTempDir.
+	_, err := os.Stat(missing)
+	require.True(t, os.IsNotExist(err), "expected %s to not exist", missing)
+
+	require.NoError(t, ensureTempDir(), "ensureTempDir should create missing TempDir")
+
+	info, err := os.Stat(missing)
+	require.NoError(t, err)
+	require.True(t, info.IsDir(), "expected %s to be a directory", missing)
+
+	// MkdirTemp("", ...) must now succeed against the freshly created dir.
+	tmpDir, err := os.MkdirTemp("", "copa-frontend-report-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+	assert.True(t, strings.HasPrefix(tmpDir, missing), "tmp dir %s should be inside %s", tmpDir, missing)
+}
 
 func TestPlatformSpecificReportFilename(t *testing.T) {
 	t.Run("AMD64 platform", func(t *testing.T) {

--- a/test/e2e/frontend/frontend_test.go
+++ b/test/e2e/frontend/frontend_test.go
@@ -328,52 +328,34 @@ func stopLocalRegistry(t *testing.T) {
 func buildFrontendImage(t *testing.T) {
 	t.Logf("Building Copa frontend image: %s", frontendImage)
 
-	// First build the frontend binary locally to avoid Docker disk space issues
-	t.Log("Building frontend binary locally...")
-	buildCmd := exec.Command("go", "build", "-ldflags", "-s -w", "-o", "copa-frontend", "./cmd/frontend")
-	buildCmd.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=linux")
-
 	// Set working directory to project root (3 levels up from test/e2e/frontend)
 	wd, _ := os.Getwd()
 	projectRoot := filepath.Join(wd, "..", "..", "..")
-	buildCmd.Dir = projectRoot
 
-	output, err := buildCmd.CombinedOutput()
-	require.NoError(t, err, fmt.Sprintf("failed to build frontend binary: %v\nOutput: %s", err, string(output)))
-
-	// Create a simple Dockerfile for the frontend image
-	// Must include BuildKit capability labels for named contexts support
-	dockerfileContent := `FROM alpine:3.18
-RUN apk add --no-cache ca-certificates busybox
-COPY copa-frontend /usr/bin/copa-frontend
-RUN chmod +x /usr/bin/copa-frontend
-LABEL moby.buildkit.frontend.network.none="true"
-LABEL moby.buildkit.frontend.caps="moby.buildkit.frontend.inputs,moby.buildkit.frontend.contexts"
-ENTRYPOINT ["/usr/bin/copa-frontend"]`
-
-	dockerfilePath := filepath.Join(projectRoot, "frontend-simple.Dockerfile")
-	binaryPath := filepath.Join(projectRoot, "copa-frontend")
-
-	err = os.WriteFile(dockerfilePath, []byte(dockerfileContent), 0o600)
-	require.NoError(t, err, "failed to create simple Dockerfile")
-	defer os.Remove(dockerfilePath)
-	defer os.Remove(binaryPath)
+	// Build the actual published frontend.Dockerfile so the e2e test
+	// exercises the same rootfs (distroless, no shell) that ships to users.
+	// Previously this test wrapped the binary in an alpine image, which
+	// masked regressions like #1597 (missing /tmp on the scratch rootfs).
+	dockerfilePath := filepath.Join(projectRoot, "frontend.Dockerfile")
+	if _, err := os.Stat(dockerfilePath); err != nil {
+		t.Fatalf("frontend.Dockerfile not found at %s: %v", dockerfilePath, err)
+	}
 
 	// Build the Docker image - use buildx with --load if available
 	var cmd *exec.Cmd
 	if _, err := exec.LookPath("docker"); err == nil {
 		// Check if buildx is available
 		if checkCmd := exec.Command("docker", "buildx", "version"); checkCmd.Run() == nil {
-			cmd = exec.Command("docker", "buildx", "build", "--load", "-f", "frontend-simple.Dockerfile", "-t", frontendImage, ".")
+			cmd = exec.Command("docker", "buildx", "build", "--load", "-f", "frontend.Dockerfile", "-t", frontendImage, ".")
 		} else {
-			cmd = exec.Command("docker", "build", "-f", "frontend-simple.Dockerfile", "-t", frontendImage, ".")
+			cmd = exec.Command("docker", "build", "-f", "frontend.Dockerfile", "-t", frontendImage, ".")
 		}
 	}
 	cmd.Dir = projectRoot
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err = cmd.Run()
-	require.NoError(t, err, "failed to build frontend image")
+	err := cmd.Run()
+	require.NoError(t, err, "failed to build frontend image from frontend.Dockerfile")
 	t.Logf("Frontend image built successfully: %s", frontendImage)
 
 	// Push the frontend image to the local registry so BuildKit can access it


### PR DESCRIPTION
## Summary

Three changes that together fix and prevent the recurrence of a regression in the published copa BuildKit frontend (v0.14.0 / `:latest`), where every patch run fails with:

```
failed to extract report from context:
  failed to create temp dir for report file:
    stat /tmp: no such file or directory
```

### 1. `pkg/frontend/build.go` — restore `/tmp` workaround as a helper

After #1507's security-hardening sweep switched `extractReportFile` / `extractReportDirectory` from `os.MkdirTemp(\"/\", ...)` to `os.MkdirTemp(\"\", ...)` and removed the explicit `os.MkdirAll(\"/tmp\", 0o1777)` that previously paired with it, the v0.14.0 frontend image (built `FROM scratch`) fails on every report extraction. `os.MkdirTemp(\"\")` delegates to `os.TempDir()` (`/tmp` on Linux), which doesn't exist in a scratch rootfs.

Add a small `ensureTempDir()` helper that `MkdirAll`s `os.TempDir()` (mode 0o1777) and call it from both extraction sites before `os.MkdirTemp(\"\", ...)`. Preserves #1507's intent (don't write under `/`) while restoring the runtime invariant.

### 2. `frontend.Dockerfile` — switch from `FROM scratch` to distroless

Change the final stage to `FROM gcr.io/distroless/static-debian12:nonroot`. The distroless image ships `/tmp` (mode 1777), CA certs, and tzdata out of the box, eliminating an entire class of \"missing rootfs bits\" failures. Attack surface is essentially identical to scratch (no shell, no package manager, ~2 MB). The published image now satisfies `os.TempDir()`'s implicit precondition by default; the Go-side helper above becomes defense-in-depth.

### 3. `test/e2e/frontend/frontend_test.go` — build the real `frontend.Dockerfile`

The previous `buildFrontendImage()` built an inline `FROM alpine:3.18` test-only Dockerfile, which hid the regression because alpine has a working `/tmp`. Replace it with `docker buildx build -f frontend.Dockerfile`. From now on CI exercises the same image release.yml ships, so scratch/distroless-rootfs drift between CI and production becomes impossible.

## Why no test caught this

- Unit tests run on the host, where `/tmp` always exists.
- The e2e test wrapped the binary in alpine (which has `/tmp`) instead of building the real `FROM scratch` Dockerfile, so the production rootfs was never exercised in CI.
- `frontend.Dockerfile` is consumed only by `release.yml`. The first run against a real scratch rootfs was in production, by users.

The new `TestEnsureTempDirCreatesMissingDir` simulates a missing `/tmp` by pointing `TMPDIR` at a non-existent path. Combined with the e2e fidelity fix, both the unit and integration layers now catch this regression class.

## Test plan

- [x] `go test ./pkg/frontend/...` passes (new test included)
- [x] `go vet ./pkg/frontend/... ./test/e2e/frontend/...` clean
- [x] `go build ./...` clean
- [x] Rebuilt `frontend.Dockerfile` (now distroless) and ran a real end-to-end patch against `nginx:1.21` via a Trivy report through `docker buildx` with an `oci-layout` build context. Result: `Installing 60 security updates`, valid `patched.tar` written.
- [x] Independently verified that switching to distroless alone (with the broken `build.go` from `main` un-patched) is also enough to fix the runtime failure — confirms the rootfs is the real precondition.
- [x] Confirmed the original `ghcr.io/project-copacetic/copacetic-frontend:v0.14.0` image fails the same flow with the documented error.

## Bisect

Regression introduced in #1507 (commit `3fa656ac`), \"fix: security hardening from codebase audit.\" The PR description notes \"Fix temp dir creation in frontend/build.go to use os.TempDir() instead of root filesystem,\" which is the right principle but missed the scratch-rootfs precondition.