### PR TITLE
fix: prevent Buildx dial hang with Docker host override

### DIFF
--- a/pkg/buildkit/connhelpers/buildx.go
+++ b/pkg/buildkit/connhelpers/buildx.go
@@ -1,7 +1,6 @@
 package connhelpers
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -15,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/cpuguy83/dockercfg"
 	"github.com/cpuguy83/go-docker"
@@ -36,6 +36,11 @@ type buildxConfig struct {
 	}
 }
 
+var (
+	buildxExecCommand        = exec.Command
+	buildxExecCommandContext = exec.CommandContext
+)
+
 // Buildx returns a buildkit connection helper for connecting to a buildx instance.
 // Only "docker-container" buildkit instances are currently supported.
 // If there are multiple nodes configured, one will be chosen at random.
@@ -49,8 +54,58 @@ func Buildx(u *url.URL) (*connhelper.ConnectionHelper, error) {
 }
 
 func supportsDialStio(ctx context.Context) bool {
-	cmd := exec.CommandContext(ctx, "docker", "buildx", "dial-stdio", "--help")
+	cmd := buildxExecCommandContext(ctx, "docker", "buildx", "dial-stdio", "--help")
 	return cmd.Run() == nil
+}
+
+type buildxProxyWriter struct {
+	io.Writer
+	once  sync.Once
+	ready chan struct{}
+}
+
+func (w *buildxProxyWriter) Write(p []byte) (int, error) {
+	if len(p) != 0 {
+		w.once.Do(func() { close(w.ready) })
+	}
+	return w.Writer.Write(p)
+}
+
+type buildxProgressWriter struct {
+	mu      sync.Mutex
+	output  bytes.Buffer
+	pending string
+	errors  chan string
+}
+
+func (w *buildxProgressWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	_, _ = w.output.Write(p)
+	w.pending += string(p)
+	for {
+		end := strings.IndexByte(w.pending, '\n')
+		if end == -1 {
+			break
+		}
+
+		line := strings.TrimSuffix(w.pending[:end], "\r")
+		w.pending = w.pending[end+1:]
+		if strings.Contains(strings.ToLower(line), "error:") {
+			select {
+			case w.errors <- line:
+			default:
+			}
+		}
+	}
+	return len(p), nil
+}
+
+func (w *buildxProgressWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.output.String()
 }
 
 // buildxDialStdio uses the buildx dial-stdio command to connect to a buildx instance.
