### PR TITLE
fix(langmgr): skip Go updates where fixed version is not newer than installed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/docker/buildx v0.32.1
 	github.com/docker/cli v29.5.3+incompatible
 	github.com/docker/docker v28.5.2+incompatible
-	github.com/docker/go-connections v0.7.0
 	github.com/google/go-containerregistry v0.21.6
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/klauspost/compress v1.18.7
@@ -71,6 +70,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/docker-credential-helpers v0.9.8 // indirect
+	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect

--- a/integration/bulk/singlearch_patch_test.go
+++ b/integration/bulk/singlearch_patch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/go-connections/nat"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -133,10 +134,10 @@ func startLocalRegistry(ctx context.Context) (testcontainers.Container, string, 
 			"REGISTRY_STORAGE_DELETE_ENABLED": "true",
 		},
 		HostConfigModifier: func(hostConfig *container.HostConfig) {
-			hostConfig.PortBindings = nat.PortMap{
-				"5000/tcp": []nat.PortBinding{
+			hostConfig.PortBindings = network.PortMap{
+				network.MustParsePort("5000/tcp"): []network.PortBinding{
 					{
-						HostIP:   "127.0.0.1",
+						HostIP:   netip.MustParseAddr("127.0.0.1"),
 						HostPort: fixedPort,
 					},
 				},

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -128,6 +128,24 @@ func isLessThanGoVersion(v1, v2 string) bool {
 	return semver.Compare(v1, v2) < 0
 }
 
+// filterGoDowngrades drops updates whose reported fixed version is not newer than
+// the installed version. A stale advisory would otherwise downgrade a module that
+// has already been patched. Updates with missing or unparsable versions are kept
+// so that existing behavior is unchanged.
+func filterGoDowngrades(updates unversioned.LangUpdatePackages) unversioned.LangUpdatePackages {
+	filtered := make(unversioned.LangUpdatePackages, 0, len(updates))
+	for _, u := range updates {
+		if u.InstalledVersion != "" && u.FixedVersion != "" &&
+			isValidGoVersion(u.InstalledVersion) && isValidGoVersion(u.FixedVersion) &&
+			!isLessThanGoVersion(u.InstalledVersion, u.FixedVersion) {
+			log.Warnf("Skipping Go module %s: installed version %s is not older than fixed version %s", u.Name, u.InstalledVersion, u.FixedVersion)
+			continue
+		}
+		filtered = append(filtered, u)
+	}
+	return filtered
+}
+
 // cleanGoVersion extracts the first valid version from a comma-separated list.
 // This handles cases where Trivy returns multiple versions.
 func cleanGoVersion(version string) string {
@@ -282,6 +300,12 @@ func (gm *golangManager) InstallUpdates(
 				continue
 			}
 		}
+	}
+
+	updatesToAttempt = filterGoDowngrades(updatesToAttempt)
+	if len(updatesToAttempt) == 0 && !hasStdlib {
+		log.Warn("No Go update packages remain to apply after filtering out non-newer fixed versions.")
+		return currentState, errPkgsReported, nil
 	}
 
 	// Perform the upgrade

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -131,19 +131,24 @@ func isLessThanGoVersion(v1, v2 string) bool {
 // filterGoDowngrades drops updates whose reported fixed version is not newer than
 // the installed version. A stale advisory would otherwise downgrade a module that
 // has already been patched. Updates with missing or unparsable versions are kept
-// so that existing behavior is unchanged.
-func filterGoDowngrades(updates unversioned.LangUpdatePackages) unversioned.LangUpdatePackages {
+// so that existing behavior is unchanged. The names of the skipped updates are
+// returned so callers can report them as unpatched: the image is left unchanged
+// for those modules, so they must not end up in the validated updates that feed
+// the VEX document.
+func filterGoDowngrades(updates unversioned.LangUpdatePackages) (unversioned.LangUpdatePackages, []string) {
 	filtered := make(unversioned.LangUpdatePackages, 0, len(updates))
+	var skipped []string
 	for _, u := range updates {
 		if u.InstalledVersion != "" && u.FixedVersion != "" &&
 			isValidGoVersion(u.InstalledVersion) && isValidGoVersion(u.FixedVersion) &&
 			!isLessThanGoVersion(u.InstalledVersion, u.FixedVersion) {
 			log.Warnf("Skipping Go module %s: installed version %s is not older than fixed version %s", u.Name, u.InstalledVersion, u.FixedVersion)
+			skipped = append(skipped, u.Name)
 			continue
 		}
 		filtered = append(filtered, u)
 	}
-	return filtered
+	return filtered, skipped
 }
 
 // cleanGoVersion extracts the first valid version from a comma-separated list.
@@ -302,7 +307,10 @@ func (gm *golangManager) InstallUpdates(
 		}
 	}
 
-	updatesToAttempt = filterGoDowngrades(updatesToAttempt)
+	updatesToAttempt, skippedDowngrades := filterGoDowngrades(updatesToAttempt)
+	// Skipped downgrades leave the module untouched in the image, so report them
+	// as unpatched to keep them out of the validated updates used for VEX.
+	errPkgsReported = append(errPkgsReported, skippedDowngrades...)
 	if len(updatesToAttempt) == 0 && !hasStdlib {
 		log.Warn("No Go update packages remain to apply after filtering out non-newer fixed versions.")
 		return currentState, errPkgsReported, nil

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -1029,3 +1029,25 @@ func TestFilterGoDowngrades(t *testing.T) {
 		})
 	}
 }
+
+func TestGolangManagerInstallUpdatesSkipsNonNewerVersion(t *testing.T) {
+	config := &buildkit.Config{}
+	currentState := &config.ImageState
+	manager := &golangManager{}
+	manifest := &unversioned.UpdateManifest{
+		LangUpdates: unversioned.LangUpdatePackages{
+			{
+				Name:             "github.com/gin-gonic/gin",
+				InstalledVersion: "v1.9.1",
+				FixedVersion:     "v1.7.7",
+				Type:             utils.GoModules,
+			},
+		},
+	}
+
+	state, errPkgs, err := manager.InstallUpdates(t.Context(), currentState, manifest, false)
+
+	require.NoError(t, err)
+	assert.Empty(t, errPkgs)
+	assert.Same(t, currentState, state)
+}

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -943,3 +943,89 @@ func TestBuildGoUpdateCmd(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterGoDowngrades(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         unversioned.LangUpdatePackages
+		expectedNames []string
+	}{
+		{
+			name: "fixed version older than installed - skipped",
+			input: unversioned.LangUpdatePackages{
+				{Name: "github.com/gin-gonic/gin", InstalledVersion: "v1.9.1", FixedVersion: "v1.7.7", Type: utils.GoModules},
+			},
+			expectedNames: []string{},
+		},
+		{
+			name: "fixed version equal to installed - skipped",
+			input: unversioned.LangUpdatePackages{
+				{Name: "github.com/gin-gonic/gin", InstalledVersion: "v1.7.7", FixedVersion: "v1.7.7", Type: utils.GoModules},
+			},
+			expectedNames: []string{},
+		},
+		{
+			name: "fixed version newer than installed - kept",
+			input: unversioned.LangUpdatePackages{
+				{Name: "github.com/gin-gonic/gin", InstalledVersion: "v1.7.0", FixedVersion: "v1.7.7", Type: utils.GoModules},
+			},
+			expectedNames: []string{"github.com/gin-gonic/gin"},
+		},
+		{
+			name: "versions without v prefix are normalized",
+			input: unversioned.LangUpdatePackages{
+				{Name: "github.com/gin-gonic/gin", InstalledVersion: "1.9.1", FixedVersion: "1.7.7", Type: utils.GoModules},
+				{Name: "golang.org/x/net", InstalledVersion: "0.4.0", FixedVersion: "0.5.0", Type: utils.GoModules},
+			},
+			expectedNames: []string{"golang.org/x/net"},
+		},
+		{
+			name: "empty installed version - kept",
+			input: unversioned.LangUpdatePackages{
+				{Name: "github.com/gin-gonic/gin", InstalledVersion: "", FixedVersion: "v1.7.7", Type: utils.GoModules},
+			},
+			expectedNames: []string{"github.com/gin-gonic/gin"},
+		},
+		{
+			name: "empty fixed version - kept",
+			input: unversioned.LangUpdatePackages{
+				{Name: "github.com/gin-gonic/gin", InstalledVersion: "v1.9.1", FixedVersion: "", Type: utils.GoModules},
+			},
+			expectedNames: []string{"github.com/gin-gonic/gin"},
+		},
+		{
+			name: "unparsable installed version - kept",
+			input: unversioned.LangUpdatePackages{
+				{Name: "github.com/gin-gonic/gin", InstalledVersion: "not-a-version", FixedVersion: "v1.7.7", Type: utils.GoModules},
+			},
+			expectedNames: []string{"github.com/gin-gonic/gin"},
+		},
+		{
+			name: "unparsable fixed version - kept",
+			input: unversioned.LangUpdatePackages{
+				{Name: "github.com/gin-gonic/gin", InstalledVersion: "v1.9.1", FixedVersion: "v1.7.7, v1.8.0", Type: utils.GoModules},
+			},
+			expectedNames: []string{"github.com/gin-gonic/gin"},
+		},
+		{
+			name: "mixed packages - only downgrades removed",
+			input: unversioned.LangUpdatePackages{
+				{Name: "github.com/gin-gonic/gin", InstalledVersion: "v1.9.1", FixedVersion: "v1.7.7", Type: utils.GoModules},
+				{Name: "golang.org/x/net", InstalledVersion: "v0.4.0", FixedVersion: "v0.5.0", Type: utils.GoModules},
+				{Name: "golang.org/x/text", InstalledVersion: "v0.3.8", FixedVersion: "v0.3.8", Type: utils.GoModules},
+			},
+			expectedNames: []string{"golang.org/x/net"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterGoDowngrades(tt.input)
+			names := make([]string, 0, len(result))
+			for _, pkg := range result {
+				names = append(names, pkg.Name)
+			}
+			assert.Equal(t, tt.expectedNames, names)
+		})
+	}
+}

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -946,23 +946,26 @@ func TestBuildGoUpdateCmd(t *testing.T) {
 
 func TestFilterGoDowngrades(t *testing.T) {
 	tests := []struct {
-		name          string
-		input         unversioned.LangUpdatePackages
-		expectedNames []string
+		name            string
+		input           unversioned.LangUpdatePackages
+		expectedNames   []string
+		expectedSkipped []string
 	}{
 		{
 			name: "fixed version older than installed - skipped",
 			input: unversioned.LangUpdatePackages{
 				{Name: "github.com/gin-gonic/gin", InstalledVersion: "v1.9.1", FixedVersion: "v1.7.7", Type: utils.GoModules},
 			},
-			expectedNames: []string{},
+			expectedNames:   []string{},
+			expectedSkipped: []string{"github.com/gin-gonic/gin"},
 		},
 		{
 			name: "fixed version equal to installed - skipped",
 			input: unversioned.LangUpdatePackages{
 				{Name: "github.com/gin-gonic/gin", InstalledVersion: "v1.7.7", FixedVersion: "v1.7.7", Type: utils.GoModules},
 			},
-			expectedNames: []string{},
+			expectedNames:   []string{},
+			expectedSkipped: []string{"github.com/gin-gonic/gin"},
 		},
 		{
 			name: "fixed version newer than installed - kept",
@@ -977,7 +980,8 @@ func TestFilterGoDowngrades(t *testing.T) {
 				{Name: "github.com/gin-gonic/gin", InstalledVersion: "1.9.1", FixedVersion: "1.7.7", Type: utils.GoModules},
 				{Name: "golang.org/x/net", InstalledVersion: "0.4.0", FixedVersion: "0.5.0", Type: utils.GoModules},
 			},
-			expectedNames: []string{"golang.org/x/net"},
+			expectedNames:   []string{"golang.org/x/net"},
+			expectedSkipped: []string{"github.com/gin-gonic/gin"},
 		},
 		{
 			name: "empty installed version - kept",
@@ -1014,18 +1018,24 @@ func TestFilterGoDowngrades(t *testing.T) {
 				{Name: "golang.org/x/net", InstalledVersion: "v0.4.0", FixedVersion: "v0.5.0", Type: utils.GoModules},
 				{Name: "golang.org/x/text", InstalledVersion: "v0.3.8", FixedVersion: "v0.3.8", Type: utils.GoModules},
 			},
-			expectedNames: []string{"golang.org/x/net"},
+			expectedNames:   []string{"golang.org/x/net"},
+			expectedSkipped: []string{"github.com/gin-gonic/gin", "golang.org/x/text"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := filterGoDowngrades(tt.input)
+			result, skipped := filterGoDowngrades(tt.input)
 			names := make([]string, 0, len(result))
 			for _, pkg := range result {
 				names = append(names, pkg.Name)
 			}
 			assert.Equal(t, tt.expectedNames, names)
+			assert.Equal(t, tt.expectedSkipped, skipped)
+			for _, skippedName := range skipped {
+				assert.NotContains(t, names, skippedName,
+					"skipped downgrade must not appear in the updates that get applied")
+			}
 		})
 	}
 }
@@ -1048,6 +1058,7 @@ func TestGolangManagerInstallUpdatesSkipsNonNewerVersion(t *testing.T) {
 	state, errPkgs, err := manager.InstallUpdates(t.Context(), currentState, manifest, false)
 
 	require.NoError(t, err)
-	assert.Empty(t, errPkgs)
+	assert.Equal(t, []string{"github.com/gin-gonic/gin"}, errPkgs,
+		"downgrade-skipped packages must be reported as unpatched so they stay out of validated updates")
 	assert.Same(t, currentState, state)
 }


### PR DESCRIPTION
## Problem

The Go language manager can downgrade a dependency. When a scanner report carries a stale advisory, or the image has already been patched to a newer version, `copa` runs `go get pkg@version` with the reported fixed version even though the installed version is already newer or equal.

## Root cause

`GetUniqueLatestUpdates` (`pkg/langmgr/langmgr.go`) deduplicates update requests and picks the highest fixed version per module. It does not compare that version with `InstalledVersion`. `golangManager.InstallUpdates` (`pkg/langmgr/golang.go`) therefore applies the reported `FixedVersion` without checking whether it is newer.

## Fix

Add `filterGoDowngrades` after update deduplication and validation. It skips an update with a warning when both versions are present and valid Go semantic versions, and the installed version is greater than or equal to the fixed version.

Missing or unparsable versions retain the filter's previous pass-through behavior. If every module update is filtered and no standard-library update remains, `InstallUpdates` returns the current state without constructing an upgrade.

A skipped downgrade leaves the module untouched in the image, so `filterGoDowngrades` returns the skipped module names and `InstallUpdates` adds them to `errPkgsReported`. That keeps them out of the validated updates built in `pkg/patch`, so the VEX document does not claim the finding was remediated when nothing changed. Consistent with existing `errPkgsReported` entries, this reports the package as unpatched and is not fatal on its own.

## Test coverage

- `TestFilterGoDowngrades` covers older, equal, newer, unprefixed, missing, unparsable, and mixed version inputs, and asserts that every skipped module is returned as skipped and absent from the updates that get applied.
- `TestGolangManagerInstallUpdatesSkipsNonNewerVersion` covers the manager-level early return, verifying the current state is preserved and the skipped module is reported as unpatched.

## Note on the second commit

`fix(test): align bulk integration test with moby container types` is unrelated to the Go downgrade guard. It repairs a build break already present on `main`: after the testcontainers-go bump, `integration/bulk/singlearch_patch_test.go` no longer compiles against `docker/docker` container types, which fails both `lint` (typecheck) and `Test Bulk Patching`. It is a separate commit so it can be dropped or cherry-picked independently.

## Verification

- `go test ./pkg/langmgr ./pkg/patch -count=1`
- `go build ./...`
- `go vet ./integration/...`
- `gofumpt -l pkg/langmgr integration/bulk` (clean)
