### PR TITLE
fix: update Go to 1.25.13

### DIFF
--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -5,7 +5,7 @@
 # The release workflow passes this automatically via --build-arg
 # GO_VERSION=$(awk '/^go /{print $2; exit}' go.mod). This default is a fallback
 # for local builds and should match go.mod.
-ARG GO_VERSION=1.25.12
+ARG GO_VERSION=1.25.13
 ARG ALPINE_VERSION=3.23
 
 FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS builder

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/project-copacetic/copacetic
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
Update the Go toolchain from 1.25.12 to 1.25.13 in `go.mod` and the frontend builder fallback. This picks up the standard-library security fixes required by the blocking `govulncheck` workflow.

Verification:
- `GOTOOLCHAIN=go1.25.13 go run golang.org/x/vuln/cmd/govulncheck@latest ./...`
- `GOTOOLCHAIN=go1.25.13 make test`
- `GOTOOLCHAIN=go1.25.13 make build`

Related failure: https://github.com/project-copacetic/copacetic/actions/runs/32132779317/job/95697360127?pr=1547
