### PR TITLE
fix(langmgr): append +incompatible suffix for pre-module major>=2 Go deps

### DIFF
--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -13,6 +13,7 @@ import (
 	"github.com/project-copacetic/copacetic/pkg/types/unversioned"
 	"github.com/project-copacetic/copacetic/pkg/utils"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
 )
 
@@ -174,6 +175,30 @@ func cleanGoVersion(version string) string {
 	}
 
 	return ""
+}
+
+// appendIncompatibleIfNeeded adds the "+incompatible" build tag that `go get`
+// requires for pre-modules dependencies released at major version 2 or higher
+// whose module path carries no /vN suffix (github.com/docker/docker@v28.0.0,
+// for example). Scanner reports commonly omit the tag and `go get` rejects the
+// bare version outright.
+func appendIncompatibleIfNeeded(modulePath, version string) string {
+	if !semver.IsValid(version) || strings.HasSuffix(version, "+incompatible") {
+		return version
+	}
+
+	switch semver.Major(version) {
+	case "v0", "v1":
+		return version
+	}
+
+	// A path major suffix (/v2, /v3, ...) means the dependency is modules-aware,
+	// so the version is used as-is.
+	if _, pathMajor, ok := module.SplitPathVersion(modulePath); !ok || pathMajor != "" {
+		return version
+	}
+
+	return version + "+incompatible"
 }
 
 // buildGoUpdateCmd assembles the shell command run inside the build container