@@ -60,55 +115,106 @@ func supportsDialStio(ctx context.Context) bool {
 //
 // This allows us to support any buildx instance, even if it is not running in a container.
 func buildxDialStdio(ctx context.Context, builder string) (net.Conn, error) {
-	cmd := exec.CommandContext(ctx, "docker", "buildx", "dial-stdio", "--progress=plain")
+	cmd := buildxExecCommand("docker", "buildx", "dial-stdio", "--progress=plain")
 	if builder != "" {
 		cmd.Args = append(cmd.Args, "--builder", builder)
 	}
-	cmd.Env = os.Environ()
+	cmd.Env = buildxDialStdioEnv(builder)
 
 	c1, c2 := net.Pipe()
 	cmd.Stdin = c1
-	cmd.Stdout = c1
-
-	// Use a pipe to check when the connection is actually complete
-	// Also write all of stderr to an error buffer so we can have more details
-	// in the error message when the command fails.
-	r, w := io.Pipe()
-	errBuf := bytes.NewBuffer(nil)
-	ww := io.MultiWriter(w, errBuf)
-	cmd.Stderr = ww
+	proxyReady := make(chan struct{})
+	cmd.Stdout = &buildxProxyWriter{Writer: c1, ready: proxyReady}
+	progressErrors := make(chan string, 1)
+	progress := &buildxProgressWriter{errors: progressErrors}
+	cmd.Stderr = progress
 
 	if err := cmd.Start(); err != nil {
+		c1.Close()
+		c2.Close()
 		return nil, err
 	}
 
+	var closeProxyOnce sync.Once
+	closeProxy := func() {
+		closeProxyOnce.Do(func() {
+			c1.Close()
+			c2.Close()
+			_ = cmd.Process.Kill()
+		})
+	}
+	stopCancellation := context.AfterFunc(ctx, func() {
+		// cmd.Wait waits for its stdin copy to finish. Close both ends of the
+		// proxy and stop the process so cancellation cannot deadlock with that
+		// copy before the connection is ready.
+		closeProxy()
+	})
+	defer stopCancellation()
+
+	processDone := make(chan error, 1)
 	go func() {
 		err := cmd.Wait()
 		c1.Close()
-		// pkgerrors.Wrap will return nil if err is nil, otherwise it will give
-		// us a wrapped error with the buffered stderr from he command.
-		w.CloseWithError(fmt.Errorf("%s: %s", err, errBuf))
+		if err == nil {
+			err = errors.New("buildx dial-stdio exited before connecting")
+		} else if detail := strings.TrimSpace(progress.String()); detail != "" {
+			err = fmt.Errorf("%w: %s", err, detail)
+		}
+		processDone <- err
 	}()
 
-	defer r.Close()
-
-	scanner := bufio.NewScanner(r)
-	for scanner.Scan() {
-		txt := strings.ToLower(scanner.Text())
-
-		if strings.HasPrefix(txt, "#1 dialing builder") && strings.HasSuffix(txt, "done") {
-			go func() {
-				// Continue draining stderr so the process does not get blocked
-				_, _ = io.Copy(io.Discard, r)
-			}()
-			break
+	for {
+		select {
+		case <-proxyReady:
+			// Buildx reports the Dialing builder sub-progress as done even when
+			// build.Dial returns an error. The first proxy output is the point at
+			// which Buildx has actually connected and started forwarding bytes.
+			select {
+			case line := <-progressErrors:
+				closeProxy()
+				return nil, fmt.Errorf("buildx dial-stdio failed before connecting: %s", line)
+			case err := <-processDone:
+				closeProxy()
+				return nil, fmt.Errorf("buildx dial-stdio failed before connecting: %w", err)
+			default:
+			}
+			if !stopCancellation() {
+				closeProxy()
+				return nil, ctx.Err()
+			}
+			return c2, nil
+		case line := <-progressErrors:
+			closeProxy()
+			return nil, fmt.Errorf("buildx dial-stdio failed before connecting: %s", line)
+		case err := <-processDone:
+			closeProxy()
+			return nil, fmt.Errorf("buildx dial-stdio failed before connecting: %w", err)
+		case <-ctx.Done():
+			closeProxy()
+			return nil, ctx.Err()
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
+}
+
+// buildxDialStdioEnv prevents a Docker endpoint override that is needed by a
+// later image loader from changing the context used by an explicitly selected
+// Buildx builder. Context-bound docker driver builders otherwise reject the
+// connection before the gRPC client can start, leaving it waiting until the
+// patch timeout. An unnamed builder continues to honor DOCKER_HOST.
+func buildxDialStdioEnv(builder string) []string {
+	env := os.Environ()
+	if builder == "" {
+		return env
 	}
 
-	return c2, nil
+	filtered := env[:0]
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "DOCKER_HOST=") {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
 }
 
 func buildxContextDialer(builder string) func(context.Context, string) (net.Conn, error) {

--- a/pkg/buildkit/connhelpers/buildx.go
+++ b/pkg/buildkit/connhelpers/buildx.go
@@ -122,7 +122,12 @@ func buildxDialStdio(ctx context.Context, builder string) (net.Conn, error) {
 	cmd.Env = buildxDialStdioEnv(builder)
 
 	c1, c2 := net.Pipe()
-	cmd.Stdin = c1
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		c1.Close()
+		c2.Close()
+		return nil, fmt.Errorf("create buildx dial-stdio stdin pipe: %w", err)
+	}
 	proxyReady := make(chan struct{})
 	cmd.Stdout = &buildxProxyWriter{Writer: c1, ready: proxyReady}
 	progressErrors := make(chan string, 1)
@@ -130,6 +135,7 @@ func buildxDialStdio(ctx context.Context, builder string) (net.Conn, error) {
 	cmd.Stderr = progress
 
 	if err := cmd.Start(); err != nil {
+		stdin.Close()
 		c1.Close()
 		c2.Close()
 		return nil, err
@@ -138,18 +144,25 @@ func buildxDialStdio(ctx context.Context, builder string) (net.Conn, error) {
 	var closeProxyOnce sync.Once
 	closeProxy := func() {
 		closeProxyOnce.Do(func() {
+			stdin.Close()
 			c1.Close()
 			c2.Close()
 			_ = cmd.Process.Kill()
 		})
 	}
 	stopCancellation := context.AfterFunc(ctx, func() {
-		// cmd.Wait waits for its stdin copy to finish. Close both ends of the
-		// proxy and stop the process so cancellation cannot deadlock with that
-		// copy before the connection is ready.
+		// Close both ends of the proxy and stop the process so cancellation
+		// cannot leave any proxy copy blocked before the connection is ready.
 		closeProxy()
 	})
 	defer stopCancellation()
+
+	go func() {
+		// Keep the stdin copy outside os/exec so cmd.Wait can report an early
+		// process exit even while no client data has arrived on the proxy.
+		_, _ = io.Copy(stdin, c1)
+		_ = stdin.Close()
+	}()
 
 	processDone := make(chan error, 1)
 	go func() {

--- a/pkg/buildkit/connhelpers/buildx_test.go
+++ b/pkg/buildkit/connhelpers/buildx_test.go
@@ -134,6 +134,22 @@ func TestBuildxDialStdioReturnsErrorAfterDialProgressCompletes(t *testing.T) {
 	assert.Nil(t, conn)
 }
 
+func TestBuildxDialStdioReturnsWhenProcessExitsBeforeConnecting(t *testing.T) {
+	originalCommand := buildxExecCommand
+	t.Cleanup(func() { buildxExecCommand = originalCommand })
+	buildxExecCommand = buildxDialHelperCommand
+
+	t.Setenv("BUILDX_DIAL_HELPER_EXIT", "1")
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	start := time.Now()
+	conn, err := buildxDialStdio(ctx, "desktop-linux")
+	require.ErrorContains(t, err, "buildx dial-stdio exited before connecting")
+	assert.Less(t, time.Since(start), 3*time.Second)
+	assert.Nil(t, conn)
+}
+
 func TestBuildxDialStdioCancellationClosesProxy(t *testing.T) {
 	originalCommand := buildxExecCommand
 	t.Cleanup(func() { buildxExecCommand = originalCommand })
@@ -183,6 +199,9 @@ func TestBuildxDialStdioHelperProcess(t *testing.T) {
 		fmt.Fprintln(os.Stderr, "ERROR: use the builder's Docker context")
 		_, _ = io.Copy(io.Discard, os.Stdin)
 		os.Exit(1)
+	}
+	if os.Getenv("BUILDX_DIAL_HELPER_EXIT") != "" {
+		os.Exit(0)
 	}
 	if os.Getenv("BUILDX_DIAL_HELPER_SILENT") != "" {
 		_, _ = io.Copy(io.Discard, os.Stdin)

--- a/pkg/buildkit/connhelpers/buildx_test.go
+++ b/pkg/buildkit/connhelpers/buildx_test.go
@@ -2,11 +2,17 @@ package connhelpers
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"os"
 	"os/exec"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/moby/buildkit/client/connhelper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildx(t *testing.T) {
@@ -83,6 +89,122 @@ func TestBuildxDialStdio(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildxDialStdioIgnoresDockerHostForNamedBuilder(t *testing.T) {
+	originalCommand := buildxExecCommand
+	t.Cleanup(func() { buildxExecCommand = originalCommand })
+	buildxExecCommand = buildxDialHelperCommand
+
+	t.Setenv("DOCKER_HOST", "unix:///docker-loader.sock")
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	conn, err := buildxDialStdio(ctx, "desktop-linux")
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.NoError(t, conn.Close())
+}
+
+func TestBuildxDialStdioReturnsEarlyProgressError(t *testing.T) {
+	originalCommand := buildxExecCommand
+	t.Cleanup(func() { buildxExecCommand = originalCommand })
+	buildxExecCommand = buildxDialHelperCommand
+
+	t.Setenv("BUILDX_DIAL_HELPER_FAIL", "1")
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	conn, err := buildxDialStdio(ctx, "desktop-linux")
+	require.ErrorContains(t, err, "buildx dial-stdio failed before connecting")
+	assert.Nil(t, conn)
+}
+
+func TestBuildxDialStdioReturnsErrorAfterDialProgressCompletes(t *testing.T) {
+	originalCommand := buildxExecCommand
+	t.Cleanup(func() { buildxExecCommand = originalCommand })
+	buildxExecCommand = buildxDialHelperCommand
+
+	t.Setenv("BUILDX_DIAL_HELPER_LATE_FAIL", "1")
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	conn, err := buildxDialStdio(ctx, "desktop-linux")
+	require.ErrorContains(t, err, "buildx dial-stdio failed before connecting")
+	assert.Nil(t, conn)
+}
+
+func TestBuildxDialStdioCancellationClosesProxy(t *testing.T) {
+	originalCommand := buildxExecCommand
+	t.Cleanup(func() { buildxExecCommand = originalCommand })
+	buildxExecCommand = buildxDialHelperCommand
+
+	t.Setenv("BUILDX_DIAL_HELPER_SILENT", "1")
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	t.Cleanup(cancel)
+
+	conn, err := buildxDialStdio(ctx, "desktop-linux")
+	require.Error(t, err)
+	assert.Nil(t, conn)
+}
+
+func TestBuildxDialStdioKeepsProxyOpenAfterDialContextEnds(t *testing.T) {
+	originalCommand := buildxExecCommand
+	t.Cleanup(func() { buildxExecCommand = originalCommand })
+	buildxExecCommand = buildxDialHelperCommand
+
+	ctx, cancel := context.WithCancel(t.Context())
+	conn, err := buildxDialStdio(ctx, "desktop-linux")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(time.Second)))
+	ready := make([]byte, len("proxy ready"))
+	_, err = io.ReadFull(conn, ready)
+	require.NoError(t, err)
+	assert.Equal(t, "proxy ready", string(ready))
+
+	cancel()
+	require.NoError(t, conn.SetWriteDeadline(time.Now().Add(time.Second)))
+	_, err = conn.Write([]byte("connection remains open"))
+	require.NoError(t, err)
+}
+
+func buildxDialHelperCommand(_ string, _ ...string) *exec.Cmd {
+	//nolint:gosec // os.Args[0] is the Go test binary, not untrusted input.
+	return exec.Command(os.Args[0], "-test.run=^TestBuildxDialStdioHelperProcess$", "--", "--buildx-dial-helper")
+}
+
+func TestBuildxDialStdioHelperProcess(t *testing.T) {
+	if !slices.Contains(os.Args, "--buildx-dial-helper") {
+		return
+	}
+
+	if os.Getenv("DOCKER_HOST") != "" || os.Getenv("BUILDX_DIAL_HELPER_FAIL") != "" {
+		fmt.Fprintln(os.Stderr, "ERROR: use the builder's Docker context")
+		_, _ = io.Copy(io.Discard, os.Stdin)
+		os.Exit(1)
+	}
+	if os.Getenv("BUILDX_DIAL_HELPER_SILENT") != "" {
+		_, _ = io.Copy(io.Discard, os.Stdin)
+		os.Exit(0)
+	}
+
+	// The progress vertex number is deliberately not #1. It is presentation
+	// detail and must not be part of the connection readiness contract.
+	fmt.Fprintln(os.Stderr, "#7 Dialing builder 0.0s done")
+	if os.Getenv("BUILDX_DIAL_HELPER_LATE_FAIL") != "" {
+		fmt.Fprintln(os.Stderr, "#1 ERROR: failed to dial builder: context deadline exceeded")
+		os.Exit(1)
+	}
+	fmt.Fprint(os.Stdout, "proxy ready")
+	_, _ = io.Copy(io.Discard, os.Stdin)
+	os.Exit(0)
+}
+
+func TestBuildxDialStdioEnvPreservesDockerHostForUnnamedBuilder(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "tcp://builder.example:2375")
+
+	assert.Contains(t, buildxDialStdioEnv(""), "DOCKER_HOST=tcp://builder.example:2375")
 }
 
 func TestContainerContextDialer(t *testing.T) {


### PR DESCRIPTION
Prevent explicitly selected context-bound Buildx builders from inheriting a conflicting `DOCKER_HOST` used by the image loader.

Surface Buildx dial failures immediately and keep cancellation from deadlocking or terminating an established stdio proxy.

Add regression coverage for endpoint isolation, progress parsing, error propagation, and proxy lifecycle behavior.

Closes #1679

## Validation

- `go test ./pkg/... -count=1 -timeout 10m` — passed with inherited Git signing disabled for fixture commits.
- `go test ./pkg/buildkit/connhelpers -run 'TestBuildxDialStdio|TestBuildxDialStdioEnv' -count=20 -timeout 60s` — passed.
- `go test -race ./pkg/buildkit/connhelpers -run 'TestBuildxDialStdio|TestBuildxDialStdioEnv' -count=1 -timeout 2m` — passed.
- `golangci-lint run --timeout 3m ./pkg/buildkit/connhelpers` — passed with zero issues.
- Real Apple Silicon ARM64 UBI8 patch with Buildx 0.36.1, ambient `DOCKER_HOST`, a platform-specific Trivy report, and `--push` — passed; pushed `linux/arm64` digest `sha256:fb1889d392628ef2d1d279324d0043c239976917a8fc112b72c983da275b2e99` to a unique one-hour `ttl.sh` repository.

## Risks and limitations

- Full `make lint` reports two unchanged G115 findings in `cmd/chisel-validator/main.go` and `pkg/chisel/manifest.go`; targeted lint for the changed package passes.
- The disposable integration image expires one hour after creation.
- `go build ./...` passed.
- `make format` completed with no diff; `make lint` passed with Go 1.26.5 and golangci-lint 2.10.1.
- The prior `Test patch with trivy podman/container` failure was external: both failing cases received `502 Bad Gateway` from `registry-1.docker.io` while fetching unrelated pinned image manifests. The same job has passed on main, including the three preceding sampled main runs; this branch only changes `pkg/buildkit/connhelpers`. The rebase creates an identical-content CI retrigger without changing the fix.
