### PR TITLE
fix(test): use moby container and network types in bulk patch test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/docker/buildx v0.32.1
 	github.com/docker/cli v29.5.3+incompatible
 	github.com/docker/docker v28.5.2+incompatible
-	github.com/docker/go-connections v0.7.0
 	github.com/google/go-containerregistry v0.21.6
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/klauspost/compress v1.18.7
@@ -71,6 +70,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/docker-credential-helpers v0.9.8 // indirect
+	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/ebitengine/purego v0.10.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect

--- a/integration/bulk/singlearch_patch_test.go
+++ b/integration/bulk/singlearch_patch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,10 +12,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/go-connections/nat"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -133,10 +134,10 @@ func startLocalRegistry(ctx context.Context) (testcontainers.Container, string, 
 			"REGISTRY_STORAGE_DELETE_ENABLED": "true",
 		},
 		HostConfigModifier: func(hostConfig *container.HostConfig) {
-			hostConfig.PortBindings = nat.PortMap{
-				"5000/tcp": []nat.PortBinding{
+			hostConfig.PortBindings = network.PortMap{
+				network.MustParsePort("5000/tcp"): []network.PortBinding{
 					{
-						HostIP:   "127.0.0.1",
+						HostIP:   netip.MustParseAddr("127.0.0.1"),
 						HostPort: fixedPort,
 					},
 				},


### PR DESCRIPTION
testcontainers-go 0.44.0 (#1568) moved `HostConfigModifier` and `PortBindings` to the `github.com/moby/moby/api` types, so `integration/bulk/singlearch_patch_test.go` stopped compiling. That breaks `Run golangci-lint` (typecheck) and `Test Bulk Patching` on main itself, and consequently on every open pull request.

This ports the registry helper to `network.PortMap` with a `netip.Addr` host IP and retidies `github.com/docker/go-connections` to indirect, since that was its last direct use.

Verified locally with `go vet ./integration/...`, `go build ./...`, `go mod tidy -diff` clean, and gofumpt clean.