@@ -942,6 +967,7 @@ func (gm *golangManager) updateGoModule(
 			if !strings.HasPrefix(version, "v") {
 				version = "v" + version
 			}
+			version = appendIncompatibleIfNeeded(u.Name, version)
 			spec := fmt.Sprintf("%s@%s", u.Name, version)
 			getCommands = append(getCommands, fmt.Sprintf("go get %s", spec))
 		} else {
@@ -1069,6 +1095,7 @@ func (gm *golangManager) upgradePackagesWithTooling(
 				if !strings.HasPrefix(version, "v") {
 					version = "v" + version
 				}
+				version = appendIncompatibleIfNeeded(u.Name, version)
 				spec := fmt.Sprintf("%s@%s", u.Name, version)
 				getCommands = append(getCommands, fmt.Sprintf("go get %s", spec))
 			}

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -181,9 +181,11 @@ func cleanGoVersion(version string) string {
 // requires for pre-modules dependencies released at major version 2 or higher
 // whose module path carries no /vN suffix (github.com/docker/docker@v28.0.0,
 // for example). Scanner reports commonly omit the tag and `go get` rejects the
-// bare version outright.
+// bare version outright. Versions that already carry build metadata are left
+// alone: semver allows a single '+' component, so appending here would produce
+// an invalid version such as v2.0.0+build1+incompatible.
 func appendIncompatibleIfNeeded(modulePath, version string) string {
-	if !semver.IsValid(version) || strings.HasSuffix(version, "+incompatible") {
+	if !semver.IsValid(version) || strings.Contains(version, "+") {
 		return version
 	}
 
@@ -665,6 +667,36 @@ func buildSyntheticBinaryInfo(binaryPaths []string, goVCSURL string, goVersion s
 	return binaries
 }
 
+// buildBinaryUpdateMap collects the module requirements shared across every
+// binary rebuilt from an image. Versions are normalized the same way the
+// in-image `go get` path normalizes them: a missing 'v' prefix is added and
+// pre-modules major>=2 dependencies gain the +incompatible build tag, since the
+// rebuild writes these values straight into go.mod requirements.
+func buildBinaryUpdateMap(updates unversioned.LangUpdatePackages) map[string]string {
+	updateMap := make(map[string]string)
+	log.Debugf("[updateMap] building from %d updates", len(updates))
+	for _, update := range updates {
+		if update.FixedVersion == "" {
+			log.Debugf("Skipping %s: no fixed version available", update.Name)
+			continue
+		}
+
+		// k8s.io/kubernetes has hundreds of replace directives and requires
+		// careful version coordination - skip for now
+		if strings.HasPrefix(update.Name, "k8s.io/kubernetes") {
+			log.Warnf("Skipping %s: k8s.io/kubernetes requires careful version coordination", update.Name)
+			continue
+		}
+
+		version := update.FixedVersion
+		if !strings.HasPrefix(version, "v") {
+			version = "v" + version
+		}
+		updateMap[update.Name] = appendIncompatibleIfNeeded(update.Name, version)
+	}
+	return updateMap
+}
+
 // attemptBinaryRebuild attempts to rebuild Go binaries using heuristic binary detection.
 // When stdlibFixedVersion is set, only binaries built with a Go version older than
 // that version are rebuilt for stdlib fixes. Binaries already on a new enough Go
@@ -721,24 +753,7 @@ func (gm *golangManager) attemptBinaryRebuild(
 		}
 	}
 
-	// Build update map from updates (shared across all binaries)
-	updateMap := make(map[string]string)
-	log.Debugf("[updateMap] building from %d updates", len(updates))
-	for _, update := range updates {
-		if update.FixedVersion == "" {
-			log.Debugf("Skipping %s: no fixed version available", update.Name)
-			continue
-		}
-
-		// k8s.io/kubernetes has hundreds of replace directives and requires
-		// careful version coordination - skip for now
-		if strings.HasPrefix(update.Name, "k8s.io/kubernetes") {
-			log.Warnf("Skipping %s: k8s.io/kubernetes requires careful version coordination", update.Name)
-			continue
-		}
-
-		updateMap[update.Name] = update.FixedVersion
-	}
+	updateMap := buildBinaryUpdateMap(updates)
 
 	if len(updateMap) == 0 && stdlibFixedVersion == "" {
 		return currentState, failedPackages, fmt.Errorf("no version updates to apply")

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -1062,3 +1062,88 @@ func TestGolangManagerInstallUpdatesSkipsNonNewerVersion(t *testing.T) {
 		"downgrade-skipped packages must be reported as unpatched so they stay out of validated updates")
 	assert.Same(t, currentState, state)
 }
+
+func TestAppendIncompatibleIfNeeded(t *testing.T) {
+	tests := []struct {
+		name       string
+		modulePath string
+		version    string
+		expected   string
+	}{
+		{
+			name:       "pre-module major v2+ without path suffix",
+			modulePath: "github.com/docker/docker",
+			version:    "v28.0.0",
+			expected:   "v28.0.0+incompatible",
+		},
+		{
+			name:       "module path with matching major suffix",
+			modulePath: "github.com/foo/bar/v2",
+			version:    "v2.1.0",
+			expected:   "v2.1.0",
+		},
+		{
+			name:       "major v0",
+			modulePath: "github.com/foo/bar",
+			version:    "v0.9.1",
+			expected:   "v0.9.1",
+		},
+		{
+			name:       "major v1",
+			modulePath: "github.com/foo/bar",
+			version:    "v1.2.3",
+			expected:   "v1.2.3",
+		},
+		{
+			name:       "already suffixed",
+			modulePath: "github.com/docker/docker",
+			version:    "v28.0.0+incompatible",
+			expected:   "v28.0.0+incompatible",
+		},
+		{
+			name:       "pseudo-version at v0",
+			modulePath: "github.com/foo/bar",
+			version:    "v0.0.0-20230101120000-abcdef123456",
+			expected:   "v0.0.0-20230101120000-abcdef123456",
+		},
+		{
+			name:       "pseudo-version at major v2 without path suffix",
+			modulePath: "github.com/foo/bar",
+			version:    "v2.0.1-0.20230101120000-abcdef123456",
+			expected:   "v2.0.1-0.20230101120000-abcdef123456+incompatible",
+		},
+		{
+			name:       "pseudo-version at major v2 with path suffix",
+			modulePath: "github.com/foo/bar/v2",
+			version:    "v2.0.1-0.20230101120000-abcdef123456",
+			expected:   "v2.0.1-0.20230101120000-abcdef123456",
+		},
+		{
+			name:       "invalid version left unchanged",
+			modulePath: "github.com/foo/bar",
+			version:    "not-a-version",
+			expected:   "not-a-version",
+		},
+		{
+			name:       "empty version left unchanged",
+			modulePath: "github.com/foo/bar",
+			version:    "",
+			expected:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := appendIncompatibleIfNeeded(tt.modulePath, tt.version)
+			assert.Equal(t, tt.expected, result, "Module: %s, version: %s", tt.modulePath, tt.version)
+		})
+	}
+}
+
+// TestIncompatibleVersionsPassValidation ensures the +incompatible build tag
+// survives the existing version validation and cleaning paths.
+func TestIncompatibleVersionsPassValidation(t *testing.T) {
+	assert.True(t, isValidGoVersion("v28.0.0+incompatible"))
+	assert.NoError(t, validateGoVersion("v28.0.0+incompatible"))
+	assert.Equal(t, "v28.0.0+incompatible", cleanGoVersion("v28.0.0+incompatible"))
+}

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -1130,6 +1130,14 @@ func TestAppendIncompatibleIfNeeded(t *testing.T) {
 			version:    "",
 			expected:   "",
 		},
+		{
+			// A version that already carries build metadata must not gain a
+			// second '+' component, which would be invalid semver.
+			name:       "existing build metadata left unchanged",
+			modulePath: "github.com/foo/bar",
+			version:    "v2.0.0+build1",
+			expected:   "v2.0.0+build1",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1146,4 +1154,31 @@ func TestIncompatibleVersionsPassValidation(t *testing.T) {
 	assert.True(t, isValidGoVersion("v28.0.0+incompatible"))
 	assert.NoError(t, validateGoVersion("v28.0.0+incompatible"))
 	assert.Equal(t, "v28.0.0+incompatible", cleanGoVersion("v28.0.0+incompatible"))
+}
+
+// TestBuildBinaryUpdateMap asserts that the binary-rebuild path normalizes the
+// versions it records as module requirements: a missing 'v' prefix is added and
+// pre-module major>=2 dependencies gain the +incompatible build tag, matching
+// the `go get` spec construction used by the in-image module path.
+func TestBuildBinaryUpdateMap(t *testing.T) {
+	updates := unversioned.LangUpdatePackages{
+		{Name: "github.com/docker/docker", FixedVersion: "v28.0.0"},
+		{Name: "github.com/moby/moby", FixedVersion: "28.0.0"},
+		{Name: "github.com/foo/bar/v2", FixedVersion: "v2.1.0"},
+		{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+		{Name: "github.com/already/tagged", FixedVersion: "v3.1.0+incompatible"},
+		{Name: "github.com/no/fix", FixedVersion: ""},
+		{Name: "k8s.io/kubernetes", FixedVersion: "v1.30.0"},
+	}
+
+	got := buildBinaryUpdateMap(updates)
+
+	want := map[string]string{
+		"github.com/docker/docker":  "v28.0.0+incompatible",
+		"github.com/moby/moby":      "v28.0.0+incompatible",
+		"github.com/foo/bar/v2":     "v2.1.0",
+		"golang.org/x/net":          "v0.23.0",
+		"github.com/already/tagged": "v3.1.0+incompatible",
+	}
+	assert.Equal(t, want, got)
 }


### PR DESCRIPTION
## Problem

`go get` fails outright when patching a pre-modules-era Go dependency released at major version 2 or higher whose module path carries no `/vN` suffix. The canonical case is `github.com/docker/docker@v28.x`: the module path is not modules-aware, so the Go toolchain only accepts the version with the `+incompatible` build tag. Scanner reports routinely report the bare version (`v28.0.0`), and the patch run dies on the `go get` step.

## Root cause

`pkg/langmgr/golang.go` builds the `go get` spec string verbatim from the report's fixed version in two places, `updateGoModule` and `upgradePackagesWithTooling`. Both only normalize the `v` prefix, so a bare `v28.0.0` is passed through unchanged.

## Fix

New helper `appendIncompatibleIfNeeded(modulePath, version)` applied at both spec construction sites, right after the `v`-prefix normalization. It appends `+incompatible` only when all of the following hold:

- the version is valid semver (non-semver input is returned untouched)
- it is not already suffixed
- the major is not v0 or v1
- `module.SplitPathVersion` reports no path major suffix, meaning the dependency is not modules-aware

Everything else is returned unchanged, so `/v2`-style modules, v0/v1 deps, and pseudo-versions below v2 keep their current behavior.

## Tests

- `TestAppendIncompatibleIfNeeded`: table-driven coverage for `github.com/docker/docker@v28.0.0`, `/v2` path suffix, v0 and v1 majors, already-suffixed input, pseudo-versions at v0 and at v2 with and without a path suffix, and invalid/empty version input.
- `TestIncompatibleVersionsPassValidation`: confirms `isValidGoVersion`, `validateGoVersion`, and `cleanGoVersion` all accept a `+incompatible` version (semver treats it as build metadata, and `+` is not in the shell-unsafe character set).

`go build ./...`, `go test ./pkg/langmgr`, and `gofumpt` all pass; `make lint` reports only pre-existing findings unrelated to this change.