### PR TITLE
fix(langmgr): verify go.mod reflects applied Go module updates

### DIFF
--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path"
 	"strings"
 
 	"github.com/moby/buildkit/client/llb"
@@ -218,8 +219,9 @@ func buildGoUpdateCmd(modPath, allGetCmd string) string {
 // the go.mod produced by the update step. `go mod tidy -e` removes requirements
 // for modules that are no longer imported by reachable code, so a successful
 // `go get` can be silently reverted and the package still reported as patched.
-// Applicable versioned replace directives override the old module's require
-// version and also count as an effective instance of their replacement target.
+// Only a replace directive whose left-hand side is the module under test can
+// change that module's effective version: versions of other module paths are
+// not comparable to the requested one.
 func verifyGoModUpdates(goModContent []byte, updates unversioned.LangUpdatePackages) error {
 	hasTargets := false
 	for _, u := range updates {
@@ -249,50 +251,109 @@ func verifyGoModUpdates(goModContent []byte, updates unversioned.LangUpdatePacka
 			continue
 		}
 
-		found := false
-		if requiredVersion, ok := required[u.Name]; ok {
-			found = true
-			landedVersion := requiredVersion
-			for _, rep := range f.Replace {
-				if rep == nil || rep.Old.Path != u.Name {
-					continue
-				}
-				if rep.Old.Version != "" && rep.Old.Version != requiredVersion {
-					continue
-				}
-				if rep.New.Version == "" {
-					return fmt.Errorf("module %s has local replacement %s; cannot verify requested version %s", u.Name, rep.New.Path, u.FixedVersion)
-				}
-				landedVersion = rep.New.Version
-				break
-			}
-			if isLessThanGoVersion(landedVersion, u.FixedVersion) {
-				return fmt.Errorf("module %s is at %s in go.mod after update, expected %s or newer", u.Name, landedVersion, u.FixedVersion)
-			}
-		}
-
-		// A module can also enter the build list as the target of a replacement
-		// for another required module.
-		for _, rep := range f.Replace {
-			if rep == nil || rep.Old.Path == u.Name || rep.New.Path != u.Name || rep.New.Version == "" {
-				continue
-			}
-			oldVersion, ok := required[rep.Old.Path]
-			if !ok || (rep.Old.Version != "" && rep.Old.Version != oldVersion) {
-				continue
-			}
-			found = true
-			if isLessThanGoVersion(rep.New.Version, u.FixedVersion) {
-				return fmt.Errorf("module %s is at %s in go.mod after update, expected %s or newer", u.Name, rep.New.Version, u.FixedVersion)
-			}
-		}
-
-		if !found {
+		requiredVersion, ok := required[u.Name]
+		if !ok {
 			return fmt.Errorf("module %s not found in go.mod after update; the requested version %s was not applied or was removed by 'go mod tidy'", u.Name, u.FixedVersion)
+		}
+
+		landedVersion := requiredVersion
+		if replacement := effectiveReplacementVersion(f.Replace, u.Name, requiredVersion); replacement != "" {
+			landedVersion = replacement
+		}
+		if isLessThanGoVersion(landedVersion, u.FixedVersion) {
+			return fmt.Errorf("module %s is at %s in go.mod after update, expected %s or newer", u.Name, landedVersion, u.FixedVersion)
 		}
 	}
 
 	return nil
+}
+
+// effectiveReplacementVersion returns the version that replace directives give
+// modPath at selectedVersion, or "" when no directive names a version for it.
+// Mirroring go.mod resolution, a directive pinned to the selected version wins
+// over a path-wide directive, and a filesystem replacement (which carries no
+// version) never overrides the require entry.
+func effectiveReplacementVersion(replacements []*modfile.Replace, modPath, selectedVersion string) string {
+	var pinned, pathWide string
+	for _, rep := range replacements {
+		if rep == nil || rep.Old.Path != modPath || rep.New.Version == "" {
+			continue
+		}
+		switch {
+		case rep.Old.Version == "":
+			if pathWide == "" {
+				pathWide = rep.New.Version
+			}
+		case rep.Old.Version == selectedVersion:
+			if pinned == "" {
+				pinned = rep.New.Version
+			}
+		}
+	}
+	if pinned != "" {
+		return pinned
+	}
+	return pathWide
+}
+
+// filterUpdatesInGoMod narrows updates to the modules the given go.mod already
+// referenced. The update step runs the same `go get` list against every module
+// in the image, so verifying all of them against one go.mod would fail modules
+// that never depended on the vulnerable package. Callers pass the module's
+// pre-update go.mod so that requirements dropped by the update are still
+// verified rather than silently excused.
+func filterUpdatesInGoMod(goModContent []byte, updates unversioned.LangUpdatePackages) (unversioned.LangUpdatePackages, error) {
+	f, err := modfile.Parse("go.mod", goModContent, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse go.mod: %w", err)
+	}
+
+	present := make(map[string]struct{}, len(f.Require)+len(f.Replace))
+	for _, r := range f.Require {
+		if r != nil && r.Mod.Path != "" {
+			present[r.Mod.Path] = struct{}{}
+		}
+	}
+	for _, rep := range f.Replace {
+		if rep != nil && rep.Old.Path != "" {
+			present[rep.Old.Path] = struct{}{}
+		}
+	}
+
+	var applicable unversioned.LangUpdatePackages
+	for _, u := range updates {
+		if _, ok := present[u.Name]; ok {
+			applicable = append(applicable, u)
+		}
+	}
+	return applicable, nil
+}
+
+// goWorkspaceMemberModPaths resolves the go.mod path of every module listed by a
+// go.work file, relative to the workspace root. A workspace root has no
+// authoritative go.mod of its own: requirements land in the member modules, so
+// those are the files to verify.
+func goWorkspaceMemberModPaths(goWorkContent []byte, workRoot string) ([]string, error) {
+	f, err := modfile.ParseWork("go.work", goWorkContent, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse go.work: %w", err)
+	}
+
+	var modPaths []string
+	for _, use := range f.Use {
+		if use == nil || use.Path == "" {
+			continue
+		}
+		dir := use.Path
+		if !path.IsAbs(dir) {
+			dir = path.Join(workRoot, dir)
+		}
+		modPaths = append(modPaths, path.Join(path.Clean(dir), "go.mod"))
+	}
+	if len(modPaths) == 0 {
+		return nil, fmt.Errorf("go.work at %s lists no module directories; cannot verify Go module updates", workRoot)
+	}
+	return modPaths, nil
 }
 
 // filterGoPackages filters for Go module and binary packages.
@@ -645,13 +706,14 @@ func (gm *golangManager) upgradePackages(
 	// If workspace exists, update from workspace root
 	if workspacePath != "" {
 		log.Debugf("Updating Go workspace at %s", workspacePath)
-		state, err = gm.updateGoModule(ctx, &state, workspacePath, updates, true, ignoreErrors)
+		var modFailedPkgs []string
+		state, modFailedPkgs, err = gm.updateGoModule(ctx, &state, workspacePath, updates, true, ignoreErrors)
 		if err != nil {
 			log.Errorf("Failed to update workspace: %v", err)
+			// Report the affected packages either way: with errors ignored they
+			// must still surface as unpatched instead of being claimed as fixed.
+			failedPackages = append(failedPackages, modFailedPkgs...)
 			if !ignoreErrors {
-				for _, u := range updates {
-					failedPackages = append(failedPackages, u.Name)
-				}
 				return currentState, failedPackages, err
 			}
 		}
@@ -659,13 +721,11 @@ func (gm *golangManager) upgradePackages(
 		// Update each module independently
 		for _, modPath := range goModPaths {
 			log.Debugf("Updating Go module at %s", modPath)
-			newState, modErr := gm.updateGoModule(ctx, &state, modPath, updates, false, ignoreErrors)
+			newState, modFailedPkgs, modErr := gm.updateGoModule(ctx, &state, modPath, updates, false, ignoreErrors)
 			if modErr != nil {
 				log.Errorf("Failed to update module at %s: %v", modPath, modErr)
+				failedPackages = append(failedPackages, modFailedPkgs...)
 				if !ignoreErrors {
-					for _, u := range updates {
-						failedPackages = append(failedPackages, u.Name)
-					}
 					return currentState, failedPackages, modErr
 				}
 				continue
@@ -1030,7 +1090,59 @@ func (gm *golangManager) attemptBinaryRebuild(
 	return state, failedPackages, nil
 }
 
-// updateGoModule updates a single Go module or workspace.
+// goVerifyTarget pairs a go.mod file with the subset of requested updates that
+// file is accountable for, captured before the update step mutates it.
+type goVerifyTarget struct {
+	goModPath string
+	updates   unversioned.LangUpdatePackages
+}
+
+// collectGoVerifyTargets records which go.mod files to verify after the update
+// and, for each, the updates it already referenced. For a workspace the go.work
+// root has no authoritative go.mod, so every member module is collected
+// instead. Reading the pre-update go.mod matters twice over: it scopes
+// verification to modules that actually depended on the vulnerable package, and
+// it still catches requirements that the update step dropped.
+func (gm *golangManager) collectGoVerifyTargets(
+	ctx context.Context,
+	state *llb.State,
+	modPath string,
+	isWorkspace bool,
+	updates unversioned.LangUpdatePackages,
+) ([]goVerifyTarget, error) {
+	goModPaths := []string{modPath + "/go.mod"}
+	if isWorkspace {
+		goWorkBytes, err := buildkit.ExtractFileFromState(ctx, gm.config.Client, state, modPath+"/go.work")
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s/go.work: %w", modPath, err)
+		}
+		goModPaths, err = goWorkspaceMemberModPaths(goWorkBytes, modPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	targets := make([]goVerifyTarget, 0, len(goModPaths))
+	for _, goModPath := range goModPaths {
+		goModBytes, err := buildkit.ExtractFileFromState(ctx, gm.config.Client, state, goModPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s before update: %w", goModPath, err)
+		}
+		applicable, err := filterUpdatesInGoMod(goModBytes, updates)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", goModPath, err)
+		}
+		if len(applicable) == 0 {
+			log.Debugf("No requested Go updates apply to %s, skipping verification", goModPath)
+			continue
+		}
+		targets = append(targets, goVerifyTarget{goModPath: goModPath, updates: applicable})
+	}
+	return targets, nil
+}
+
+// updateGoModule updates a single Go module or workspace. On failure it returns
+// the names of the packages left unpatched so callers can report them.
 func (gm *golangManager) updateGoModule(
 	ctx context.Context,
 	currentState *llb.State,
@@ -1038,12 +1150,12 @@ func (gm *golangManager) updateGoModule(
 	updates unversioned.LangUpdatePackages,
 	isWorkspace bool,
 	ignoreErrors bool,
-) (llb.State, error) {
+) (llb.State, []string, error) {
 	state := *currentState
 
 	// Validate modPath before shell interpolation (comes from target image filesystem)
 	if strings.ContainsAny(modPath, shellUnsafeChars) {
-		return state, fmt.Errorf("go.mod path contains unsafe characters: %s", modPath)
+		return state, getPackageNames(updates), fmt.Errorf("go.mod path contains unsafe characters: %s", modPath)
 	}
 
 	// Build list of 'go get' commands with input validation
@@ -1051,13 +1163,13 @@ func (gm *golangManager) updateGoModule(
 	for _, u := range updates {
 		if u.FixedVersion != "" {
 			if strings.ContainsAny(u.Name, shellUnsafeChars) {
-				return state, fmt.Errorf("package name contains unsafe characters: %s", u.Name)
+				return state, getPackageNames(updates), fmt.Errorf("package name contains unsafe characters: %s", u.Name)
 			}
 			if strings.HasPrefix(u.Name, "-") {
-				return state, fmt.Errorf("package name cannot start with '-': %s", u.Name)
+				return state, getPackageNames(updates), fmt.Errorf("package name cannot start with '-': %s", u.Name)
 			}
 			if strings.ContainsAny(u.FixedVersion, shellUnsafeChars) {
-				return state, fmt.Errorf("version contains unsafe characters: %s for package %s", u.FixedVersion, u.Name)
+				return state, getPackageNames(updates), fmt.Errorf("version contains unsafe characters: %s for package %s", u.FixedVersion, u.Name)
 			}
 			// Ensure version has 'v' prefix
 			version := u.FixedVersion
@@ -1074,7 +1186,13 @@ func (gm *golangManager) updateGoModule(
 
 	if len(getCommands) == 0 {
 		log.Debug("No package updates to apply")
-		return state, nil
+		return state, nil, nil
+	}
+
+	// Record what to verify while the pre-update go.mod files are still intact.
+	verifyTargets, err := gm.collectGoVerifyTargets(ctx, &state, modPath, isWorkspace, updates)
+	if err != nil {
+		return state, getPackageNames(updates), err
 	}
 
 	// Execute all 'go get' commands
@@ -1095,15 +1213,14 @@ func (gm *golangManager) updateGoModule(
 	).Root()
 
 	// Confirm the bumps survived 'go mod tidy -e' instead of trusting the exit
-	// code. Skipped for workspaces: the go.work root has no authoritative
-	// go.mod, since requirements land in the member modules.
-	if !isWorkspace {
-		goModBytes, err := buildkit.ExtractFileFromState(ctx, gm.config.Client, &state, modPath+"/go.mod")
-		if err != nil {
-			return state, fmt.Errorf("failed to read %s/go.mod after update: %w", modPath, err)
+	// code.
+	for _, target := range verifyTargets {
+		goModBytes, extractErr := buildkit.ExtractFileFromState(ctx, gm.config.Client, &state, target.goModPath)
+		if extractErr != nil {
+			return state, getPackageNames(target.updates), fmt.Errorf("failed to read %s after update: %w", target.goModPath, extractErr)
 		}
-		if err := verifyGoModUpdates(goModBytes, updates); err != nil {
-			return state, err
+		if verifyErr := verifyGoModUpdates(goModBytes, target.updates); verifyErr != nil {
+			return state, getPackageNames(target.updates), fmt.Errorf("go module update verification failed for %s: %w", target.goModPath, verifyErr)
 		}
 	}
 
@@ -1128,7 +1245,7 @@ func (gm *golangManager) updateGoModule(
 
 	log.Warn("Note: Go binaries are not automatically rebuilt. Updated go.mod/go.sum only.")
 
-	return state, nil
+	return state, nil, nil
 }
 
 // upgradePackagesWithTooling handles Go module updates when the Go toolchain is not in the target image.
@@ -1215,6 +1332,19 @@ func (gm *golangManager) upgradePackagesWithTooling(
 			continue
 		}
 
+		// Record which updates this module is accountable for while its
+		// pre-update go.mod is still intact. The same `go get` list runs against
+		// every module in the image, so verifying all of them here would fail a
+		// module that never depended on the vulnerable package.
+		originalGoMod, origErr := buildkit.ExtractFileFromState(ctx, gm.config.Client, &state, modPath+"/go.mod")
+		if origErr != nil {
+			return currentState, getPackageNames(updates), fmt.Errorf("failed to read %s/go.mod before update: %w", modPath, origErr)
+		}
+		moduleUpdates, filterErr := filterUpdatesInGoMod(originalGoMod, updates)
+		if filterErr != nil {
+			return currentState, getPackageNames(updates), fmt.Errorf("%s/go.mod: %w", modPath, filterErr)
+		}
+
 		allGetCmd := strings.Join(getCommands, " && ")
 		// -e tolerates broken upstream go.mod files; see comment in the
 		// primary updateCmd above.
@@ -1227,13 +1357,17 @@ func (gm *golangManager) upgradePackagesWithTooling(
 			llb.WithProxy(utils.GetProxy()),
 		).Root()
 
-		// Confirm the bumps survived 'go mod tidy -e' instead of trusting the exit code.
-		goModBytes, extractErr := buildkit.ExtractFileFromState(ctx, gm.config.Client, &toolingState, "/workspace/go.mod")
-		if extractErr != nil {
-			return currentState, nil, fmt.Errorf("failed to read go.mod after update at %s: %w", modPath, extractErr)
-		}
-		if verifyErr := verifyGoModUpdates(goModBytes, updates); verifyErr != nil {
-			return currentState, nil, fmt.Errorf("go module update verification failed at %s: %w", modPath, verifyErr)
+		// Confirm the bumps survived 'go mod tidy -e' instead of trusting the
+		// exit code. Failures name the affected packages so they are reported as
+		// unpatched rather than claimed as remediated.
+		if len(moduleUpdates) > 0 {
+			goModBytes, extractErr := buildkit.ExtractFileFromState(ctx, gm.config.Client, &toolingState, "/workspace/go.mod")
+			if extractErr != nil {
+				return currentState, getPackageNames(moduleUpdates), fmt.Errorf("failed to read go.mod after update at %s: %w", modPath, extractErr)
+			}
+			if verifyErr := verifyGoModUpdates(goModBytes, moduleUpdates); verifyErr != nil {
+				return currentState, getPackageNames(moduleUpdates), fmt.Errorf("go module update verification failed at %s: %w", modPath, verifyErr)
+			}
 		}
 
 		// Check if vendor exists in original and update if so

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -222,10 +222,13 @@ func buildGoUpdateCmd(modPath, allGetCmd string) string {
 // successful `go get` can be silently reverted and the package still reported as
 // patched. Modules before go 1.17 record only direct requirements in go.mod, so
 // an indirect dependency falls back to the version go.sum says the build
-// downloads. A replacement that hides the module behind unversioned local
-// contents or a different module path leaves the requested version unprovable
-// and is reported as a failure rather than assumed patched.
-func verifyGoModUpdates(goModContent, goSumContent []byte, updates unversioned.LangUpdatePackages) error {
+// downloads. workReplaces carries the replace directives of the go.work file
+// governing this module, if any: a workspace replacement overrides the member
+// module's own metadata, so it decides what the build compiles. A replacement
+// that hides the module behind unversioned local contents or a different module
+// path leaves the requested version unprovable and is reported as a failure
+// rather than assumed patched.
+func verifyGoModUpdates(goModContent, goSumContent []byte, workReplaces []*modfile.Replace, updates unversioned.LangUpdatePackages) error {
 	hasTargets := false
 	for _, u := range updates {
 		if u.FixedVersion != "" {
@@ -256,6 +259,16 @@ func verifyGoModUpdates(goModContent, goSumContent []byte, updates unversioned.L
 		}
 
 		requiredVersion, inGoMod := required[u.Name]
+
+		// A go.work replace overrides every member module, so it governs what
+		// the workspace build compiles no matter what the member's go.mod says.
+		if rep := governingReplacement(workReplaces, u.Name, requiredVersion); rep != nil {
+			if err := verifyReplacementVersion(rep, "go.work", u.Name, u.FixedVersion); err != nil {
+				return err
+			}
+			continue
+		}
+
 		if !inGoMod {
 			if err := verifyGoSumVersions(builtVersions[u.Name], u.Name, u.FixedVersion); err != nil {
 				return err
@@ -263,21 +276,34 @@ func verifyGoModUpdates(goModContent, goSumContent []byte, updates unversioned.L
 			continue
 		}
 
-		landedVersion := requiredVersion
 		if rep := governingReplacement(f.Replace, u.Name, requiredVersion); rep != nil {
-			switch {
-			case rep.New.Version == "":
-				return fmt.Errorf("module %s is replaced by %s, whose contents are unversioned; cannot verify that requested version %s was applied", u.Name, rep.New.Path, u.FixedVersion)
-			case rep.New.Path != u.Name:
-				return fmt.Errorf("module %s is replaced by %s@%s; a different module path cannot prove that requested version %s was applied", u.Name, rep.New.Path, rep.New.Version, u.FixedVersion)
+			if err := verifyReplacementVersion(rep, "go.mod", u.Name, u.FixedVersion); err != nil {
+				return err
 			}
-			landedVersion = rep.New.Version
+			continue
 		}
-		if isLessThanGoVersion(landedVersion, u.FixedVersion) {
-			return fmt.Errorf("module %s is at %s in go.mod after update, expected %s or newer", u.Name, landedVersion, u.FixedVersion)
+		if isLessThanGoVersion(requiredVersion, u.FixedVersion) {
+			return fmt.Errorf("module %s is at %s in go.mod after update, expected %s or newer", u.Name, requiredVersion, u.FixedVersion)
 		}
 	}
 
+	return nil
+}
+
+// verifyReplacementVersion confirms that the code a replacement substitutes can
+// be shown to carry the fix. Unversioned local contents and a different module
+// path both leave the requested version unprovable, so they are reported as
+// failures instead of assumed patched. file names the file the directive came
+// from so the failure points at the metadata that has to change.
+func verifyReplacementVersion(rep *modfile.Replace, file, modPath, fixedVersion string) error {
+	switch {
+	case rep.New.Version == "":
+		return fmt.Errorf("module %s is replaced in %s by %s, whose contents are unversioned; cannot verify that requested version %s was applied", modPath, file, rep.New.Path, fixedVersion)
+	case rep.New.Path != modPath:
+		return fmt.Errorf("module %s is replaced in %s by %s@%s; a different module path cannot prove that requested version %s was applied", modPath, file, rep.New.Path, rep.New.Version, fixedVersion)
+	case isLessThanGoVersion(rep.New.Version, fixedVersion):
+		return fmt.Errorf("module %s is replaced in %s by %s@%s after update, expected %s or newer", modPath, file, rep.New.Path, rep.New.Version, fixedVersion)
+	}
 	return nil
 }
 
@@ -348,11 +374,11 @@ func goSumBuiltVersions(goSumContent []byte) map[string][]string {
 // filterUpdatesInGoMod narrows updates to the modules the given module already
 // referenced. The update step runs the same `go get` list against every module
 // in the image, so verifying all of them against one module would fail modules
-// that never depended on the vulnerable package. go.sum is consulted as well
-// because a module before go 1.17 keeps indirect dependencies out of go.mod, and
-// dropping those would leave them unverified while still reported as patched.
-// Callers pass the pre-update files so that requirements removed by the update
-// are still verified rather than silently excused.
+// that never depended on the vulnerable package. Modules before go 1.17 keep
+// indirect dependencies out of go.mod, so those fall back to go.sum: dropping
+// them would leave them unverified while still reported as patched. Callers pass
+// the pre-update files so that requirements removed by the update are still
+// verified rather than silently excused.
 func filterUpdatesInGoMod(goModContent, goSumContent []byte, updates unversioned.LangUpdatePackages) (unversioned.LangUpdatePackages, error) {
 	f, err := modfile.Parse("go.mod", goModContent, nil)
 	if err != nil {
@@ -370,8 +396,14 @@ func filterUpdatesInGoMod(goModContent, goSumContent []byte, updates unversioned
 			present[rep.Old.Path] = struct{}{}
 		}
 	}
-	for modPath := range goSumBuiltVersions(goSumContent) {
-		present[modPath] = struct{}{}
+	// From go 1.17 on go.mod records every dependency of the build, so a go.sum
+	// entry that go.mod never mentions is a stale checksum rather than a
+	// dependency. Counting it would demand a version bump from a module that
+	// does not use the package.
+	if !goModListsAllDependencies(f) {
+		for modPath := range goSumBuiltVersions(goSumContent) {
+			present[modPath] = struct{}{}
+		}
 	}
 
 	var applicable unversioned.LangUpdatePackages
@@ -383,14 +415,27 @@ func filterUpdatesInGoMod(goModContent, goSumContent []byte, updates unversioned
 	return applicable, nil
 }
 
-// unverifiedUpdateNames returns the names of every requested update that has not
-// been confirmed yet. A verification step that cannot finish must report all of
-// them, since an unproven package left out of the failure list is reported as
-// remediated.
-func unverifiedUpdateNames(updates unversioned.LangUpdatePackages, verified map[string]struct{}) []string {
+// goModListsAllDependencies reports whether the module's go directive selects
+// the module graph pruning added in go 1.17, from which go.mod records every
+// dependency of the build, direct and indirect. Before that only direct
+// requirements appear, leaving go.sum as the sole record of the rest.
+func goModListsAllDependencies(f *modfile.File) bool {
+	if f == nil || f.Go == nil || f.Go.Version == "" {
+		return false
+	}
+	return !isLessThanGoVersion(f.Go.Version, "1.17")
+}
+
+// unverifiedUpdateNames returns the names of every requested update that is not
+// proven yet. pendingProofs holds, per package, the number of modules
+// accountable for it that still have to be checked; a package missing from the
+// map was never observed in any module and is unproven as well. A verification
+// step that cannot finish must report all of them, since an unproven package
+// left out of the failure list is reported as remediated.
+func unverifiedUpdateNames(updates unversioned.LangUpdatePackages, pendingProofs map[string]int) []string {
 	names := make([]string, 0, len(updates))
 	for _, u := range updates {
-		if _, ok := verified[u.Name]; ok {
+		if remaining, tracked := pendingProofs[u.Name]; tracked && remaining <= 0 {
 			continue
 		}
 		names = append(names, u.Name)
@@ -398,17 +443,28 @@ func unverifiedUpdateNames(updates unversioned.LangUpdatePackages, verified map[
 	return names
 }
 
-// goWorkspaceMemberDirs resolves the directory of every module listed by a
-// go.work file, relative to the workspace root. A workspace root has no
-// authoritative go.mod of its own: requirements land in the member modules, so
-// those are the modules to verify.
-func goWorkspaceMemberDirs(goWorkContent []byte, workRoot string) ([]string, error) {
+// goWorkspace holds the parts of a go.work file that decide what a workspace
+// build compiles: the member modules and the replacements the workspace forces
+// on all of them.
+type goWorkspace struct {
+	memberDirs   []string
+	replacements []*modfile.Replace
+}
+
+// parseGoWorkspace resolves the directory of every module listed by a go.work
+// file, relative to the workspace root, along with the workspace-wide replace
+// directives. A workspace root has no authoritative go.mod of its own:
+// requirements land in the member modules, so those are the modules to verify.
+// The replacements travel with them because a go.work replace overrides the
+// member modules and decides which code the build uses, so a module redirected
+// there cannot be proven patched from a member's go.mod alone.
+func parseGoWorkspace(goWorkContent []byte, workRoot string) (*goWorkspace, error) {
 	f, err := modfile.ParseWork("go.work", goWorkContent, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse go.work: %w", err)
 	}
 
-	var modDirs []string
+	ws := &goWorkspace{replacements: f.Replace}
 	for _, use := range f.Use {
 		if use == nil || use.Path == "" {
 			continue
@@ -417,12 +473,12 @@ func goWorkspaceMemberDirs(goWorkContent []byte, workRoot string) ([]string, err
 		if !path.IsAbs(dir) {
 			dir = path.Join(workRoot, dir)
 		}
-		modDirs = append(modDirs, path.Clean(dir))
+		ws.memberDirs = append(ws.memberDirs, path.Clean(dir))
 	}
-	if len(modDirs) == 0 {
+	if len(ws.memberDirs) == 0 {
 		return nil, fmt.Errorf("go.work at %s lists no module directories; cannot verify Go module updates", workRoot)
 	}
-	return modDirs, nil
+	return ws, nil
 }
 
 // filterGoPackages filters for Go module and binary packages.
@@ -1161,11 +1217,13 @@ func (gm *golangManager) attemptBinaryRebuild(
 
 // goVerifyTarget pairs a module's metadata files with the subset of requested
 // updates that module is accountable for, captured before the update step
-// mutates them.
+// mutates them. workReplaces holds the replace directives of the go.work file
+// governing the module, if any, because they override the module's own metadata.
 type goVerifyTarget struct {
-	goModPath string
-	goSumPath string
-	updates   unversioned.LangUpdatePackages
+	goModPath    string
+	goSumPath    string
+	workReplaces []*modfile.Replace
+	updates      unversioned.LangUpdatePackages
 }
 
 // readOptionalGoSum returns the contents of goSumPath, or nil when the module
@@ -1184,7 +1242,8 @@ func (gm *golangManager) readOptionalGoSum(ctx context.Context, state *llb.State
 
 // collectGoVerifyTargets records which modules to verify after the update and,
 // for each, the updates it already referenced. For a workspace the go.work root
-// has no authoritative go.mod, so every member module is collected instead.
+// has no authoritative go.mod, so every member module is collected instead,
+// carrying the workspace replacements that override them.
 // Reading the pre-update files matters twice over: it scopes verification to
 // modules that actually depended on the vulnerable package, and it still catches
 // requirements that the update step dropped.
@@ -1196,15 +1255,17 @@ func (gm *golangManager) collectGoVerifyTargets(
 	updates unversioned.LangUpdatePackages,
 ) ([]goVerifyTarget, error) {
 	modDirs := []string{modPath}
+	var workReplaces []*modfile.Replace
 	if isWorkspace {
 		goWorkBytes, err := buildkit.ExtractFileFromState(ctx, gm.config.Client, state, modPath+"/go.work")
 		if err != nil {
 			return nil, fmt.Errorf("failed to read %s/go.work: %w", modPath, err)
 		}
-		modDirs, err = goWorkspaceMemberDirs(goWorkBytes, modPath)
+		ws, err := parseGoWorkspace(goWorkBytes, modPath)
 		if err != nil {
 			return nil, err
 		}
+		modDirs, workReplaces = ws.memberDirs, ws.replacements
 	}
 
 	targets := make([]goVerifyTarget, 0, len(modDirs))
@@ -1226,7 +1287,12 @@ func (gm *golangManager) collectGoVerifyTargets(
 			log.Debugf("No requested Go updates apply to %s, skipping verification", goModPath)
 			continue
 		}
-		targets = append(targets, goVerifyTarget{goModPath: goModPath, goSumPath: goSumPath, updates: applicable})
+		targets = append(targets, goVerifyTarget{
+			goModPath:    goModPath,
+			goSumPath:    goSumPath,
+			workReplaces: workReplaces,
+			updates:      applicable,
+		})
 	}
 	return targets, nil
 }
@@ -1303,24 +1369,32 @@ func (gm *golangManager) updateGoModule(
 	).Root()
 
 	// Confirm the bumps survived 'go mod tidy -e' instead of trusting the exit
-	// code. Any failure reports every update still lacking proof, since a
-	// workspace aborts with later members unread and an unreported package is
-	// treated as remediated.
-	verified := make(map[string]struct{}, len(updates))
+	// code. A workspace runs the same `go get` list in every member module, so a
+	// package is proven only once every member accountable for it has been
+	// checked: proving it in one member says nothing about another member that
+	// still requires the vulnerable version. Any failure reports every update
+	// still lacking proof, since a workspace aborts with later members unread and
+	// an unreported package is treated as remediated.
+	pendingProofs := make(map[string]int, len(updates))
+	for _, target := range verifyTargets {
+		for _, u := range target.updates {
+			pendingProofs[u.Name]++
+		}
+	}
 	for _, target := range verifyTargets {
 		goModBytes, extractErr := buildkit.ExtractFileFromState(ctx, gm.config.Client, &state, target.goModPath)
 		if extractErr != nil {
-			return state, unverifiedUpdateNames(updates, verified), fmt.Errorf("failed to read %s after update: %w", target.goModPath, extractErr)
+			return state, unverifiedUpdateNames(updates, pendingProofs), fmt.Errorf("failed to read %s after update: %w", target.goModPath, extractErr)
 		}
 		goSumBytes, goSumErr := gm.readOptionalGoSum(ctx, &state, target.goSumPath)
 		if goSumErr != nil {
-			return state, unverifiedUpdateNames(updates, verified), fmt.Errorf("failed to read %s after update: %w", target.goSumPath, goSumErr)
+			return state, unverifiedUpdateNames(updates, pendingProofs), fmt.Errorf("failed to read %s after update: %w", target.goSumPath, goSumErr)
 		}
-		if verifyErr := verifyGoModUpdates(goModBytes, goSumBytes, target.updates); verifyErr != nil {
-			return state, unverifiedUpdateNames(updates, verified), fmt.Errorf("go module update verification failed for %s: %w", target.goModPath, verifyErr)
+		if verifyErr := verifyGoModUpdates(goModBytes, goSumBytes, target.workReplaces, target.updates); verifyErr != nil {
+			return state, unverifiedUpdateNames(updates, pendingProofs), fmt.Errorf("go module update verification failed for %s: %w", target.goModPath, verifyErr)
 		}
 		for _, u := range target.updates {
-			verified[u.Name] = struct{}{}
+			pendingProofs[u.Name]--
 		}
 	}
 
@@ -1376,11 +1450,38 @@ func (gm *golangManager) upgradePackagesWithTooling(
 
 	state := *currentState
 
-	// Process each module path
+	// Validate every module path before one of them is interpolated into a shell
+	// command further down.
 	for _, modPath := range goModPaths {
 		if strings.ContainsAny(modPath, shellUnsafeChars) {
-			return currentState, nil, fmt.Errorf("go.mod path contains unsafe characters: %s", modPath)
+			return currentState, getPackageNames(updates), fmt.Errorf("go.mod path contains unsafe characters: %s", modPath)
 		}
+	}
+
+	// Record which updates each module is accountable for before any module is
+	// touched. The same `go get` list runs against every module in the image, so
+	// verifying all of them against one module would fail a module that never
+	// depended on the vulnerable package. Collecting up front also keeps
+	// reporting honest: a failure partway through leaves the remaining modules
+	// unprocessed, and the packages they carry must still be reported as
+	// unpatched instead of assumed remediated.
+	accountableUpdates := make(map[string]unversioned.LangUpdatePackages, len(goModPaths))
+	pendingProofs := make(map[string]int, len(updates))
+	for _, modPath := range goModPaths {
+		targets, targetErr := gm.collectGoVerifyTargets(ctx, currentState, modPath, false, updates)
+		if targetErr != nil {
+			return currentState, getPackageNames(updates), targetErr
+		}
+		for _, target := range targets {
+			accountableUpdates[modPath] = target.updates
+			for _, u := range target.updates {
+				pendingProofs[u.Name]++
+			}
+		}
+	}
+
+	// Process each module path
+	for _, modPath := range goModPaths {
 		log.Debugf("Updating Go module at %s using tooling container", modPath)
 
 		// Create tooling container state with target platform
@@ -1410,13 +1511,13 @@ func (gm *golangManager) upgradePackagesWithTooling(
 		for _, u := range updates {
 			if u.FixedVersion != "" {
 				if strings.ContainsAny(u.Name, shellUnsafeChars) {
-					return currentState, nil, fmt.Errorf("package name contains unsafe characters: %s", u.Name)
+					return currentState, getPackageNames(updates), fmt.Errorf("package name contains unsafe characters: %s", u.Name)
 				}
 				if strings.HasPrefix(u.Name, "-") {
-					return currentState, nil, fmt.Errorf("package name cannot start with '-': %s", u.Name)
+					return currentState, getPackageNames(updates), fmt.Errorf("package name cannot start with '-': %s", u.Name)
 				}
 				if strings.ContainsAny(u.FixedVersion, shellUnsafeChars) {
-					return currentState, nil, fmt.Errorf("version contains unsafe characters: %s for package %s", u.FixedVersion, u.Name)
+					return currentState, getPackageNames(updates), fmt.Errorf("version contains unsafe characters: %s for package %s", u.FixedVersion, u.Name)
 				}
 				version := u.FixedVersion
 				if !strings.HasPrefix(version, "v") {
@@ -1432,22 +1533,7 @@ func (gm *golangManager) upgradePackagesWithTooling(
 			continue
 		}
 
-		// Record which updates this module is accountable for while its
-		// pre-update metadata is still intact. The same `go get` list runs
-		// against every module in the image, so verifying all of them here would
-		// fail a module that never depended on the vulnerable package.
-		originalGoMod, origErr := buildkit.ExtractFileFromState(ctx, gm.config.Client, &state, modPath+"/go.mod")
-		if origErr != nil {
-			return currentState, getPackageNames(updates), fmt.Errorf("failed to read %s/go.mod before update: %w", modPath, origErr)
-		}
-		originalGoSum, sumErr := gm.readOptionalGoSum(ctx, &state, modPath+"/go.sum")
-		if sumErr != nil {
-			return currentState, getPackageNames(updates), fmt.Errorf("failed to read %s/go.sum before update: %w", modPath, sumErr)
-		}
-		moduleUpdates, filterErr := filterUpdatesInGoMod(originalGoMod, originalGoSum, updates)
-		if filterErr != nil {
-			return currentState, getPackageNames(updates), fmt.Errorf("%s/go.mod: %w", modPath, filterErr)
-		}
+		moduleUpdates := accountableUpdates[modPath]
 
 		allGetCmd := strings.Join(getCommands, " && ")
 		// -e tolerates broken upstream go.mod files; see comment in the
@@ -1462,19 +1548,24 @@ func (gm *golangManager) upgradePackagesWithTooling(
 		).Root()
 
 		// Confirm the bumps survived 'go mod tidy -e' instead of trusting the
-		// exit code. Failures name the affected packages so they are reported as
-		// unpatched rather than claimed as remediated.
+		// exit code. A failure reports every update still lacking proof: the
+		// modules queued behind this one are never processed, so their packages
+		// must not be claimed as remediated. The tooling container is handed only
+		// this module's go.mod and go.sum, so no workspace replacements apply.
 		if len(moduleUpdates) > 0 {
 			goModBytes, extractErr := buildkit.ExtractFileFromState(ctx, gm.config.Client, &toolingState, "/workspace/go.mod")
 			if extractErr != nil {
-				return currentState, getPackageNames(moduleUpdates), fmt.Errorf("failed to read go.mod after update at %s: %w", modPath, extractErr)
+				return currentState, unverifiedUpdateNames(updates, pendingProofs), fmt.Errorf("failed to read go.mod after update at %s: %w", modPath, extractErr)
 			}
 			goSumBytes, goSumErr := gm.readOptionalGoSum(ctx, &toolingState, "/workspace/go.sum")
 			if goSumErr != nil {
-				return currentState, getPackageNames(moduleUpdates), fmt.Errorf("failed to read go.sum after update at %s: %w", modPath, goSumErr)
+				return currentState, unverifiedUpdateNames(updates, pendingProofs), fmt.Errorf("failed to read go.sum after update at %s: %w", modPath, goSumErr)
 			}
-			if verifyErr := verifyGoModUpdates(goModBytes, goSumBytes, moduleUpdates); verifyErr != nil {
-				return currentState, getPackageNames(moduleUpdates), fmt.Errorf("go module update verification failed at %s: %w", modPath, verifyErr)
+			if verifyErr := verifyGoModUpdates(goModBytes, goSumBytes, nil, moduleUpdates); verifyErr != nil {
+				return currentState, unverifiedUpdateNames(updates, pendingProofs), fmt.Errorf("go module update verification failed at %s: %w", modPath, verifyErr)
+			}
+			for _, u := range moduleUpdates {
+				pendingProofs[u.Name]--
 			}
 		}
 

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -218,8 +218,8 @@ func buildGoUpdateCmd(modPath, allGetCmd string) string {
 // the go.mod produced by the update step. `go mod tidy -e` removes requirements
 // for modules that are no longer imported by reachable code, so a successful
 // `go get` can be silently reverted and the package still reported as patched.
-// The effective version of a module is the version from a replace directive
-// targeting it, if any, otherwise its require entry.
+// Applicable versioned replace directives override the old module's require
+// version and also count as an effective instance of their replacement target.
 func verifyGoModUpdates(goModContent []byte, updates unversioned.LangUpdatePackages) error {
 	hasTargets := false
 	for _, u := range updates {
@@ -243,29 +243,52 @@ func verifyGoModUpdates(goModContent []byte, updates unversioned.LangUpdatePacka
 			required[r.Mod.Path] = r.Mod.Version
 		}
 	}
-	// A replace directive pointing at the module overrides its require entry.
-	// Filesystem replacements carry no version, so they leave the require entry
-	// as the effective version.
-	replaced := make(map[string]string, len(f.Replace))
-	for _, rep := range f.Replace {
-		if rep != nil && rep.New.Path != "" && rep.New.Version != "" {
-			replaced[rep.New.Path] = rep.New.Version
-		}
-	}
 
 	for _, u := range updates {
 		if u.FixedVersion == "" {
 			continue
 		}
-		landed, ok := replaced[u.Name]
-		if !ok {
-			landed, ok = required[u.Name]
+
+		found := false
+		if requiredVersion, ok := required[u.Name]; ok {
+			found = true
+			landedVersion := requiredVersion
+			for _, rep := range f.Replace {
+				if rep == nil || rep.Old.Path != u.Name {
+					continue
+				}
+				if rep.Old.Version != "" && rep.Old.Version != requiredVersion {
+					continue
+				}
+				if rep.New.Version == "" {
+					return fmt.Errorf("module %s has local replacement %s; cannot verify requested version %s", u.Name, rep.New.Path, u.FixedVersion)
+				}
+				landedVersion = rep.New.Version
+				break
+			}
+			if isLessThanGoVersion(landedVersion, u.FixedVersion) {
+				return fmt.Errorf("module %s is at %s in go.mod after update, expected %s or newer", u.Name, landedVersion, u.FixedVersion)
+			}
 		}
-		if !ok || landed == "" {
+
+		// A module can also enter the build list as the target of a replacement
+		// for another required module.
+		for _, rep := range f.Replace {
+			if rep == nil || rep.Old.Path == u.Name || rep.New.Path != u.Name || rep.New.Version == "" {
+				continue
+			}
+			oldVersion, ok := required[rep.Old.Path]
+			if !ok || (rep.Old.Version != "" && rep.Old.Version != oldVersion) {
+				continue
+			}
+			found = true
+			if isLessThanGoVersion(rep.New.Version, u.FixedVersion) {
+				return fmt.Errorf("module %s is at %s in go.mod after update, expected %s or newer", u.Name, rep.New.Version, u.FixedVersion)
+			}
+		}
+
+		if !found {
 			return fmt.Errorf("module %s not found in go.mod after update; the requested version %s was not applied or was removed by 'go mod tidy'", u.Name, u.FixedVersion)
-		}
-		if isLessThanGoVersion(landed, u.FixedVersion) {
-			return fmt.Errorf("module %s is at %s in go.mod after update, expected %s or newer", u.Name, landed, u.FixedVersion)
 		}
 	}
 

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -13,6 +13,7 @@ import (
 	"github.com/project-copacetic/copacetic/pkg/types/unversioned"
 	"github.com/project-copacetic/copacetic/pkg/utils"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
 	"golang.org/x/mod/semver"
 )
@@ -211,6 +212,64 @@ func appendIncompatibleIfNeeded(modulePath, version string) string {
 // working binary.
 func buildGoUpdateCmd(modPath, allGetCmd string) string {
 	return fmt.Sprintf(`sh -c 'cd %s && %s && go mod tidy -e'`, modPath, allGetCmd)
+}
+
+// verifyGoModUpdates confirms that the requested version bumps are reflected in
+// the go.mod produced by the update step. `go mod tidy -e` removes requirements
+// for modules that are no longer imported by reachable code, so a successful
+// `go get` can be silently reverted and the package still reported as patched.
+// The effective version of a module is the version from a replace directive
+// targeting it, if any, otherwise its require entry.
+func verifyGoModUpdates(goModContent []byte, updates unversioned.LangUpdatePackages) error {
+	hasTargets := false
+	for _, u := range updates {
+		if u.FixedVersion != "" {
+			hasTargets = true
+			break
+		}
+	}
+	if !hasTargets {
+		return nil
+	}
+
+	f, err := modfile.Parse("go.mod", goModContent, nil)
+	if err != nil {
+		return fmt.Errorf("failed to parse go.mod after update: %w", err)
+	}
+
+	required := make(map[string]string, len(f.Require))
+	for _, r := range f.Require {
+		if r != nil && r.Mod.Path != "" {
+			required[r.Mod.Path] = r.Mod.Version
+		}
+	}
+	// A replace directive pointing at the module overrides its require entry.
+	// Filesystem replacements carry no version, so they leave the require entry
+	// as the effective version.
+	replaced := make(map[string]string, len(f.Replace))
+	for _, rep := range f.Replace {
+		if rep != nil && rep.New.Path != "" && rep.New.Version != "" {
+			replaced[rep.New.Path] = rep.New.Version
+		}
+	}
+
+	for _, u := range updates {
+		if u.FixedVersion == "" {
+			continue
+		}
+		landed, ok := replaced[u.Name]
+		if !ok {
+			landed, ok = required[u.Name]
+		}
+		if !ok || landed == "" {
+			return fmt.Errorf("module %s not found in go.mod after update; the requested version %s was not applied or was removed by 'go mod tidy'", u.Name, u.FixedVersion)
+		}
+		if isLessThanGoVersion(landed, u.FixedVersion) {
+			return fmt.Errorf("module %s is at %s in go.mod after update, expected %s or newer", u.Name, landed, u.FixedVersion)
+		}
+	}
+
+	return nil
 }
 
 // filterGoPackages filters for Go module and binary packages.
@@ -1012,6 +1071,19 @@ func (gm *golangManager) updateGoModule(
 		llb.WithProxy(utils.GetProxy()),
 	).Root()
 
+	// Confirm the bumps survived 'go mod tidy -e' instead of trusting the exit
+	// code. Skipped for workspaces: the go.work root has no authoritative
+	// go.mod, since requirements land in the member modules.
+	if !isWorkspace {
+		goModBytes, err := buildkit.ExtractFileFromState(ctx, gm.config.Client, &state, modPath+"/go.mod")
+		if err != nil {
+			return state, fmt.Errorf("failed to read %s/go.mod after update: %w", modPath, err)
+		}
+		if err := verifyGoModUpdates(goModBytes, updates); err != nil {
+			return state, err
+		}
+	}
+
 	// Check for vendor directory and update if present
 	hasVendor, _ := gm.detectVendor(ctx, &state, modPath)
 	if hasVendor {
@@ -1131,6 +1203,15 @@ func (gm *golangManager) upgradePackagesWithTooling(
 			llb.Shlex(updateCmd),
 			llb.WithProxy(utils.GetProxy()),
 		).Root()
+
+		// Confirm the bumps survived 'go mod tidy -e' instead of trusting the exit code.
+		goModBytes, extractErr := buildkit.ExtractFileFromState(ctx, gm.config.Client, &toolingState, "/workspace/go.mod")
+		if extractErr != nil {
+			return currentState, nil, fmt.Errorf("failed to read go.mod after update at %s: %w", modPath, extractErr)
+		}
+		if verifyErr := verifyGoModUpdates(goModBytes, updates); verifyErr != nil {
+			return currentState, nil, fmt.Errorf("go module update verification failed at %s: %w", modPath, verifyErr)
+		}
 
 		// Check if vendor exists in original and update if so
 		hasVendor, _ := gm.detectVendor(ctx, &state, modPath)

--- a/pkg/langmgr/golang.go
+++ b/pkg/langmgr/golang.go
@@ -10,6 +10,7 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
+	"github.com/project-copacetic/copacetic/pkg/common"
 	"github.com/project-copacetic/copacetic/pkg/provenance"
 	"github.com/project-copacetic/copacetic/pkg/types/unversioned"
 	"github.com/project-copacetic/copacetic/pkg/utils"
@@ -216,13 +217,15 @@ func buildGoUpdateCmd(modPath, allGetCmd string) string {
 }
 
 // verifyGoModUpdates confirms that the requested version bumps are reflected in
-// the go.mod produced by the update step. `go mod tidy -e` removes requirements
-// for modules that are no longer imported by reachable code, so a successful
-// `go get` can be silently reverted and the package still reported as patched.
-// Only a replace directive whose left-hand side is the module under test can
-// change that module's effective version: versions of other module paths are
-// not comparable to the requested one.
-func verifyGoModUpdates(goModContent []byte, updates unversioned.LangUpdatePackages) error {
+// the module metadata produced by the update step. `go mod tidy -e` removes
+// requirements for modules that are no longer imported by reachable code, so a
+// successful `go get` can be silently reverted and the package still reported as
+// patched. Modules before go 1.17 record only direct requirements in go.mod, so
+// an indirect dependency falls back to the version go.sum says the build
+// downloads. A replacement that hides the module behind unversioned local
+// contents or a different module path leaves the requested version unprovable
+// and is reported as a failure rather than assumed patched.
+func verifyGoModUpdates(goModContent, goSumContent []byte, updates unversioned.LangUpdatePackages) error {
 	hasTargets := false
 	for _, u := range updates {
 		if u.FixedVersion != "" {
@@ -245,20 +248,30 @@ func verifyGoModUpdates(goModContent []byte, updates unversioned.LangUpdatePacka
 			required[r.Mod.Path] = r.Mod.Version
 		}
 	}
+	builtVersions := goSumBuiltVersions(goSumContent)
 
 	for _, u := range updates {
 		if u.FixedVersion == "" {
 			continue
 		}
 
-		requiredVersion, ok := required[u.Name]
-		if !ok {
-			return fmt.Errorf("module %s not found in go.mod after update; the requested version %s was not applied or was removed by 'go mod tidy'", u.Name, u.FixedVersion)
+		requiredVersion, inGoMod := required[u.Name]
+		if !inGoMod {
+			if err := verifyGoSumVersions(builtVersions[u.Name], u.Name, u.FixedVersion); err != nil {
+				return err
+			}
+			continue
 		}
 
 		landedVersion := requiredVersion
-		if replacement := effectiveReplacementVersion(f.Replace, u.Name, requiredVersion); replacement != "" {
-			landedVersion = replacement
+		if rep := governingReplacement(f.Replace, u.Name, requiredVersion); rep != nil {
+			switch {
+			case rep.New.Version == "":
+				return fmt.Errorf("module %s is replaced by %s, whose contents are unversioned; cannot verify that requested version %s was applied", u.Name, rep.New.Path, u.FixedVersion)
+			case rep.New.Path != u.Name:
+				return fmt.Errorf("module %s is replaced by %s@%s; a different module path cannot prove that requested version %s was applied", u.Name, rep.New.Path, rep.New.Version, u.FixedVersion)
+			}
+			landedVersion = rep.New.Version
 		}
 		if isLessThanGoVersion(landedVersion, u.FixedVersion) {
 			return fmt.Errorf("module %s is at %s in go.mod after update, expected %s or newer", u.Name, landedVersion, u.FixedVersion)
@@ -268,41 +281,79 @@ func verifyGoModUpdates(goModContent []byte, updates unversioned.LangUpdatePacka
 	return nil
 }
 
-// effectiveReplacementVersion returns the version that replace directives give
-// modPath at selectedVersion, or "" when no directive names a version for it.
-// Mirroring go.mod resolution, a directive pinned to the selected version wins
-// over a path-wide directive, and a filesystem replacement (which carries no
-// version) never overrides the require entry.
-func effectiveReplacementVersion(replacements []*modfile.Replace, modPath, selectedVersion string) string {
-	var pinned, pathWide string
+// verifyGoSumVersions checks a module that go.mod does not require against the
+// versions go.sum records full contents for. Those are the versions the build
+// downloads, so every one of them must carry the fix.
+func verifyGoSumVersions(builtVersions []string, modPath, fixedVersion string) error {
+	if len(builtVersions) == 0 {
+		return fmt.Errorf("module %s not found in go.mod or go.sum after update; the requested version %s was not applied or was removed by 'go mod tidy'", modPath, fixedVersion)
+	}
+	for _, version := range builtVersions {
+		if isLessThanGoVersion(version, fixedVersion) {
+			return fmt.Errorf("module %s is at %s in go.sum after update, expected %s or newer", modPath, version, fixedVersion)
+		}
+	}
+	return nil
+}
+
+// governingReplacement returns the replace directive that controls modPath at
+// selectedVersion, or nil when none applies. Mirroring go.mod resolution, a
+// directive pinned to the selected version wins over a path-wide directive.
+func governingReplacement(replacements []*modfile.Replace, modPath, selectedVersion string) *modfile.Replace {
+	var pinned, pathWide *modfile.Replace
 	for _, rep := range replacements {
-		if rep == nil || rep.Old.Path != modPath || rep.New.Version == "" {
+		if rep == nil || rep.Old.Path != modPath {
 			continue
 		}
-		switch {
-		case rep.Old.Version == "":
-			if pathWide == "" {
-				pathWide = rep.New.Version
+		switch rep.Old.Version {
+		case "":
+			if pathWide == nil {
+				pathWide = rep
 			}
-		case rep.Old.Version == selectedVersion:
-			if pinned == "" {
-				pinned = rep.New.Version
+		case selectedVersion:
+			if pinned == nil {
+				pinned = rep
 			}
 		}
 	}
-	if pinned != "" {
+	if pinned != nil {
 		return pinned
 	}
 	return pathWide
 }
 
-// filterUpdatesInGoMod narrows updates to the modules the given go.mod already
+// goSumBuiltVersions maps module paths to the versions go.sum records full
+// module contents for. A "/go.mod" line names a version that exists in the
+// module graph without contributing code to the build, so it proves nothing
+// about the code in the image.
+func goSumBuiltVersions(goSumContent []byte) map[string][]string {
+	if len(goSumContent) == 0 {
+		return nil
+	}
+	versions := make(map[string][]string)
+	for line := range strings.SplitSeq(string(goSumContent), "\n") {
+		modPath, rest, ok := strings.Cut(strings.TrimSpace(line), " ")
+		if !ok {
+			continue
+		}
+		version, hash, ok := strings.Cut(rest, " ")
+		if !ok || hash == "" || strings.HasSuffix(version, "/go.mod") {
+			continue
+		}
+		versions[modPath] = append(versions[modPath], version)
+	}
+	return versions
+}
+
+// filterUpdatesInGoMod narrows updates to the modules the given module already
 // referenced. The update step runs the same `go get` list against every module
-// in the image, so verifying all of them against one go.mod would fail modules
-// that never depended on the vulnerable package. Callers pass the module's
-// pre-update go.mod so that requirements dropped by the update are still
-// verified rather than silently excused.
-func filterUpdatesInGoMod(goModContent []byte, updates unversioned.LangUpdatePackages) (unversioned.LangUpdatePackages, error) {
+// in the image, so verifying all of them against one module would fail modules
+// that never depended on the vulnerable package. go.sum is consulted as well
+// because a module before go 1.17 keeps indirect dependencies out of go.mod, and
+// dropping those would leave them unverified while still reported as patched.
+// Callers pass the pre-update files so that requirements removed by the update
+// are still verified rather than silently excused.
+func filterUpdatesInGoMod(goModContent, goSumContent []byte, updates unversioned.LangUpdatePackages) (unversioned.LangUpdatePackages, error) {
 	f, err := modfile.Parse("go.mod", goModContent, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse go.mod: %w", err)
@@ -319,6 +370,9 @@ func filterUpdatesInGoMod(goModContent []byte, updates unversioned.LangUpdatePac
 			present[rep.Old.Path] = struct{}{}
 		}
 	}
+	for modPath := range goSumBuiltVersions(goSumContent) {
+		present[modPath] = struct{}{}
+	}
 
 	var applicable unversioned.LangUpdatePackages
 	for _, u := range updates {
@@ -329,17 +383,32 @@ func filterUpdatesInGoMod(goModContent []byte, updates unversioned.LangUpdatePac
 	return applicable, nil
 }
 
-// goWorkspaceMemberModPaths resolves the go.mod path of every module listed by a
+// unverifiedUpdateNames returns the names of every requested update that has not
+// been confirmed yet. A verification step that cannot finish must report all of
+// them, since an unproven package left out of the failure list is reported as
+// remediated.
+func unverifiedUpdateNames(updates unversioned.LangUpdatePackages, verified map[string]struct{}) []string {
+	names := make([]string, 0, len(updates))
+	for _, u := range updates {
+		if _, ok := verified[u.Name]; ok {
+			continue
+		}
+		names = append(names, u.Name)
+	}
+	return names
+}
+
+// goWorkspaceMemberDirs resolves the directory of every module listed by a
 // go.work file, relative to the workspace root. A workspace root has no
 // authoritative go.mod of its own: requirements land in the member modules, so
-// those are the files to verify.
-func goWorkspaceMemberModPaths(goWorkContent []byte, workRoot string) ([]string, error) {
+// those are the modules to verify.
+func goWorkspaceMemberDirs(goWorkContent []byte, workRoot string) ([]string, error) {
 	f, err := modfile.ParseWork("go.work", goWorkContent, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse go.work: %w", err)
 	}
 
-	var modPaths []string
+	var modDirs []string
 	for _, use := range f.Use {
 		if use == nil || use.Path == "" {
 			continue
@@ -348,12 +417,12 @@ func goWorkspaceMemberModPaths(goWorkContent []byte, workRoot string) ([]string,
 		if !path.IsAbs(dir) {
 			dir = path.Join(workRoot, dir)
 		}
-		modPaths = append(modPaths, path.Join(path.Clean(dir), "go.mod"))
+		modDirs = append(modDirs, path.Clean(dir))
 	}
-	if len(modPaths) == 0 {
+	if len(modDirs) == 0 {
 		return nil, fmt.Errorf("go.work at %s lists no module directories; cannot verify Go module updates", workRoot)
 	}
-	return modPaths, nil
+	return modDirs, nil
 }
 
 // filterGoPackages filters for Go module and binary packages.
@@ -1090,19 +1159,35 @@ func (gm *golangManager) attemptBinaryRebuild(
 	return state, failedPackages, nil
 }
 
-// goVerifyTarget pairs a go.mod file with the subset of requested updates that
-// file is accountable for, captured before the update step mutates it.
+// goVerifyTarget pairs a module's metadata files with the subset of requested
+// updates that module is accountable for, captured before the update step
+// mutates them.
 type goVerifyTarget struct {
 	goModPath string
+	goSumPath string
 	updates   unversioned.LangUpdatePackages
 }
 
-// collectGoVerifyTargets records which go.mod files to verify after the update
-// and, for each, the updates it already referenced. For a workspace the go.work
-// root has no authoritative go.mod, so every member module is collected
-// instead. Reading the pre-update go.mod matters twice over: it scopes
-// verification to modules that actually depended on the vulnerable package, and
-// it still catches requirements that the update step dropped.
+// readOptionalGoSum returns the contents of goSumPath, or nil when the module
+// has no go.sum. A module without external dependencies ships none, so absence
+// is not a failure, while a broken solve still surfaces as an error.
+func (gm *golangManager) readOptionalGoSum(ctx context.Context, state *llb.State, goSumPath string) ([]byte, error) {
+	exists, err := common.StateFileExists(ctx, gm.config.Client, state, gm.config.Platform, goSumPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat %s: %w", goSumPath, err)
+	}
+	if !exists {
+		return nil, nil
+	}
+	return buildkit.ExtractFileFromState(ctx, gm.config.Client, state, goSumPath)
+}
+
+// collectGoVerifyTargets records which modules to verify after the update and,
+// for each, the updates it already referenced. For a workspace the go.work root
+// has no authoritative go.mod, so every member module is collected instead.
+// Reading the pre-update files matters twice over: it scopes verification to
+// modules that actually depended on the vulnerable package, and it still catches
+// requirements that the update step dropped.
 func (gm *golangManager) collectGoVerifyTargets(
 	ctx context.Context,
 	state *llb.State,
@@ -1110,25 +1195,30 @@ func (gm *golangManager) collectGoVerifyTargets(
 	isWorkspace bool,
 	updates unversioned.LangUpdatePackages,
 ) ([]goVerifyTarget, error) {
-	goModPaths := []string{modPath + "/go.mod"}
+	modDirs := []string{modPath}
 	if isWorkspace {
 		goWorkBytes, err := buildkit.ExtractFileFromState(ctx, gm.config.Client, state, modPath+"/go.work")
 		if err != nil {
 			return nil, fmt.Errorf("failed to read %s/go.work: %w", modPath, err)
 		}
-		goModPaths, err = goWorkspaceMemberModPaths(goWorkBytes, modPath)
+		modDirs, err = goWorkspaceMemberDirs(goWorkBytes, modPath)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	targets := make([]goVerifyTarget, 0, len(goModPaths))
-	for _, goModPath := range goModPaths {
+	targets := make([]goVerifyTarget, 0, len(modDirs))
+	for _, modDir := range modDirs {
+		goModPath, goSumPath := modDir+"/go.mod", modDir+"/go.sum"
 		goModBytes, err := buildkit.ExtractFileFromState(ctx, gm.config.Client, state, goModPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read %s before update: %w", goModPath, err)
 		}
-		applicable, err := filterUpdatesInGoMod(goModBytes, updates)
+		goSumBytes, err := gm.readOptionalGoSum(ctx, state, goSumPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s before update: %w", goSumPath, err)
+		}
+		applicable, err := filterUpdatesInGoMod(goModBytes, goSumBytes, updates)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", goModPath, err)
 		}
@@ -1136,7 +1226,7 @@ func (gm *golangManager) collectGoVerifyTargets(
 			log.Debugf("No requested Go updates apply to %s, skipping verification", goModPath)
 			continue
 		}
-		targets = append(targets, goVerifyTarget{goModPath: goModPath, updates: applicable})
+		targets = append(targets, goVerifyTarget{goModPath: goModPath, goSumPath: goSumPath, updates: applicable})
 	}
 	return targets, nil
 }
@@ -1213,14 +1303,24 @@ func (gm *golangManager) updateGoModule(
 	).Root()
 
 	// Confirm the bumps survived 'go mod tidy -e' instead of trusting the exit
-	// code.
+	// code. Any failure reports every update still lacking proof, since a
+	// workspace aborts with later members unread and an unreported package is
+	// treated as remediated.
+	verified := make(map[string]struct{}, len(updates))
 	for _, target := range verifyTargets {
 		goModBytes, extractErr := buildkit.ExtractFileFromState(ctx, gm.config.Client, &state, target.goModPath)
 		if extractErr != nil {
-			return state, getPackageNames(target.updates), fmt.Errorf("failed to read %s after update: %w", target.goModPath, extractErr)
+			return state, unverifiedUpdateNames(updates, verified), fmt.Errorf("failed to read %s after update: %w", target.goModPath, extractErr)
 		}
-		if verifyErr := verifyGoModUpdates(goModBytes, target.updates); verifyErr != nil {
-			return state, getPackageNames(target.updates), fmt.Errorf("go module update verification failed for %s: %w", target.goModPath, verifyErr)
+		goSumBytes, goSumErr := gm.readOptionalGoSum(ctx, &state, target.goSumPath)
+		if goSumErr != nil {
+			return state, unverifiedUpdateNames(updates, verified), fmt.Errorf("failed to read %s after update: %w", target.goSumPath, goSumErr)
+		}
+		if verifyErr := verifyGoModUpdates(goModBytes, goSumBytes, target.updates); verifyErr != nil {
+			return state, unverifiedUpdateNames(updates, verified), fmt.Errorf("go module update verification failed for %s: %w", target.goModPath, verifyErr)
+		}
+		for _, u := range target.updates {
+			verified[u.Name] = struct{}{}
 		}
 	}
 
@@ -1333,14 +1433,18 @@ func (gm *golangManager) upgradePackagesWithTooling(
 		}
 
 		// Record which updates this module is accountable for while its
-		// pre-update go.mod is still intact. The same `go get` list runs against
-		// every module in the image, so verifying all of them here would fail a
-		// module that never depended on the vulnerable package.
+		// pre-update metadata is still intact. The same `go get` list runs
+		// against every module in the image, so verifying all of them here would
+		// fail a module that never depended on the vulnerable package.
 		originalGoMod, origErr := buildkit.ExtractFileFromState(ctx, gm.config.Client, &state, modPath+"/go.mod")
 		if origErr != nil {
 			return currentState, getPackageNames(updates), fmt.Errorf("failed to read %s/go.mod before update: %w", modPath, origErr)
 		}
-		moduleUpdates, filterErr := filterUpdatesInGoMod(originalGoMod, updates)
+		originalGoSum, sumErr := gm.readOptionalGoSum(ctx, &state, modPath+"/go.sum")
+		if sumErr != nil {
+			return currentState, getPackageNames(updates), fmt.Errorf("failed to read %s/go.sum before update: %w", modPath, sumErr)
+		}
+		moduleUpdates, filterErr := filterUpdatesInGoMod(originalGoMod, originalGoSum, updates)
 		if filterErr != nil {
 			return currentState, getPackageNames(updates), fmt.Errorf("%s/go.mod: %w", modPath, filterErr)
 		}
@@ -1365,7 +1469,11 @@ func (gm *golangManager) upgradePackagesWithTooling(
 			if extractErr != nil {
 				return currentState, getPackageNames(moduleUpdates), fmt.Errorf("failed to read go.mod after update at %s: %w", modPath, extractErr)
 			}
-			if verifyErr := verifyGoModUpdates(goModBytes, moduleUpdates); verifyErr != nil {
+			goSumBytes, goSumErr := gm.readOptionalGoSum(ctx, &toolingState, "/workspace/go.sum")
+			if goSumErr != nil {
+				return currentState, getPackageNames(moduleUpdates), fmt.Errorf("failed to read go.sum after update at %s: %w", modPath, goSumErr)
+			}
+			if verifyErr := verifyGoModUpdates(goModBytes, goSumBytes, moduleUpdates); verifyErr != nil {
 				return currentState, getPackageNames(moduleUpdates), fmt.Errorf("go module update verification failed at %s: %w", modPath, verifyErr)
 			}
 		}

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -1158,6 +1158,21 @@ replace github.com/pkg/legacy => golang.org/x/net v0.23.0
 			wantErr: false,
 		},
 		{
+			name: "required module resolved through cross-module replace",
+			goMod: `module example.com/app
+
+go 1.22
+
+require github.com/pkg/legacy v0.17.0
+
+replace github.com/pkg/legacy => golang.org/x/net v0.23.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "github.com/pkg/legacy", FixedVersion: "v0.23.0"},
+			},
+			wantErr: false,
+		},
+		{
 			name: "replace directive pins version below target",
 			goMod: `module example.com/app
 
@@ -1174,7 +1189,7 @@ replace golang.org/x/net => golang.org/x/net v0.17.0
 			errSubstr: "v0.17.0",
 		},
 		{
-			name: "local replace directive falls back to require",
+			name: "local replace directive cannot prove applied version",
 			goMod: `module example.com/app
 
 go 1.22
@@ -1182,6 +1197,22 @@ go 1.22
 require golang.org/x/net v0.23.0
 
 replace golang.org/x/net => ./vendored/net
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr:   true,
+			errSubstr: "local replacement",
+		},
+		{
+			name: "version-specific replace for unselected version is ignored",
+			goMod: `module example.com/app
+
+go 1.22
+
+require golang.org/x/net v0.23.0
+
+replace golang.org/x/net v0.17.0 => golang.org/x/net v0.10.0
 `,
 			updates: unversioned.LangUpdatePackages{
 				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -1063,122 +1063,213 @@ func TestGolangManagerInstallUpdatesSkipsNonNewerVersion(t *testing.T) {
 	assert.Same(t, currentState, state)
 }
 
-func TestAppendIncompatibleIfNeeded(t *testing.T) {
+// TestVerifyGoModUpdates asserts that the post-update go.mod check catches
+// updates that did not land. `go mod tidy -e` drops requirements for modules
+// no longer imported by reachable code, so a `go get` bump can be silently
+// reverted and the package still reported as patched.
+func TestVerifyGoModUpdates(t *testing.T) {
 	tests := []struct {
-		name       string
-		modulePath string
-		version    string
-		expected   string
+		name      string
+		goMod     string
+		updates   unversioned.LangUpdatePackages
+		wantErr   bool
+		errSubstr string
 	}{
 		{
-			name:       "pre-module major v2+ without path suffix",
-			modulePath: "github.com/docker/docker",
-			version:    "v28.0.0",
-			expected:   "v28.0.0+incompatible",
+			name: "module present at target version",
+			goMod: `module example.com/app
+
+go 1.22
+
+require golang.org/x/net v0.23.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr: false,
 		},
 		{
-			name:       "module path with matching major suffix",
-			modulePath: "github.com/foo/bar/v2",
-			version:    "v2.1.0",
-			expected:   "v2.1.0",
+			name: "module dropped by tidy",
+			goMod: `module example.com/app
+
+go 1.22
+
+require golang.org/x/text v0.14.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr:   true,
+			errSubstr: "golang.org/x/net",
 		},
 		{
-			name:       "major v0",
-			modulePath: "github.com/foo/bar",
-			version:    "v0.9.1",
-			expected:   "v0.9.1",
+			name: "landed version below target",
+			goMod: `module example.com/app
+
+go 1.22
+
+require golang.org/x/net v0.17.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr:   true,
+			errSubstr: "v0.17.0",
 		},
 		{
-			name:       "major v1",
-			modulePath: "github.com/foo/bar",
-			version:    "v1.2.3",
-			expected:   "v1.2.3",
+			name: "landed version above target",
+			goMod: `module example.com/app
+
+go 1.22
+
+require golang.org/x/net v0.25.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr: false,
 		},
 		{
-			name:       "already suffixed",
-			modulePath: "github.com/docker/docker",
-			version:    "v28.0.0+incompatible",
-			expected:   "v28.0.0+incompatible",
+			name: "target version without v prefix",
+			goMod: `module example.com/app
+
+go 1.22
+
+require golang.org/x/net v0.23.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "0.23.0"},
+			},
+			wantErr: false,
 		},
 		{
-			name:       "pseudo-version at v0",
-			modulePath: "github.com/foo/bar",
-			version:    "v0.0.0-20230101120000-abcdef123456",
-			expected:   "v0.0.0-20230101120000-abcdef123456",
+			name: "resolved via replace directive",
+			goMod: `module example.com/app
+
+go 1.22
+
+require github.com/pkg/legacy v1.0.0
+
+replace github.com/pkg/legacy => golang.org/x/net v0.23.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr: false,
 		},
 		{
-			name:       "pseudo-version at major v2 without path suffix",
-			modulePath: "github.com/foo/bar",
-			version:    "v2.0.1-0.20230101120000-abcdef123456",
-			expected:   "v2.0.1-0.20230101120000-abcdef123456+incompatible",
+			name: "replace directive pins version below target",
+			goMod: `module example.com/app
+
+go 1.22
+
+require golang.org/x/net v0.23.0
+
+replace golang.org/x/net => golang.org/x/net v0.17.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr:   true,
+			errSubstr: "v0.17.0",
 		},
 		{
-			name:       "pseudo-version at major v2 with path suffix",
-			modulePath: "github.com/foo/bar/v2",
-			version:    "v2.0.1-0.20230101120000-abcdef123456",
-			expected:   "v2.0.1-0.20230101120000-abcdef123456",
+			name: "local replace directive falls back to require",
+			goMod: `module example.com/app
+
+go 1.22
+
+require golang.org/x/net v0.23.0
+
+replace golang.org/x/net => ./vendored/net
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr: false,
 		},
 		{
-			name:       "invalid version left unchanged",
-			modulePath: "github.com/foo/bar",
-			version:    "not-a-version",
-			expected:   "not-a-version",
+			name: "incompatible suffix compares by semver core",
+			goMod: `module example.com/app
+
+go 1.22
+
+require github.com/docker/docker v25.0.6+incompatible
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "github.com/docker/docker", FixedVersion: "v25.0.6+incompatible"},
+			},
+			wantErr: false,
 		},
 		{
-			name:       "empty version left unchanged",
-			modulePath: "github.com/foo/bar",
-			version:    "",
-			expected:   "",
+			name: "incompatible suffix below target",
+			goMod: `module example.com/app
+
+go 1.22
+
+require github.com/docker/docker v24.0.9+incompatible
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "github.com/docker/docker", FixedVersion: "v25.0.6+incompatible"},
+			},
+			wantErr:   true,
+			errSubstr: "github.com/docker/docker",
 		},
 		{
-			// A version that already carries build metadata must not gain a
-			// second '+' component, which would be invalid semver.
-			name:       "existing build metadata left unchanged",
-			modulePath: "github.com/foo/bar",
-			version:    "v2.0.0+build1",
-			expected:   "v2.0.0+build1",
+			name: "empty updates",
+			goMod: `module example.com/app
+
+go 1.22
+`,
+			updates: unversioned.LangUpdatePackages{},
+			wantErr: false,
+		},
+		{
+			name: "updates without fixed version are skipped",
+			goMod: `module example.com/app
+
+go 1.22
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: ""},
+			},
+			wantErr: false,
+		},
+		{
+			name:  "unparseable go.mod",
+			goMod: "this is not a go.mod\n",
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr:   true,
+			errSubstr: "go.mod",
+		},
+		{
+			name: "multiple modules, one missing",
+			goMod: `module example.com/app
+
+go 1.22
+
+require golang.org/x/net v0.23.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+				{Name: "golang.org/x/text", FixedVersion: "v0.14.0"},
+			},
+			wantErr:   true,
+			errSubstr: "golang.org/x/text",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := appendIncompatibleIfNeeded(tt.modulePath, tt.version)
-			assert.Equal(t, tt.expected, result, "Module: %s, version: %s", tt.modulePath, tt.version)
+			err := verifyGoModUpdates([]byte(tt.goMod), tt.updates)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			assert.NoError(t, err)
 		})
 	}
-}
-
-// TestIncompatibleVersionsPassValidation ensures the +incompatible build tag
-// survives the existing version validation and cleaning paths.
-func TestIncompatibleVersionsPassValidation(t *testing.T) {
-	assert.True(t, isValidGoVersion("v28.0.0+incompatible"))
-	assert.NoError(t, validateGoVersion("v28.0.0+incompatible"))
-	assert.Equal(t, "v28.0.0+incompatible", cleanGoVersion("v28.0.0+incompatible"))
-}
-
-// TestBuildBinaryUpdateMap asserts that the binary-rebuild path normalizes the
-// versions it records as module requirements: a missing 'v' prefix is added and
-// pre-module major>=2 dependencies gain the +incompatible build tag, matching
-// the `go get` spec construction used by the in-image module path.
-func TestBuildBinaryUpdateMap(t *testing.T) {
-	updates := unversioned.LangUpdatePackages{
-		{Name: "github.com/docker/docker", FixedVersion: "v28.0.0"},
-		{Name: "github.com/moby/moby", FixedVersion: "28.0.0"},
-		{Name: "github.com/foo/bar/v2", FixedVersion: "v2.1.0"},
-		{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
-		{Name: "github.com/already/tagged", FixedVersion: "v3.1.0+incompatible"},
-		{Name: "github.com/no/fix", FixedVersion: ""},
-		{Name: "k8s.io/kubernetes", FixedVersion: "v1.30.0"},
-	}
-
-	got := buildBinaryUpdateMap(updates)
-
-	want := map[string]string{
-		"github.com/docker/docker":  "v28.0.0+incompatible",
-		"github.com/moby/moby":      "v28.0.0+incompatible",
-		"github.com/foo/bar/v2":     "v2.1.0",
-		"golang.org/x/net":          "v0.23.0",
-		"github.com/already/tagged": "v3.1.0+incompatible",
-	}
-	assert.Equal(t, want, got)
 }

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -1,9 +1,11 @@
 package langmgr
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/moby/buildkit/client/llb"
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
 	"github.com/project-copacetic/copacetic/pkg/types/unversioned"
 	"github.com/project-copacetic/copacetic/pkg/utils"
@@ -1143,7 +1145,9 @@ require golang.org/x/net v0.23.0
 			wantErr: false,
 		},
 		{
-			name: "resolved via replace directive",
+			// A replacement whose left-hand side is another module says nothing
+			// about u.Name: the two module paths have unrelated version lines.
+			name: "unrelated module replacement does not satisfy target",
 			goMod: `module example.com/app
 
 go 1.22
@@ -1155,7 +1159,8 @@ replace github.com/pkg/legacy => golang.org/x/net v0.23.0
 			updates: unversioned.LangUpdatePackages{
 				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
 			},
-			wantErr: false,
+			wantErr:   true,
+			errSubstr: "not found in go.mod",
 		},
 		{
 			name: "required module resolved through cross-module replace",
@@ -1189,7 +1194,9 @@ replace golang.org/x/net => golang.org/x/net v0.17.0
 			errSubstr: "v0.17.0",
 		},
 		{
-			name: "local replace directive cannot prove applied version",
+			// A filesystem replacement carries no version, so the require entry
+			// stays the effective version instead of failing the patch.
+			name: "filesystem replacement falls back to require version",
 			goMod: `module example.com/app
 
 go 1.22
@@ -1201,8 +1208,62 @@ replace golang.org/x/net => ./vendored/net
 			updates: unversioned.LangUpdatePackages{
 				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
 			},
+			wantErr: false,
+		},
+		{
+			name: "filesystem replacement fallback still enforces require version",
+			goMod: `module example.com/app
+
+go 1.22
+
+require golang.org/x/net v0.17.0
+
+replace golang.org/x/net => ./vendored/net
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
 			wantErr:   true,
-			errSubstr: "local replacement",
+			errSubstr: "v0.17.0",
+		},
+		{
+			// go.mod resolution prefers a replacement that names a version over
+			// a filesystem replacement of the same module path.
+			name: "versioned replacement preferred over filesystem replacement",
+			goMod: `module example.com/app
+
+go 1.22
+
+require golang.org/x/net v0.17.0
+
+replace golang.org/x/net => ./vendored/net
+
+replace golang.org/x/net v0.17.0 => golang.org/x/net v0.23.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr: false,
+		},
+		{
+			// A replacement pinned to the selected version wins over a
+			// path-wide replacement, as it does in the go command.
+			name: "version pinned replacement preferred over path wide replacement",
+			goMod: `module example.com/app
+
+go 1.22
+
+require golang.org/x/net v0.17.0
+
+replace golang.org/x/net => golang.org/x/net v0.23.0
+
+replace golang.org/x/net v0.17.0 => golang.org/x/net v0.10.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr:   true,
+			errSubstr: "v0.10.0",
 		},
 		{
 			name: "version-specific replace for unselected version is ignored",
@@ -1301,6 +1362,202 @@ require golang.org/x/net v0.23.0
 				return
 			}
 			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestFilterUpdatesInGoMod asserts that verification is scoped to the modules a
+// given go.mod actually referenced before the update. Verifying every requested
+// update against every module in the image fails modules that never depended on
+// the vulnerable package.
+func TestFilterUpdatesInGoMod(t *testing.T) {
+	goMod := `module example.com/app
+
+go 1.22
+
+require (
+	golang.org/x/net v0.17.0
+	golang.org/x/text v0.14.0 // indirect
+)
+
+replace github.com/pkg/legacy => github.com/pkg/legacy v1.2.3
+`
+
+	tests := []struct {
+		name      string
+		goMod     string
+		updates   unversioned.LangUpdatePackages
+		want      []string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:  "keeps required modules and drops absent ones",
+			goMod: goMod,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+				{Name: "github.com/absent/mod", FixedVersion: "v1.0.0"},
+			},
+			want: []string{"golang.org/x/net"},
+		},
+		{
+			name:  "keeps indirect requirements",
+			goMod: goMod,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/text", FixedVersion: "v0.21.0"},
+			},
+			want: []string{"golang.org/x/text"},
+		},
+		{
+			name:  "keeps replaced module paths",
+			goMod: goMod,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "github.com/pkg/legacy", FixedVersion: "v1.2.3"},
+			},
+			want: []string{"github.com/pkg/legacy"},
+		},
+		{
+			name:  "no applicable updates",
+			goMod: goMod,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "github.com/absent/mod", FixedVersion: "v1.0.0"},
+			},
+			want: []string{},
+		},
+		{
+			name:      "unparseable go.mod",
+			goMod:     "not a go.mod\n",
+			updates:   unversioned.LangUpdatePackages{{Name: "golang.org/x/net", FixedVersion: "v0.23.0"}},
+			wantErr:   true,
+			errSubstr: "go.mod",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := filterUpdatesInGoMod([]byte(tt.goMod), tt.updates)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, getPackageNames(got))
+		})
+	}
+}
+
+// TestGoWorkspaceMemberModPaths asserts that workspace members are resolved from
+// go.work so each member's go.mod can be verified. The workspace root has no
+// authoritative go.mod: requirements land in the member modules.
+func TestGoWorkspaceMemberModPaths(t *testing.T) {
+	tests := []struct {
+		name      string
+		goWork    string
+		root      string
+		want      []string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "relative use entries",
+			goWork: `go 1.22
+
+use ./svc-a
+use ./svc-b
+`,
+			root: "/app",
+			want: []string{"/app/svc-a/go.mod", "/app/svc-b/go.mod"},
+		},
+		{
+			name: "use block with root and parent entries",
+			goWork: `go 1.22
+
+use (
+	.
+	../lib
+)
+`,
+			root: "/app",
+			want: []string{"/app/go.mod", "/lib/go.mod"},
+		},
+		{
+			name: "absolute use entry",
+			goWork: `go 1.22
+
+use /src/other
+`,
+			root: "/app",
+			want: []string{"/src/other/go.mod"},
+		},
+		{
+			name:      "no use entries",
+			goWork:    "go 1.22\n",
+			root:      "/app",
+			wantErr:   true,
+			errSubstr: "no module directories",
+		},
+		{
+			name:      "unparseable go.work",
+			goWork:    "not a go.work\n",
+			root:      "/app",
+			wantErr:   true,
+			errSubstr: "go.work",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := goWorkspaceMemberModPaths([]byte(tt.goWork), tt.root)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestUpdateGoModuleReportsFailedPackages asserts that a failed module update
+// names the affected packages so callers can report them as unpatched. Without
+// the names, --ignore-errors drops the failure and the VEX document claims
+// remediation that never landed.
+func TestUpdateGoModuleReportsFailedPackages(t *testing.T) {
+	updates := unversioned.LangUpdatePackages{
+		{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+		{Name: "golang.org/x/text", FixedVersion: "v0.21.0"},
+	}
+
+	tests := []struct {
+		name    string
+		modPath string
+		updates unversioned.LangUpdatePackages
+		want    []string
+	}{
+		{
+			name:    "unsafe module path",
+			modPath: "/app; rm -rf /",
+			updates: updates,
+			want:    []string{"golang.org/x/net", "golang.org/x/text"},
+		},
+		{
+			name:    "unsafe package name",
+			modPath: "/app",
+			updates: unversioned.LangUpdatePackages{{Name: "golang.org/x/net;id", FixedVersion: "v0.23.0"}},
+			want:    []string{"golang.org/x/net;id"},
+		},
+	}
+
+	gm := &golangManager{config: &buildkit.Config{}}
+	state := llb.Scratch()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, failed, err := gm.updateGoModule(context.Background(), &state, tt.modPath, tt.updates, false, false)
+			require.Error(t, err)
+			assert.Equal(t, tt.want, failed)
 		})
 	}
 }

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -3,14 +3,17 @@ package langmgr
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"testing"
 
 	"github.com/moby/buildkit/client/llb"
+	gwclient "github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/project-copacetic/copacetic/pkg/buildkit"
 	"github.com/project-copacetic/copacetic/pkg/types/unversioned"
 	"github.com/project-copacetic/copacetic/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	fstypes "github.com/tonistiigi/fsutil/types"
 )
 
 func TestIsValidGoVersion(t *testing.T) {
@@ -1073,6 +1076,7 @@ func TestVerifyGoModUpdates(t *testing.T) {
 	tests := []struct {
 		name      string
 		goMod     string
+		goSum     string
 		updates   unversioned.LangUpdatePackages
 		wantErr   bool
 		errSubstr string
@@ -1163,7 +1167,10 @@ replace github.com/pkg/legacy => golang.org/x/net v0.23.0
 			errSubstr: "not found in go.mod",
 		},
 		{
-			name: "required module resolved through cross-module replace",
+			// A versioned replacement pointing at a different module path cannot
+			// prove the replaced module reached the requested version: the two
+			// paths have unrelated version lines.
+			name: "cross-module replacement cannot prove requested version",
 			goMod: `module example.com/app
 
 go 1.22
@@ -1175,7 +1182,8 @@ replace github.com/pkg/legacy => golang.org/x/net v0.23.0
 			updates: unversioned.LangUpdatePackages{
 				{Name: "github.com/pkg/legacy", FixedVersion: "v0.23.0"},
 			},
-			wantErr: false,
+			wantErr:   true,
+			errSubstr: "different module path",
 		},
 		{
 			name: "replace directive pins version below target",
@@ -1194,9 +1202,9 @@ replace golang.org/x/net => golang.org/x/net v0.17.0
 			errSubstr: "v0.17.0",
 		},
 		{
-			// A filesystem replacement carries no version, so the require entry
-			// stays the effective version instead of failing the patch.
-			name: "filesystem replacement falls back to require version",
+			// The contents behind a filesystem replacement carry no version, so
+			// the require entry cannot prove the local code is patched.
+			name: "filesystem replacement cannot prove requested version",
 			goMod: `module example.com/app
 
 go 1.22
@@ -1208,23 +1216,8 @@ replace golang.org/x/net => ./vendored/net
 			updates: unversioned.LangUpdatePackages{
 				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
 			},
-			wantErr: false,
-		},
-		{
-			name: "filesystem replacement fallback still enforces require version",
-			goMod: `module example.com/app
-
-go 1.22
-
-require golang.org/x/net v0.17.0
-
-replace golang.org/x/net => ./vendored/net
-`,
-			updates: unversioned.LangUpdatePackages{
-				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
-			},
 			wantErr:   true,
-			errSubstr: "v0.17.0",
+			errSubstr: "unversioned",
 		},
 		{
 			// go.mod resolution prefers a replacement that names a version over
@@ -1351,11 +1344,88 @@ require golang.org/x/net v0.23.0
 			wantErr:   true,
 			errSubstr: "golang.org/x/text",
 		},
+		{
+			// Modules before go 1.17 record only direct requirements in go.mod,
+			// so an indirect dependency Trivy reports is proven by the version
+			// go.sum says the build downloads.
+			name: "pre-1.17 go.sum only dependency at target version",
+			goMod: `module example.com/app
+
+go 1.16
+
+require github.com/direct/dep v1.4.0
+`,
+			goSum: `github.com/direct/dep v1.4.0 h1:aaaa=
+github.com/direct/dep v1.4.0/go.mod h1:bbbb=
+golang.org/x/net v0.17.0/go.mod h1:cccc=
+golang.org/x/net v0.23.0 h1:dddd=
+golang.org/x/net v0.23.0/go.mod h1:eeee=
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "pre-1.17 go.sum only dependency below target version",
+			goMod: `module example.com/app
+
+go 1.16
+
+require github.com/direct/dep v1.4.0
+`,
+			goSum: `github.com/direct/dep v1.4.0 h1:aaaa=
+github.com/direct/dep v1.4.0/go.mod h1:bbbb=
+golang.org/x/net v0.17.0 h1:cccc=
+golang.org/x/net v0.17.0/go.mod h1:dddd=
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr:   true,
+			errSubstr: "v0.17.0",
+		},
+		{
+			// A go.mod-only entry names a version in the module graph whose code
+			// is not downloaded, so it cannot prove the patch landed.
+			name: "go.sum go.mod only entry does not prove the patch",
+			goMod: `module example.com/app
+
+go 1.16
+
+require github.com/direct/dep v1.4.0
+`,
+			goSum: `golang.org/x/net v0.23.0/go.mod h1:aaaa=
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr:   true,
+			errSubstr: "not found in go.mod",
+		},
+		{
+			name: "require entry wins over stale go.sum entry",
+			goMod: `module example.com/app
+
+go 1.16
+
+require golang.org/x/net v0.23.0
+`,
+			goSum: `golang.org/x/net v0.17.0 h1:aaaa=
+golang.org/x/net v0.17.0/go.mod h1:bbbb=
+golang.org/x/net v0.23.0 h1:cccc=
+golang.org/x/net v0.23.0/go.mod h1:dddd=
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := verifyGoModUpdates([]byte(tt.goMod), tt.updates)
+			err := verifyGoModUpdates([]byte(tt.goMod), []byte(tt.goSum), tt.updates)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errSubstr)
@@ -1383,14 +1453,42 @@ require (
 replace github.com/pkg/legacy => github.com/pkg/legacy v1.2.3
 `
 
+	goSum := `github.com/pkg/legacy v1.2.3 h1:aaaa=
+github.com/pkg/legacy v1.2.3/go.mod h1:bbbb=
+gopkg.in/yaml.v2 v2.4.0 h1:cccc=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:dddd=
+`
+
 	tests := []struct {
 		name      string
 		goMod     string
+		goSum     string
 		updates   unversioned.LangUpdatePackages
 		want      []string
 		wantErr   bool
 		errSubstr string
 	}{
+		{
+			// Before go 1.17 an indirect dependency lives only in go.sum, and
+			// excluding it would leave the update unverified while the VEX
+			// document still claimed it as patched.
+			name:  "keeps pre-1.17 go.sum only dependency",
+			goMod: goMod,
+			goSum: goSum,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "gopkg.in/yaml.v2", FixedVersion: "v2.4.0"},
+			},
+			want: []string{"gopkg.in/yaml.v2"},
+		},
+		{
+			name:  "drops modules absent from go.mod and go.sum",
+			goMod: goMod,
+			goSum: goSum,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "github.com/absent/mod", FixedVersion: "v1.0.0"},
+			},
+			want: []string{},
+		},
 		{
 			name:  "keeps required modules and drops absent ones",
 			goMod: goMod,
@@ -1435,7 +1533,7 @@ replace github.com/pkg/legacy => github.com/pkg/legacy v1.2.3
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := filterUpdatesInGoMod([]byte(tt.goMod), tt.updates)
+			got, err := filterUpdatesInGoMod([]byte(tt.goMod), []byte(tt.goSum), tt.updates)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errSubstr)
@@ -1447,10 +1545,10 @@ replace github.com/pkg/legacy => github.com/pkg/legacy v1.2.3
 	}
 }
 
-// TestGoWorkspaceMemberModPaths asserts that workspace members are resolved from
-// go.work so each member's go.mod can be verified. The workspace root has no
+// TestGoWorkspaceMemberDirs asserts that workspace members are resolved from
+// go.work so each member module can be verified. The workspace root has no
 // authoritative go.mod: requirements land in the member modules.
-func TestGoWorkspaceMemberModPaths(t *testing.T) {
+func TestGoWorkspaceMemberDirs(t *testing.T) {
 	tests := []struct {
 		name      string
 		goWork    string
@@ -1467,7 +1565,7 @@ use ./svc-a
 use ./svc-b
 `,
 			root: "/app",
-			want: []string{"/app/svc-a/go.mod", "/app/svc-b/go.mod"},
+			want: []string{"/app/svc-a", "/app/svc-b"},
 		},
 		{
 			name: "use block with root and parent entries",
@@ -1479,7 +1577,7 @@ use (
 )
 `,
 			root: "/app",
-			want: []string{"/app/go.mod", "/lib/go.mod"},
+			want: []string{"/app", "/lib"},
 		},
 		{
 			name: "absolute use entry",
@@ -1488,7 +1586,7 @@ use (
 use /src/other
 `,
 			root: "/app",
-			want: []string{"/src/other/go.mod"},
+			want: []string{"/src/other"},
 		},
 		{
 			name:      "no use entries",
@@ -1508,7 +1606,7 @@ use /src/other
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := goWorkspaceMemberModPaths([]byte(tt.goWork), tt.root)
+			got, err := goWorkspaceMemberDirs([]byte(tt.goWork), tt.root)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errSubstr)
@@ -1560,4 +1658,137 @@ func TestUpdateGoModuleReportsFailedPackages(t *testing.T) {
 			assert.Equal(t, tt.want, failed)
 		})
 	}
+}
+
+// TestGoSumBuiltVersions asserts that only full module hashes count as versions
+// the build downloads. A "/go.mod" line names a version in the module graph
+// whose code never enters the image, so it cannot prove a patch landed.
+func TestGoSumBuiltVersions(t *testing.T) {
+	goSum := `golang.org/x/net v0.17.0/go.mod h1:aaaa=
+golang.org/x/net v0.23.0 h1:bbbb=
+golang.org/x/net v0.23.0/go.mod h1:cccc=
+gopkg.in/yaml.v2 v2.4.0 h1:dddd=
+
+malformed line
+`
+
+	got := goSumBuiltVersions([]byte(goSum))
+
+	assert.Equal(t, map[string][]string{
+		"golang.org/x/net": {"v0.23.0"},
+		"gopkg.in/yaml.v2": {"v2.4.0"},
+	}, got)
+	assert.Empty(t, goSumBuiltVersions(nil))
+}
+
+// TestUnverifiedUpdateNames asserts that failure reporting names every update
+// whose patch has not been confirmed, so partial verification cannot leave an
+// unproven package inside the validated set.
+func TestUnverifiedUpdateNames(t *testing.T) {
+	updates := unversioned.LangUpdatePackages{
+		{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+		{Name: "golang.org/x/text", FixedVersion: "v0.21.0"},
+		{Name: "gopkg.in/yaml.v2", FixedVersion: "v2.4.0"},
+	}
+
+	assert.Equal(t,
+		[]string{"golang.org/x/net", "golang.org/x/text", "gopkg.in/yaml.v2"},
+		unverifiedUpdateNames(updates, nil))
+
+	verified := map[string]struct{}{"golang.org/x/text": {}}
+	assert.Equal(t,
+		[]string{"golang.org/x/net", "gopkg.in/yaml.v2"},
+		unverifiedUpdateNames(updates, verified))
+
+	for _, u := range updates {
+		verified[u.Name] = struct{}{}
+	}
+	assert.Empty(t, unverifiedUpdateNames(updates, verified))
+}
+
+// goSumTestReference serves file contents from a map and fails once the read
+// budget is exhausted, standing in for a BuildKit solve that breaks partway
+// through workspace verification.
+type fakeGatewayReference struct {
+	gwclient.Reference
+	files      map[string][]byte
+	reads      *int
+	failAfter  int
+	failedRead error
+}
+
+func (r *fakeGatewayReference) ReadFile(_ context.Context, req gwclient.ReadRequest) ([]byte, error) {
+	*r.reads++
+	if r.failAfter > 0 && *r.reads > r.failAfter {
+		return nil, r.failedRead
+	}
+	content, ok := r.files[req.Filename]
+	if !ok {
+		return nil, fmt.Errorf("%s: no such file or directory", req.Filename)
+	}
+	return content, nil
+}
+
+func (r *fakeGatewayReference) StatFile(_ context.Context, req gwclient.StatRequest) (*fstypes.Stat, error) {
+	content, ok := r.files[req.Path]
+	if !ok {
+		return nil, fmt.Errorf("lstat %s: %w", req.Path, fs.ErrNotExist)
+	}
+	return &fstypes.Stat{Mode: uint32(0o644), Size: int64(len(content))}, nil
+}
+
+type fakeGatewayClient struct {
+	gwclient.Client
+	ref *fakeGatewayReference
+}
+
+func (c *fakeGatewayClient) Solve(context.Context, gwclient.SolveRequest) (*gwclient.Result, error) {
+	result := gwclient.NewResult()
+	result.SetRef(c.ref)
+	return result, nil
+}
+
+// TestUpdateGoModuleWorkspaceFailureReportsAllUnverified asserts that a read
+// failure during workspace verification reports every update still lacking
+// proof, not only the member being read. Reporting one member would let the
+// other members' packages reach the validated set unverified.
+func TestUpdateGoModuleWorkspaceFailureReportsAllUnverified(t *testing.T) {
+	memberGoMod := `module example.com/svc-a
+
+go 1.22
+
+require golang.org/x/net v0.23.0
+`
+	otherGoMod := `module example.com/svc-b
+
+go 1.22
+
+require golang.org/x/text v0.21.0
+`
+	files := map[string][]byte{
+		"/app/go.work":      []byte("go 1.22\n\nuse (\n\t./svc-a\n\t./svc-b\n)\n"),
+		"/app/svc-a/go.mod": []byte(memberGoMod),
+		"/app/svc-b/go.mod": []byte(otherGoMod),
+	}
+
+	reads := 0
+	client := &fakeGatewayClient{ref: &fakeGatewayReference{
+		files:      files,
+		reads:      &reads,
+		failAfter:  3, // go.work plus both pre-update go.mod reads succeed
+		failedRead: fmt.Errorf("failed to solve: exit code 1"),
+	}}
+	gm := &golangManager{config: &buildkit.Config{Client: client}}
+	state := llb.Scratch()
+	updates := unversioned.LangUpdatePackages{
+		{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+		{Name: "golang.org/x/text", FixedVersion: "v0.21.0"},
+	}
+
+	_, failed, err := gm.updateGoModule(t.Context(), &state, "/app", updates, true, false)
+
+	require.ErrorContains(t, err, "after update",
+		"the failure must come from post-update verification, not the pre-update capture")
+	assert.Equal(t, []string{"golang.org/x/net", "golang.org/x/text"}, failed,
+		"a workspace verification failure must report every update still lacking verification")
 }

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -1068,6 +1068,126 @@ func TestGolangManagerInstallUpdatesSkipsNonNewerVersion(t *testing.T) {
 	assert.Same(t, currentState, state)
 }
 
+func TestAppendIncompatibleIfNeeded(t *testing.T) {
+	tests := []struct {
+		name       string
+		modulePath string
+		version    string
+		expected   string
+	}{
+		{
+			name:       "pre-module major v2+ without path suffix",
+			modulePath: "github.com/docker/docker",
+			version:    "v28.0.0",
+			expected:   "v28.0.0+incompatible",
+		},
+		{
+			name:       "module path with matching major suffix",
+			modulePath: "github.com/foo/bar/v2",
+			version:    "v2.1.0",
+			expected:   "v2.1.0",
+		},
+		{
+			name:       "major v0",
+			modulePath: "github.com/foo/bar",
+			version:    "v0.9.1",
+			expected:   "v0.9.1",
+		},
+		{
+			name:       "major v1",
+			modulePath: "github.com/foo/bar",
+			version:    "v1.2.3",
+			expected:   "v1.2.3",
+		},
+		{
+			name:       "already suffixed",
+			modulePath: "github.com/docker/docker",
+			version:    "v28.0.0+incompatible",
+			expected:   "v28.0.0+incompatible",
+		},
+		{
+			name:       "pseudo-version at v0",
+			modulePath: "github.com/foo/bar",
+			version:    "v0.0.0-20230101120000-abcdef123456",
+			expected:   "v0.0.0-20230101120000-abcdef123456",
+		},
+		{
+			name:       "pseudo-version at major v2 without path suffix",
+			modulePath: "github.com/foo/bar",
+			version:    "v2.0.1-0.20230101120000-abcdef123456",
+			expected:   "v2.0.1-0.20230101120000-abcdef123456+incompatible",
+		},
+		{
+			name:       "pseudo-version at major v2 with path suffix",
+			modulePath: "github.com/foo/bar/v2",
+			version:    "v2.0.1-0.20230101120000-abcdef123456",
+			expected:   "v2.0.1-0.20230101120000-abcdef123456",
+		},
+		{
+			name:       "invalid version left unchanged",
+			modulePath: "github.com/foo/bar",
+			version:    "not-a-version",
+			expected:   "not-a-version",
+		},
+		{
+			name:       "empty version left unchanged",
+			modulePath: "github.com/foo/bar",
+			version:    "",
+			expected:   "",
+		},
+		{
+			// A version that already carries build metadata must not gain a
+			// second '+' component, which would be invalid semver.
+			name:       "existing build metadata left unchanged",
+			modulePath: "github.com/foo/bar",
+			version:    "v2.0.0+build1",
+			expected:   "v2.0.0+build1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := appendIncompatibleIfNeeded(tt.modulePath, tt.version)
+			assert.Equal(t, tt.expected, result, "Module: %s, version: %s", tt.modulePath, tt.version)
+		})
+	}
+}
+
+// TestIncompatibleVersionsPassValidation ensures the +incompatible build tag
+// survives the existing version validation and cleaning paths.
+func TestIncompatibleVersionsPassValidation(t *testing.T) {
+	assert.True(t, isValidGoVersion("v28.0.0+incompatible"))
+	assert.NoError(t, validateGoVersion("v28.0.0+incompatible"))
+	assert.Equal(t, "v28.0.0+incompatible", cleanGoVersion("v28.0.0+incompatible"))
+}
+
+// TestBuildBinaryUpdateMap asserts that the binary-rebuild path normalizes the
+// versions it records as module requirements: a missing 'v' prefix is added and
+// pre-module major>=2 dependencies gain the +incompatible build tag, matching
+// the `go get` spec construction used by the in-image module path.
+func TestBuildBinaryUpdateMap(t *testing.T) {
+	updates := unversioned.LangUpdatePackages{
+		{Name: "github.com/docker/docker", FixedVersion: "v28.0.0"},
+		{Name: "github.com/moby/moby", FixedVersion: "28.0.0"},
+		{Name: "github.com/foo/bar/v2", FixedVersion: "v2.1.0"},
+		{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+		{Name: "github.com/already/tagged", FixedVersion: "v3.1.0+incompatible"},
+		{Name: "github.com/no/fix", FixedVersion: ""},
+		{Name: "k8s.io/kubernetes", FixedVersion: "v1.30.0"},
+	}
+
+	got := buildBinaryUpdateMap(updates)
+
+	want := map[string]string{
+		"github.com/docker/docker":  "v28.0.0+incompatible",
+		"github.com/moby/moby":      "v28.0.0+incompatible",
+		"github.com/foo/bar/v2":     "v2.1.0",
+		"golang.org/x/net":          "v0.23.0",
+		"github.com/already/tagged": "v3.1.0+incompatible",
+	}
+	assert.Equal(t, want, got)
+}
+
 // TestVerifyGoModUpdates asserts that the post-update go.mod check catches
 // updates that did not land. `go mod tidy -e` drops requirements for modules
 // no longer imported by reachable code, so a `go get` bump can be silently

--- a/pkg/langmgr/golang_test.go
+++ b/pkg/langmgr/golang_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	fstypes "github.com/tonistiigi/fsutil/types"
+	"golang.org/x/mod/modfile"
 )
 
 func TestIsValidGoVersion(t *testing.T) {
@@ -1197,6 +1198,7 @@ func TestVerifyGoModUpdates(t *testing.T) {
 		name      string
 		goMod     string
 		goSum     string
+		goWork    string
 		updates   unversioned.LangUpdatePackages
 		wantErr   bool
 		errSubstr string
@@ -1541,11 +1543,144 @@ golang.org/x/net v0.23.0/go.mod h1:dddd=
 			},
 			wantErr: false,
 		},
+		{
+			// A go.work replace overrides every member module, so local contents
+			// substituted there leave the requested version unprovable no matter
+			// what the member's go.mod requires.
+			name: "go.work filesystem replacement cannot prove requested version",
+			goMod: `module example.com/svc-a
+
+go 1.22
+
+require golang.org/x/net v0.23.0
+`,
+			goWork: `go 1.22
+
+use ./svc-a
+
+replace golang.org/x/net => ./vendored/net
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr:   true,
+			errSubstr: "go.work",
+		},
+		{
+			name: "go.work replacement to a different module path cannot prove requested version",
+			goMod: `module example.com/svc-a
+
+go 1.22
+
+require golang.org/x/net v0.23.0
+`,
+			goWork: `go 1.22
+
+use ./svc-a
+
+replace golang.org/x/net => example.com/fork/net v1.0.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr:   true,
+			errSubstr: "different module path",
+		},
+		{
+			name: "go.work replacement pins version below target",
+			goMod: `module example.com/svc-a
+
+go 1.22
+
+require golang.org/x/net v0.23.0
+`,
+			goWork: `go 1.22
+
+use ./svc-a
+
+replace golang.org/x/net => golang.org/x/net v0.17.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr:   true,
+			errSubstr: "v0.17.0",
+		},
+		{
+			// A workspace replacement that names the same module at a version
+			// carrying the fix is provable, so it must not be rejected.
+			name: "go.work replacement at target version is accepted",
+			goMod: `module example.com/svc-a
+
+go 1.22
+
+require golang.org/x/net v0.17.0
+`,
+			goWork: `go 1.22
+
+use ./svc-a
+
+replace golang.org/x/net => golang.org/x/net v0.23.0
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr: false,
+		},
+		{
+			// go.work replacements win over go.mod replacements, so a patched
+			// go.mod replacement cannot excuse a workspace redirection.
+			name: "go.work replacement overrides go.mod replacement",
+			goMod: `module example.com/svc-a
+
+go 1.22
+
+require golang.org/x/net v0.17.0
+
+replace golang.org/x/net => golang.org/x/net v0.23.0
+`,
+			goWork: `go 1.22
+
+use ./svc-a
+
+replace golang.org/x/net => ./vendored/net
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr:   true,
+			errSubstr: "unversioned",
+		},
+		{
+			// A workspace replacement of a module the member no longer requires
+			// still governs the build, so go.sum cannot excuse it either.
+			name: "go.work replacement applies to modules absent from go.mod",
+			goMod: `module example.com/svc-a
+
+go 1.16
+
+require github.com/direct/dep v1.4.0
+`,
+			goSum: `golang.org/x/net v0.23.0 h1:aaaa=
+golang.org/x/net v0.23.0/go.mod h1:bbbb=
+`,
+			goWork: `go 1.22
+
+use ./svc-a
+
+replace golang.org/x/net => ./vendored/net
+`,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+			},
+			wantErr:   true,
+			errSubstr: "unversioned",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := verifyGoModUpdates([]byte(tt.goMod), []byte(tt.goSum), tt.updates)
+			err := verifyGoModUpdates([]byte(tt.goMod), []byte(tt.goSum), goWorkReplaces(t, tt.goWork), tt.updates)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errSubstr)
@@ -1556,6 +1691,18 @@ golang.org/x/net v0.23.0/go.mod h1:dddd=
 	}
 }
 
+// goWorkReplaces parses go.work content into the replace directives that
+// verification receives for a workspace member module.
+func goWorkReplaces(t *testing.T, goWork string) []*modfile.Replace {
+	t.Helper()
+	if goWork == "" {
+		return nil
+	}
+	f, err := modfile.ParseWork("go.work", []byte(goWork), nil)
+	require.NoError(t, err)
+	return f.Replace
+}
+
 // TestFilterUpdatesInGoMod asserts that verification is scoped to the modules a
 // given go.mod actually referenced before the update. Verifying every requested
 // update against every module in the image fails modules that never depended on
@@ -1564,6 +1711,18 @@ func TestFilterUpdatesInGoMod(t *testing.T) {
 	goMod := `module example.com/app
 
 go 1.22
+
+require (
+	golang.org/x/net v0.17.0
+	golang.org/x/text v0.14.0 // indirect
+)
+
+replace github.com/pkg/legacy => github.com/pkg/legacy v1.2.3
+`
+
+	legacyGoMod := `module example.com/app
+
+go 1.16
 
 require (
 	golang.org/x/net v0.17.0
@@ -1593,7 +1752,34 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:dddd=
 			// excluding it would leave the update unverified while the VEX
 			// document still claimed it as patched.
 			name:  "keeps pre-1.17 go.sum only dependency",
+			goMod: legacyGoMod,
+			goSum: goSum,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "gopkg.in/yaml.v2", FixedVersion: "v2.4.0"},
+			},
+			want: []string{"gopkg.in/yaml.v2"},
+		},
+		{
+			// From go 1.17 on go.mod lists every dependency of the build, so a
+			// go.sum entry it never mentions is a stale checksum. Treating it as
+			// a dependency would demand a bump from a module that does not use
+			// the package and fail the patch for the whole image.
+			name:  "ignores stale go.sum entry for a pruned module graph",
 			goMod: goMod,
+			goSum: goSum,
+			updates: unversioned.LangUpdatePackages{
+				{Name: "gopkg.in/yaml.v2", FixedVersion: "v2.4.0"},
+			},
+			want: []string{},
+		},
+		{
+			// A go.mod without a go directive predates module graph pruning, so
+			// go.sum is still the only record of its indirect dependencies.
+			name: "keeps go.sum only dependency when go directive is absent",
+			goMod: `module example.com/app
+
+require golang.org/x/net v0.17.0
+`,
 			goSum: goSum,
 			updates: unversioned.LangUpdatePackages{
 				{Name: "gopkg.in/yaml.v2", FixedVersion: "v2.4.0"},
@@ -1665,17 +1851,20 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:dddd=
 	}
 }
 
-// TestGoWorkspaceMemberDirs asserts that workspace members are resolved from
-// go.work so each member module can be verified. The workspace root has no
-// authoritative go.mod: requirements land in the member modules.
-func TestGoWorkspaceMemberDirs(t *testing.T) {
+// TestParseGoWorkspace asserts that workspace members are resolved from go.work
+// so each member module can be verified, and that the workspace-wide replace
+// directives travel with them. The workspace root has no authoritative go.mod:
+// requirements land in the member modules, while a go.work replace overrides
+// every one of them.
+func TestParseGoWorkspace(t *testing.T) {
 	tests := []struct {
-		name      string
-		goWork    string
-		root      string
-		want      []string
-		wantErr   bool
-		errSubstr string
+		name         string
+		goWork       string
+		root         string
+		want         []string
+		wantReplaced []string
+		wantErr      bool
+		errSubstr    string
 	}{
 		{
 			name: "relative use entries",
@@ -1722,18 +1911,37 @@ use /src/other
 			wantErr:   true,
 			errSubstr: "go.work",
 		},
+		{
+			name: "workspace replacements are returned",
+			goWork: `go 1.22
+
+use ./svc-a
+
+replace golang.org/x/net => ./vendored/net
+
+replace golang.org/x/text v0.14.0 => golang.org/x/text v0.21.0
+`,
+			root:         "/app",
+			want:         []string{"/app/svc-a"},
+			wantReplaced: []string{"golang.org/x/net", "golang.org/x/text"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := goWorkspaceMemberDirs([]byte(tt.goWork), tt.root)
+			got, err := parseGoWorkspace([]byte(tt.goWork), tt.root)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errSubstr)
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, got.memberDirs)
+			var replaced []string
+			for _, rep := range got.replacements {
+				replaced = append(replaced, rep.Old.Path)
+			}
+			assert.Equal(t, tt.wantReplaced, replaced)
 		})
 	}
 }
@@ -1802,8 +2010,9 @@ malformed line
 }
 
 // TestUnverifiedUpdateNames asserts that failure reporting names every update
-// whose patch has not been confirmed, so partial verification cannot leave an
-// unproven package inside the validated set.
+// whose patch has not been confirmed in every module accountable for it, so
+// partial verification cannot leave an unproven package inside the validated
+// set.
 func TestUnverifiedUpdateNames(t *testing.T) {
 	updates := unversioned.LangUpdatePackages{
 		{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
@@ -1811,19 +2020,22 @@ func TestUnverifiedUpdateNames(t *testing.T) {
 		{Name: "gopkg.in/yaml.v2", FixedVersion: "v2.4.0"},
 	}
 
+	// Nothing tracked: no module has been checked, so nothing is proven.
 	assert.Equal(t,
 		[]string{"golang.org/x/net", "golang.org/x/text", "gopkg.in/yaml.v2"},
 		unverifiedUpdateNames(updates, nil))
 
-	verified := map[string]struct{}{"golang.org/x/text": {}}
+	// One module still owes proof for x/net while x/text is fully proven.
+	// gopkg.in/yaml.v2 is untracked, so it is unproven as well.
+	pendingProofs := map[string]int{"golang.org/x/net": 1, "golang.org/x/text": 0}
 	assert.Equal(t,
 		[]string{"golang.org/x/net", "gopkg.in/yaml.v2"},
-		unverifiedUpdateNames(updates, verified))
+		unverifiedUpdateNames(updates, pendingProofs))
 
 	for _, u := range updates {
-		verified[u.Name] = struct{}{}
+		pendingProofs[u.Name] = 0
 	}
-	assert.Empty(t, unverifiedUpdateNames(updates, verified))
+	assert.Empty(t, unverifiedUpdateNames(updates, pendingProofs))
 }
 
 // goSumTestReference serves file contents from a map and fails once the read
@@ -1911,4 +2123,115 @@ require golang.org/x/text v0.21.0
 		"the failure must come from post-update verification, not the pre-update capture")
 	assert.Equal(t, []string{"golang.org/x/net", "golang.org/x/text"}, failed,
 		"a workspace verification failure must report every update still lacking verification")
+}
+
+// TestUpdateGoModuleWorkspaceProofIsPerMember asserts that proving a module in
+// one workspace member does not excuse the same module in another member. The
+// same `go get` list runs in every member, so a member left unverified can still
+// require the vulnerable version while the package is reported as remediated.
+func TestUpdateGoModuleWorkspaceProofIsPerMember(t *testing.T) {
+	sharedRequirement := func(module string) []byte {
+		return []byte(`module example.com/` + module + `
+
+go 1.22
+
+require golang.org/x/net v0.23.0
+`)
+	}
+	files := map[string][]byte{
+		"/app/go.work":      []byte("go 1.22\n\nuse (\n\t./svc-a\n\t./svc-b\n)\n"),
+		"/app/svc-a/go.mod": sharedRequirement("svc-a"),
+		"/app/svc-b/go.mod": sharedRequirement("svc-b"),
+	}
+
+	reads := 0
+	client := &fakeGatewayClient{ref: &fakeGatewayReference{
+		files: files,
+		reads: &reads,
+		// go.work, both pre-update reads and svc-a's post-update read succeed;
+		// svc-b's post-update read fails.
+		failAfter:  4,
+		failedRead: fmt.Errorf("failed to solve: exit code 1"),
+	}}
+	gm := &golangManager{config: &buildkit.Config{Client: client}}
+	state := llb.Scratch()
+	updates := unversioned.LangUpdatePackages{
+		{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+	}
+
+	_, failed, err := gm.updateGoModule(t.Context(), &state, "/app", updates, true, false)
+
+	require.ErrorContains(t, err, "/app/svc-b/go.mod")
+	assert.Equal(t, []string{"golang.org/x/net"}, failed,
+		"a module verified in one member is still unproven while another member owes proof")
+}
+
+// TestUpdateGoModuleWorkspaceReplacementIsUnprovable asserts that a go.work
+// replace directive pointing at local contents fails verification. The
+// workspace replacement overrides every member module, so the version a member
+// requires says nothing about the code the build actually compiles.
+func TestUpdateGoModuleWorkspaceReplacementIsUnprovable(t *testing.T) {
+	files := map[string][]byte{
+		"/app/go.work": []byte("go 1.22\n\nuse ./svc-a\n\nreplace golang.org/x/net => ./vendored/net\n"),
+		"/app/svc-a/go.mod": []byte(`module example.com/svc-a
+
+go 1.22
+
+require golang.org/x/net v0.23.0
+`),
+	}
+
+	reads := 0
+	client := &fakeGatewayClient{ref: &fakeGatewayReference{files: files, reads: &reads}}
+	gm := &golangManager{config: &buildkit.Config{Client: client}}
+	state := llb.Scratch()
+	updates := unversioned.LangUpdatePackages{
+		{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+	}
+
+	_, failed, err := gm.updateGoModule(t.Context(), &state, "/app", updates, true, false)
+
+	require.ErrorContains(t, err, "go.work")
+	require.ErrorContains(t, err, "unversioned")
+	assert.Equal(t, []string{"golang.org/x/net"}, failed,
+		"a module redirected by the workspace must be reported as unpatched")
+}
+
+// TestUpgradePackagesWithToolingReportsUnprocessedModules asserts that a failure
+// in the tooling container reports the packages of the modules queued behind it
+// as well. Those modules are never processed, so with --ignore-errors their
+// packages would otherwise reach the validated set and be claimed as patched.
+func TestUpgradePackagesWithToolingReportsUnprocessedModules(t *testing.T) {
+	files := map[string][]byte{
+		goModDetectFile: []byte("/app /srv\n"),
+		"/app/go.mod": []byte(`module example.com/app
+
+go 1.22
+
+require golang.org/x/net v0.23.0
+`),
+		"/srv/go.mod": []byte(`module example.com/srv
+
+go 1.22
+
+require golang.org/x/text v0.21.0
+`),
+	}
+
+	reads := 0
+	client := &fakeGatewayClient{ref: &fakeGatewayReference{files: files, reads: &reads}}
+	gm := &golangManager{config: &buildkit.Config{Client: client}}
+	state := llb.Scratch()
+	updates := unversioned.LangUpdatePackages{
+		{Name: "golang.org/x/net", FixedVersion: "v0.23.0"},
+		{Name: "golang.org/x/text", FixedVersion: "v0.21.0"},
+	}
+
+	// The tooling container never runs here, so /workspace/go.mod is missing and
+	// verification of the first module fails before /srv is touched.
+	_, failed, err := gm.upgradePackagesWithTooling(t.Context(), &state, updates, true)
+
+	require.ErrorContains(t, err, "after update at /app")
+	assert.Equal(t, []string{"golang.org/x/net", "golang.org/x/text"}, failed,
+		"packages carried by modules that were never processed must be reported as unpatched")
 }


### PR DESCRIPTION
## Problem

Both Go module update paths in `pkg/langmgr/golang.go` (`updateGoModule` for the in-image toolchain and `upgradePackagesWithTooling` for the tooling container) run `go get <mod>@<ver> && go mod tidy -e` and treated a zero exit code as proof the bump landed. There was no post-update check on the resulting `go.mod` anywhere in the Go path.

## Root cause

`go mod tidy` removes requirements for modules that are not imported by reachable code, and `-e` makes it continue past load errors while doing so. A `go get` bump could therefore be reverted by the tidy step in the same shell command while copa still reported the package as patched.

## Fix

- Add `verifyGoModUpdates`, which parses post-update `go.mod` metadata and uses full-module `go.sum` entries for pre-Go 1.17 indirect dependencies, failing when a requested module is absent, unprovable, or below its fixed version.
- Resolve Go replacement semantics conservatively:
  - an applicable versioned replacement overrides the selected requirement for the old module identity;
  - version-qualified replacements apply only when their old version matches the selected requirement;
  - a replacement to a different module path, or to local unversioned contents, fails verification because module metadata cannot prove which source version it contains;
  - `go.work` replacements are resolved first and override the member module's own `replace` directives, as the go command does.
- Extract and verify the updated `go.mod` after both the in-image and tooling-container update steps.
- Resolve `go.work` members and verify each member module because the workspace root has no authoritative `go.mod`.
- Scope verification per module: each module is only accountable for the updates it already referenced, and a package counts as proven only once every accountable module has been checked. Proving a module in one workspace member no longer excuses another member that still requires the vulnerable version.
- Report every unproven package on failure. Module accountability is collected before any module is touched, so a failure partway through the tooling-container loop still reports the packages carried by the modules queued behind it instead of letting `--ignore-errors` claim them as remediated.
- Limit the `go.sum` fallback to modules whose `go` directive predates module graph pruning (absent or below 1.17). From Go 1.17 on, `go.mod` lists every dependency of the build, so a `go.sum` entry it never mentions is a stale checksum and would otherwise demand a bump from a module that does not use the package.

Existing `--ignore-errors` handling is unchanged. The caller loop in `upgradePackages` still decides whether a per-module verification error is fatal.

## Tests

`TestVerifyGoModUpdates` covers target, missing, below-target, above-target, no-`v` prefix, `+incompatible`, malformed, multi-module, pre-Go 1.17 `go.sum`, unprovable `go.mod` replacement, and `go.work` replacement precedence cases. `TestFilterUpdatesInGoMod` covers the pruned-module-graph gate on `go.sum`, and `TestParseGoWorkspace` covers member resolution plus workspace replacement extraction. Behavior-level regressions run `updateGoModule` and `upgradePackagesWithTooling` against a fake BuildKit gateway:

- `TestUpdateGoModuleWorkspaceProofIsPerMember` — a module proven in one member is still reported when another member owes proof.
- `TestUpdateGoModuleWorkspaceReplacementIsUnprovable` — a `go.work` local replacement fails verification.
- `TestUpgradePackagesWithToolingReportsUnprocessedModules` — a failure reports packages of modules never processed.
- `TestUpdateGoModuleWorkspaceFailureReportsAllUnverified` — a read failure reports every update lacking proof.

Existing coverage for `+incompatible` normalization from #1682 and downgrade/VEX behavior from #1683 is preserved.

Verified locally with:

- `make format`
- `go build ./...`
- `go vet ./pkg/langmgr`
- `go test ./pkg/langmgr ./pkg/patch`