### PR TITLE
docs: add FAQ for GPG key expiry

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,7 +33,7 @@ Copacetic (Copa) is a CLI tool that patches container image vulnerabilities usin
   - Unit tests for individual functions and components
   - Integration tests for end-to-end patching scenarios
 - Add relevant documentation for new functionality in `website/docs/`
-- When updating current website docs, check whether the latest versioned docs need the same change, especially `website/versioned_docs/version-v0.14.x` for current release docs
+- When updating current website docs (`website/docs`), check whether the latest versioned docs need the same change (`website/versioned_docs`)
 
 ## Key Architecture Concepts
 - **Patching modes**: Targeted (with vulnerability reports) or comprehensive (all available updates)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,6 +33,7 @@ Copacetic (Copa) is a CLI tool that patches container image vulnerabilities usin
   - Unit tests for individual functions and components
   - Integration tests for end-to-end patching scenarios
 - Add relevant documentation for new functionality in `website/docs/`
+- When updating current website docs, check whether the latest versioned docs need the same change, especially `website/versioned_docs/version-v0.14.x` for current release docs
 
 ## Key Architecture Concepts
 - **Patching modes**: Targeted (with vulnerability reports) or comprehensive (all available updates)

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -137,6 +137,12 @@ export EXPERIMENTAL_BUILDKIT_SOURCE_POLICY=source-policy.json
 
 For more information on source policies, see [Buildkit Source Policies](https://docs.docker.com/build/building/env-vars/#experimental_buildkit_source_policy).
 
+## Why do package updates fail with expired GPG keys?
+
+Copa can fail when it runs the distro package manager's repository refresh inside the target image, such as `apt-get update`, `dnf makecache`, `yum makecache`, `zypper refresh`, or `apk update` equivalents, if the image contains expired package repository GPG keys or other stale trust material. Copa uses the package repositories and trust material already present in the image and does not automatically replace expired repository keys.
+
+To resolve this, rebuild or update the source image with refreshed repository keys, move to a maintained base image that has current repository metadata and keys, or adjust the repository and key material in the image before running Copa.
+
 ## Can I use Dependabot with Copa patched images?
 
 Yes, see [best practices](best-practices.md#dependabot) to learn more about using Dependabot with Copa patched images.

--- a/website/versioned_docs/version-v0.14.x/faq.md
+++ b/website/versioned_docs/version-v0.14.x/faq.md
@@ -137,6 +137,12 @@ export EXPERIMENTAL_BUILDKIT_SOURCE_POLICY=source-policy.json
 
 For more information on source policies, see [Buildkit Source Policies](https://docs.docker.com/build/building/env-vars/#experimental_buildkit_source_policy).
 
+## Why do package updates fail with expired GPG keys?
+
+Copa can fail when it runs the distro package manager's repository refresh inside the target image, such as `apt-get update`, `dnf makecache`, `yum makecache`, `zypper refresh`, or `apk update` equivalents, if the image contains expired package repository GPG keys or other stale trust material. Copa uses the package repositories and trust material already present in the image and does not automatically replace expired repository keys.
+
+To resolve this, rebuild or update the source image with refreshed repository keys, move to a maintained base image that has current repository metadata and keys, or adjust the repository and key material in the image before running Copa.
+
 ## Can I use Dependabot with Copa patched images?
 
 Yes, see [best practices](best-practices.md#dependabot) to learn more about using Dependabot with Copa patched images.


### PR DESCRIPTION
## Summary
- Add a FAQ entry for expired package repository GPG keys during patching.
- Clarify that failures can happen when Copa runs distro package manager repository refresh commands inside the target image.
- Add the same FAQ entry to v0.14.x versioned docs.
- Add agent guidance to check relevant versioned docs when updating current website docs.

## Validation
- Ran git diff --check HEAD~1..HEAD.
- Ran lightweight FAQ and agent-guidance validation for heading presence, package-manager examples, versioned docs coverage, and balanced fenced code blocks.
- CI passed, including Generate docs website to GitHub Pages.

## Issue
- Addresses [#1127](https://github.com/project-copacetic/copacetic/issues/1127).