### PR TITLE
fix: skip index entries with no platform in DiscoverPlatformsFromReference

### DIFF
--- a/pkg/buildkit/buildkit.go
+++ b/pkg/buildkit/buildkit.go
@@ -318,6 +318,47 @@ func TryGetManifestFromLocal(ref name.Reference) (*remote.Descriptor, error) {
 	return nil, fmt.Errorf("single-platform image")
 }
 
+// platformsFromIndexManifest converts the entries of a multi-platform image
+// index into the platforms copa can patch. Entries without a platform (for
+// example attestation or provenance entries) or with an unknown platform are
+// skipped, since an image index can legitimately contain them.
+func platformsFromIndexManifest(manifest *v1.IndexManifest) []types.PatchPlatform {
+	var platforms []types.PatchPlatform
+	for i := range manifest.Manifests {
+		m := &manifest.Manifests[i]
+
+		// Skip manifests with no platform (e.g. attestation or provenance
+		// entries). Reading m.Platform below would otherwise panic.
+		if m.Platform == nil {
+			log.Debugf("Skipping manifest with no platform")
+			continue
+		}
+		if m.Platform.OS == "unknown" || m.Platform.Architecture == "unknown" {
+			log.Debugf("Skipping manifest with unknown platform: %s/%s", m.Platform.OS, m.Platform.Architecture)
+			continue
+		}
+
+		patchPlatform := types.PatchPlatform{
+			Platform: specs.Platform{
+				OS:           m.Platform.OS,
+				Architecture: m.Platform.Architecture,
+				Variant:      m.Platform.Variant,
+				OSVersion:    m.Platform.OSVersion,
+				OSFeatures:   m.Platform.OSFeatures,
+			},
+			ReportFile:     "",    // No report file for platforms discovered from reference
+			ShouldPreserve: false, // Default to false, will be set appropriately later
+		}
+		if m.Platform.Architecture == arm64 && m.Platform.Variant == "v8" {
+			// some scanners may not add v8 to arm64 reports, so we
+			// need to remove it here to maintain consistency
+			patchPlatform.Variant = ""
+		}
+		platforms = append(platforms, patchPlatform)
+	}
+	return platforms
+}
+
 // DiscoverPlatformsFromReference discovers platforms from both local and remote manifests.
 // It first attempts to inspect the manifest locally using Docker API
 // to get raw manifest data and determine if it's multi-platform.
@@ -392,34 +433,7 @@ func DiscoverPlatformsFromReference(manifestRef string) ([]types.PatchPlatform, 
 			return nil, fmt.Errorf("error getting manifest: %w", err)
 		}
 
-		for i := range manifest.Manifests {
-			m := &manifest.Manifests[i]
-
-			// Skip manifests with unknown platforms
-			if m.Platform == nil || m.Platform.OS == "unknown" || m.Platform.Architecture == "unknown" {
-				log.Debugf("Skipping manifest with unknown platform: %s/%s", m.Platform.OS, m.Platform.Architecture)
-				continue
-			}
-
-			patchPlatform := types.PatchPlatform{
-				Platform: specs.Platform{
-					OS:           m.Platform.OS,
-					Architecture: m.Platform.Architecture,
-					Variant:      m.Platform.Variant,
-					OSVersion:    m.Platform.OSVersion,
-					OSFeatures:   m.Platform.OSFeatures,
-				},
-				ReportFile:     "",    // No report file for platforms discovered from reference
-				ShouldPreserve: false, // Default to false, will be set appropriately later
-			}
-			if m.Platform.Architecture == arm64 && m.Platform.Variant == "v8" {
-				// some scanners may not add v8 to arm64 reports, so we
-				// need to remove it here to maintain consistency
-				patchPlatform.Variant = ""
-			}
-			platforms = append(platforms, patchPlatform)
-		}
-		return platforms, nil
+		return platformsFromIndexManifest(manifest), nil
 	}
 
 	// For single-platform images, try to get the image config to extract platform information

--- a/pkg/buildkit/buildkit_test.go
+++ b/pkg/buildkit/buildkit_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -615,4 +616,27 @@ func TestOCIExporterAttrs(t *testing.T) {
 			assert.Equal(t, tc.wantForceCompression, hasForceCompression)
 		})
 	}
+}
+
+func TestPlatformsFromIndexManifest(t *testing.T) {
+	linux := func(arch, variant string) *v1.Platform {
+		return &v1.Platform{OS: "linux", Architecture: arch, Variant: variant}
+	}
+
+	manifest := &v1.IndexManifest{
+		Manifests: []v1.Descriptor{
+			{Platform: linux("amd64", "")},
+			{Platform: nil}, // e.g. attestation or provenance entry
+			{Platform: linux("arm64", "v8")},
+			{Platform: &v1.Platform{OS: "unknown", Architecture: "unknown"}},
+		},
+	}
+
+	got := platformsFromIndexManifest(manifest)
+
+	want := []types.PatchPlatform{
+		{Platform: ispec.Platform{OS: "linux", Architecture: "amd64"}},
+		{Platform: ispec.Platform{OS: "linux", Architecture: "arm64"}}, // v8 variant stripped
+	}
+	assert.Equal(t, want, got)
 }


### PR DESCRIPTION
Fix a nil pointer dereference in `DiscoverPlatformsFromReference` when an image index contains an entry with no platform field.

The branch that skips such entries still passed `m.Platform.OS` and `m.Platform.Architecture` to the log call, which Go evaluates before logging, so a nil platform was dereferenced and the process panicked. This splits the guard so the no-platform case is handled without touching `m.Platform`. Index entries without a platform (for example attestation or provenance entries) are legitimate, so any image with one triggered this.

Extract the index-to-platforms loop into `platformsFromIndexManifest` and add a unit test covering the nil-platform, unknown-platform, and arm64/v8 cases.

Closes #1645