### PR TITLE
test: make LogPipe test deterministic

### DIFF
--- a/pkg/utils/log_test.go
+++ b/pkg/utils/log_test.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"bytes"
 	"fmt"
-	"os/exec"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -14,35 +14,35 @@ import (
 const testLogPipeMsg = "Test LogPipe message"
 
 func TestLogPipe(t *testing.T) {
-	cmd := exec.Command("echo", testLogPipeMsg)
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		t.Fatalf("Failed to get stdout pipe: %s", err)
-		return
-	}
-
 	stdOutBuf := new(bytes.Buffer)
-	log.StandardLogger().SetOutput(stdOutBuf)
-	go LogPipe(stdout, log.InfoLevel)
-	err = cmd.Run()
-	if err != nil {
-		t.Fatalf("Failed to run command: %s", err)
-		return
+	logger := log.StandardLogger()
+	originalOutput := logger.Out
+	logger.SetOutput(stdOutBuf)
+	t.Cleanup(func() {
+		logger.SetOutput(originalOutput)
+	})
+
+	reader, writer := io.Pipe()
+	done := make(chan struct{})
+	go func() {
+		LogPipe(reader, log.InfoLevel)
+		close(done)
+	}()
+
+	if _, err := fmt.Fprintln(writer, testLogPipeMsg); err != nil {
+		t.Fatalf("Failed to write log message: %s", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Failed to close log writer: %s", err)
 	}
 
-	expected := fmt.Sprintf("level=info msg=\"%s\"", testLogPipeMsg)
-	start := time.Now()
-	for stdOutBuf.Len() < len(expected) {
-		if time.Since(start) > 10*time.Millisecond {
-			t.Errorf("LogPipe() did not finish write within 10ms")
-			return
-		}
-		// Wait for LogPipe to finish writing, should be on the order of ns
-		time.Sleep(1 * time.Millisecond)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("LogPipe() did not finish reading from the closed pipe")
 	}
 
 	if !strings.Contains(stdOutBuf.String(), fmt.Sprintf("level=info msg=\"%s\"", testLogPipeMsg)) {
-		t.Errorf("LogPipe() result: \"%s\", want: \"%s\"", stdOutBuf.String(), testLogPipeMsg)
-		return
+		t.Errorf("LogPipe() result: %q, want message %q", stdOutBuf.String(), testLogPipeMsg)
 	}
 }


### PR DESCRIPTION
## Summary

- replace the timing-based `TestLogPipe` assertion with deterministic `io.Pipe` completion synchronization
- avoid concurrent reads and writes to the shared output buffer
- restore the global Logrus output after the test

## Testing

- `go test ./pkg/utils -run '^TestLogPipe$' -count=1000`
- `go test -race ./pkg/utils -run '^TestLogPipe$' -count=100`
- `make test`
- `make lint`